### PR TITLE
Add a max_workers parameter to get_data and get_data_async

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ If your query is badly formed or there is an other problem with the backend, an 
 
 If you'd like to be able to submit multiple queries and have them run on the ServiceX back end in parallel, it may be best to use the `asyncio` interface, which has the identical signature, but is called `get_data_async`.
 
+For documentation of `get_data` and `get_data_async` see the `servicex.py` source file.
+
 # Features
 
 Implemented:
@@ -83,7 +85,6 @@ This code has been tested in several environments:
 
 - Windows, Linux, MacOS
 - Python 3.6, 3.7, 3.8
-   - 3.8.0 and 3.8.1 only. Unfortunately, 3.8.2 has caused `nest_asyncio` to fail. Until that package is updated we are stuck at 3.8.1.
 - Jupyter Notebooks (not automated), regular python command-line invoked source files
 
 # Development

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -251,6 +251,13 @@ async def test_image_spec(good_transform_request, reduce_wait_time, files_back_1
     assert called['image'] == 'fork-it-over:latest'
 
 
+def test_max_workers_spec(good_transform_request, reduce_wait_time, files_back_1):
+    'Simple run with expected results'
+    fe.get_data('(valid qastle string)', 'one_ds', max_workers=50)
+    called = good_transform_request
+    assert called['workers'] == 50
+
+
 @pytest.mark.asyncio
 async def test_servicex_rejects_transform_request(bad_transform_request, reduce_wait_time):
     'Simple run bomb during transform query'


### PR DESCRIPTION
# Motivation and what this fixes

A physicist would like some control over how many resources are used by `servicex` (until auto-scaling is present). This gives the user access to the number of transformers that will run simultaneously.

- This PR adds the parameter `max_workers` to `get_data` and `get_data_async`, which allow the user to control the number of workers used by ServiceX (see issue #17 ). The amount of code changed is actually quite small.

## Reviewing

- @kyungeonchoi - I've put you on review here to make sure you are happy with the interface.
- @BenGalewsky and @mweinberg2718 - I've put you on the review to make sure the text I'm using to describe `max_workers` is ok. Right now, without autoscaling, `max_workers` is really the number of workers, but eventually, it will either be removed, or it will be an upper limit. If it remains, I'm hoping my description of it is useful.