### PR TITLE
Support File Downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ Implemented:
 
 - Accepts a `qastle` formatted query
 - Exceptions are used to report back errors of all sorts from the service to the user's code.
-- Data is return as a `pandas.DataFrame` or a  `awkward` array (see the `data_type` parameter)
+- Data is return in the following forms:
+    - `pandas.DataFrame` an in process DataFrame of all the data requested
+    - `awkward` an in process `JaggedArray` or dictionary of `JaggedArray`s
+    - A list of root files that can be upened with `uproot` and used as desired.
+    - Not all output formats are compatible with all transformations.
 - Complete returned data must fit in the process' memory
 - Run in an async or a non-async environment and non-async methods will accomodate automatically (including `jupyter` notebooks).
 - Support up to 100 simultanious queries from a laptop-like front end without overwhelming the local machine (hopefully ServiceX will be overwhelmed!)
@@ -76,7 +80,6 @@ Implemented:
 
 Comming:
 
-- Data is returned as a list of ROOT files located in a specified directory
 - Make it easy to submit the same query for 100 different datasets
 
 # Testing

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -86,7 +86,11 @@ def _download_file(minio_client: Minio, request_id: str, bucket_fname: str,
     dir = os.path.dirname(local_filepath)
     if not os.path.exists(dir):
         os.mkdir(dir)
-    minio_client.fget_object(request_id, bucket_fname, local_filepath)
+
+    # We are going to build a temp file, and download it from there.
+    temp_local_filepath = f'{local_filepath}.temp'
+    minio_client.fget_object(request_id, bucket_fname, temp_local_filepath)
+    os.replace(temp_local_filepath, local_filepath)
 
     return local_filepath
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -299,7 +299,7 @@ async def get_data_async(selection_query: str, dataset: str,
             files_remaining, files_processed = await _get_transform_status(client,
                                                                            servicex_endpoint,
                                                                            request_id)
-            if files_processed != last_files_processed:
+            if files_processed > last_files_processed:
                 new_downloads = await _download_new_files(files_downloading.keys(),
                                                           servicex_endpoint, request_id,
                                                           data_type, file_name_func,

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -187,7 +187,7 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
                          storage_directory: Optional[str] = None,
                          file_name_func: Callable[[str, str], str] = None,
                          redownload_files: bool = False) \
-        -> Union[pd.DataFrame, Dict[bytes, np.ndarray]]:
+        -> Union[pd.DataFrame, Dict[bytes, np.ndarray], List[str]]:
     '''
     Return data from a query with data sets.
 
@@ -258,6 +258,7 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
             file_name_func = file_name
         else:
             def file_name(req_id: str, minio_name: str):
+                assert storage_directory is not None
                 return os.path.join(tempfile.gettempdir(), storage_directory,
                                     santize_filename(minio_name))
             file_name_func = file_name
@@ -336,7 +337,7 @@ def get_data(selection_query: str, datasets: Union[str, List[str]],
              data_type: str = 'pandas',
              image: str = 'sslhep/servicex_xaod_cpp_transformer:v0.2',
              max_workers: int = 20) \
-        -> Union[pd.DataFrame, Dict[bytes, np.ndarray]]:
+        -> Union[pd.DataFrame, Dict[bytes, np.ndarray], List[str]]:
     '''
     Return data from a query with data sets.
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -314,7 +314,7 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
         assert len(all_files) > 0
 
         if data_type == 'root-file':
-            return all_files
+            return list(all_files)
 
         # We need to shift the files to another format.
         if len(all_files) == 1:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -182,7 +182,7 @@ async def _download_new_files(files_queued: Iterable[str], end_point: str,
     return futures
 
 
-async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
+async def get_data_async(selection_query: str, dataset: str,
                          servicex_endpoint: str = 'http://localhost:5000/servicex',
                          data_type: str = 'pandas',
                          image: str = 'sslhep/servicex_xaod_cpp_transformer:v0.2',
@@ -195,9 +195,9 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
     Return data from a query with data sets.
 
     Arguments:
-        selection_query     `qastle` string that specifies what columnes to extract, how to format
+        selection_query     `qastle` string that specifies what columns to extract, how to format
                             them, and how to format them.
-        datasets            Dataset or datasets to run the query against.
+        dataset             Dataset (DID) to run the query against.
         service_endpoint    The URL where the instance of ServivceX we are querying lives
         data_type           How should the data come back? 'pandas', 'awkward', and 'root-file'
                             are the only legal values. Defaults to 'pandas'
@@ -242,10 +242,6 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
           the end of the string without causing any trouble.
     '''
     # Parameter clean up, API saftey checking
-    if isinstance(datasets, str):
-        datasets = [datasets]
-    assert len(datasets) == 1
-
     if (data_type != 'pandas') \
             and (data_type != 'awkward') \
             and (data_type != 'parquet') \
@@ -271,7 +267,7 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
 
     # Build the query, get a request ID back.
     json_query = {
-        "did": datasets[0],
+        "did": dataset[0],
         "selection": selection_query,
         "image": image,
         "result-destination": "object-store",
@@ -340,7 +336,7 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
                                                 'not be unknown.')
 
 
-def get_data(selection_query: str, datasets: Union[str, List[str]],
+def get_data(selection_query: str, dataset: str,
              servicex_endpoint: str = 'http://localhost:5000/servicex',
              data_type: str = 'pandas',
              image: str = 'sslhep/servicex_xaod_cpp_transformer:v0.2',
@@ -353,9 +349,9 @@ def get_data(selection_query: str, datasets: Union[str, List[str]],
     Return data from a query with data sets.
 
     Arguments:
-        selection_query     `qastle` string that specifies what columnes to extract, how to format
+        selection_query     `qastle` string that specifies what columns to extract, how to format
                             them, and how to format them.
-        datasets            Dataset or datasets to run the query against.
+        datasets            Dataset (DID) to run the query against.
         service_endpoint    The URL where the instance of ServivceX we are querying lives
         data_type           How should the data come back? 'pandas', 'awkward', and 'root-file'
                             are the only legal values. Defaults to 'pandas'
@@ -398,7 +394,7 @@ def get_data(selection_query: str, datasets: Union[str, List[str]],
     '''
     loop = asyncio.get_event_loop()
     if not loop.is_running():
-        r = get_data_async(selection_query, datasets, servicex_endpoint, image=image,
+        r = get_data_async(selection_query, dataset, servicex_endpoint, image=image,
                            max_workers=max_workers, data_type=data_type,
                            storage_directory=storage_directory, file_name_func=file_name_func,
                            redownload_files=redownload_files)
@@ -415,7 +411,7 @@ def get_data(selection_query: str, datasets: Union[str, List[str]],
                 pass
 
         exector = ThreadPoolExecutor(max_workers=1)
-        future = exector.submit(get_data_wrapper, selection_query, datasets,
+        future = exector.submit(get_data_wrapper, selection_query, dataset,
                                 servicex_endpoint, image=image,
                                 max_workers=max_workers)
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -16,6 +16,10 @@ from retry import retry
 import uproot
 
 
+# Where shall we store files by default when we pull them down?
+default_file_cache_name = os.path.join(tempfile.gettempdir(), 'servicex')
+
+
 # Number of seconds to wait between polling servicex for the status of a transform job
 # while waiting for it to finish.
 servicex_status_poll_time = 5.0
@@ -255,7 +259,7 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
     if file_name_func is None:
         if storage_directory is None:
             def file_name(req_id: str, minio_name: str):
-                return os.path.join(tempfile.gettempdir(), 'servicex', req_id,
+                return os.path.join(default_file_cache_name, req_id,
                                     santize_filename(minio_name))
             file_name_func = file_name
         else:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -267,7 +267,7 @@ async def get_data_async(selection_query: str, dataset: str,
 
     # Build the query, get a request ID back.
     json_query = {
-        "did": dataset[0],
+        "did": dataset,
         "selection": selection_query,
         "image": image,
         "result-destination": "object-store",

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -89,6 +89,32 @@ def files_back_2(mocker):
 
 
 @pytest.fixture()
+def files_back_4_order_1(mocker):
+    mocker.patch('minio.api.Minio.list_objects',
+                 return_value=[
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000002.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000003.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000004.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')
+                 ])
+    mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
+    return None
+
+
+@pytest.fixture()
+def files_back_4_order_2(mocker):
+    mocker.patch('minio.api.Minio.list_objects',
+                 return_value=[
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000003.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000004.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000002.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')
+                 ])
+    mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
+    return None
+
+
+@pytest.fixture()
 def files_back_2_one_at_a_time(mocker):
     q = queue.Queue()
     d = {}
@@ -399,6 +425,24 @@ async def test_good_download_files_parquet(good_transform_request, reduce_wait_t
     assert os.path.exists(r[0])
     called = good_transform_request
     assert called['result-format'] == 'parquet'
+
+
+@pytest.mark.asyncio
+async def test_good_run_files_order_1(good_transform_request, reduce_wait_time, files_back_4_order_1):
+    'Simple run with expected results'
+    r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
+    assert isinstance(r, list)
+    s_r = sorted(r)
+    assert r == s_r
+
+
+@pytest.mark.asyncio
+async def test_good_run_files_order_2(good_transform_request, reduce_wait_time, files_back_4_order_2):
+    'Simple run with expected results'
+    r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
+    assert isinstance(r, list)
+    s_r = sorted(r)
+    assert r == s_r
 
 
 @pytest.mark.asyncio

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -390,6 +390,18 @@ async def test_good_download_files_1(good_transform_request, reduce_wait_time, f
 
 
 @pytest.mark.asyncio
+async def test_good_download_files_parquet(good_transform_request, reduce_wait_time, files_back_1):
+    'Simple run with expected results'
+    r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='parquet')
+    assert isinstance(r, List)
+    assert len(r) == 1
+    assert isinstance(r[0], str)
+    assert os.path.exists(r[0])
+    called = good_transform_request
+    assert called['result-format'] == 'parquet'
+
+
+@pytest.mark.asyncio
 async def test_download_to_temp_file(good_transform_request, reduce_wait_time, files_back_1):
     'Simple run with expected results'
     r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -5,6 +5,8 @@ import re
 import shutil
 from unittest import mock
 from unittest.mock import MagicMock
+from typing import List
+import os
 
 from minio.error import ResponseError
 import pandas as pd
@@ -362,6 +364,28 @@ async def test_files_downloading_is_interleaved(good_transform_request_delayed_f
 
     assert ordering[0] == 'get-file-list 0'
     assert ordering[1].startswith('copy-a-file')
+
+
+@pytest.mark.asyncio
+async def test_good_download_files_1(good_transform_request, reduce_wait_time, files_back_1):
+    'Simple run with expected results'
+    r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
+    assert isinstance(r, List)
+    assert len(r) == 1
+    assert isinstance(r[0], str)
+    assert os.path.exists(r[0])
+
+
+@pytest.mark.asyncio
+async def test_good_download_files_2(good_transform_request, reduce_wait_time, files_back_2):
+    'Simple run with expected results'
+    r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
+    assert isinstance(r, List)
+    assert len(r) == 2
+    assert isinstance(r[0], str)
+    assert os.path.exists(r[0])
+    assert isinstance(r[1], str)
+    assert os.path.exists(r[1])
 
 # TODO:
 # Other tests

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -55,12 +55,6 @@ def make_minio_file(fname):
 
 @pytest.fixture()
 def files_back_1(mocker):
-    # I attempted a full blown mock, but it failed. It wasn't getting picked up.
-    # No idea why. But I've left this here for future in case we return to it.
-    # mock_minio = mocker.MagicMock(minio.api.Minio)
-    # mocker.patch('minio.Minio', return_value=mock_minio)
-    # mock_minio.list_objects = MagicMock(return_value=[make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')])
-    # mock_minio.fget_object = MagicMock(side_effect=good_copy)
     mocker.patch('minio.api.Minio.list_objects', return_value=[make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')])
     p = mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
     return p

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -62,8 +62,8 @@ def files_back_1(mocker):
     # mock_minio.list_objects = MagicMock(return_value=[make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')])
     # mock_minio.fget_object = MagicMock(side_effect=good_copy)
     mocker.patch('minio.api.Minio.list_objects', return_value=[make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')])
-    mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
-    return None
+    p = mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
+    return p
 
 
 @pytest.fixture()
@@ -381,6 +381,16 @@ async def test_good_download_files_1(good_transform_request, reduce_wait_time, f
     assert len(r) == 1
     assert isinstance(r[0], str)
     assert os.path.exists(r[0])
+
+
+@pytest.mark.asyncio
+async def test_download_to_temp_file(good_transform_request, reduce_wait_time, files_back_1):
+    'Simple run with expected results'
+    r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
+    assert os.path.exists(r[0])
+    assert not r[0].endswith('.temp')
+    local_filepath = files_back_1.call_args[0][2]
+    assert local_filepath.endswith('.temp')
 
 
 @pytest.mark.asyncio

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -18,7 +18,9 @@ import servicex as fe
 
 @pytest.fixture(autouse=True)
 def delete_default_downloaded_files():
-    download_location = os.path.join(tempfile.gettempdir(), 'servicex')
+    download_location = os.path.join(tempfile.gettempdir(), 'servicex-testing')
+    import servicex.servicex as sx
+    sx.default_file_cache_name = download_location
     if os.path.exists(download_location):
         shutil.rmtree(download_location)
     yield

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -15,6 +15,7 @@ import pytest
 
 import servicex as fe
 
+
 @pytest.fixture(autouse=True)
 def delete_default_downloaded_files():
     download_location = os.path.join(tempfile.gettempdir(), 'servicex')
@@ -23,7 +24,6 @@ def delete_default_downloaded_files():
     yield
     if os.path.exists(download_location):
         shutil.rmtree(download_location)
-
 
 
 @pytest.fixture(scope="module")
@@ -201,6 +201,7 @@ def clean_fname(fname: str):
                 .replace(';', '_') \
                 .replace(':', '_')
 
+
 @pytest.mark.asyncio
 async def test_good_run_single_ds_1file_pandas(good_transform_request, reduce_wait_time, files_back_1):
     'Simple run with expected results'
@@ -252,6 +253,7 @@ async def test_2awkward_combined_correctly(good_transform_request, reduce_wait_t
 
     # Test that what we pull down can correctly be used by uproot methods
     import uproot_methods
+    assert isinstance(r, dict)
     arr = uproot_methods.TLorentzVectorArray.from_ptetaphi(r[b'JetPt'], r[b'JetPt'], r[b'JetPt'], r[b'JetPt'])
     assert len(arr) == 283458*2
 
@@ -391,6 +393,7 @@ async def test_good_download_files_1(good_transform_request, reduce_wait_time, f
 async def test_download_to_temp_file(good_transform_request, reduce_wait_time, files_back_1):
     'Simple run with expected results'
     r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
+    assert isinstance(r, list)
     assert os.path.exists(r[0])
     assert not r[0].endswith('.temp')
     local_filepath = files_back_1.call_args[0][2]
@@ -459,7 +462,7 @@ async def test_download_already_there_files(good_transform_request, reduce_wait_
     os.mkdir(tmp)
     output_file = os.path.join(tmp, 'bogus.root')
     # Put in a good file for reading
-    good_copy (None, None, output_file)
+    good_copy(None, None, output_file)
 
     r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file',
                                 file_name_func=lambda rid, obj_name: output_file,

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -7,6 +7,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 from typing import List
 import os
+import tempfile
 
 from minio.error import ResponseError
 import pandas as pd
@@ -386,6 +387,20 @@ async def test_good_download_files_2(good_transform_request, reduce_wait_time, f
     assert os.path.exists(r[0])
     assert isinstance(r[1], str)
     assert os.path.exists(r[1])
+
+
+@pytest.mark.asyncio
+async def test_download_to_temp_dir(good_transform_request, reduce_wait_time, files_back_1):
+    'Simple run with expected results'
+    tmp = os.path.join(tempfile.gettempdir(), 'my_test_dir')
+    if os.path.exists(tmp):
+        shutil.rmtree(tmp)
+    os.mkdir(tmp)
+    r = await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file', storage_directory=tmp)
+    assert isinstance(r, List)
+    assert len(r) == 1
+    assert os.path.exists(r[0])
+    assert r[0].startswith(tmp)
 
 # TODO:
 # Other tests


### PR DESCRIPTION
# Purpose

This library has not, up to this point, supported downloading files from `servicex` and returning them to the user. There are now several people who are using this feature ad-hoc. This PR:

- File downloads (see issue #8 for details)
- Support Parquet files (see issue #7 for details)
- Always return the same event ordering (see issue #14 for details).

# Approach

The library already does this asynchronously. This PR exposes that to the user, and then adds a few small features onto that (like sorting and parquet files).

# Reviews

- @kyungeonchoi - I assume this is all that you need - just pass in a new file type (search the changed files tab for `parquet`.
- @BenGalewsky and @mweinberg2718 - There is a lot in here, sorry! I guess sorting by filename to maintain order (see slack convo), and also anything generic about what I'm doing. It is clear that this is starting to accumulate some technical debt. I have an issue, not addressed here, which is to refactor this guy.