### PR TITLE
WIP: Data and File Caching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     - name: Lint with Flake8
       if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
       run: |
-        flake8 --exclude=tests/* --ignore=E501
+        flake8 --exclude=tests/* --ignore=E501,W503
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,9 @@
     "python.linting.flake8Enabled": true,
     "python.testing.pytestArgs": [
         "--no-cov"
+    ],
+    "cSpell.words": [
+        "Reconstructor",
+        "qastle"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,9 +9,12 @@
         "--no-cov"
     ],
     "cSpell.words": [
+        "NOQA",
         "Reconstructor",
         "aiohttp",
+        "linq",
         "pytest",
-        "qastle"
+        "qastle",
+        "servicex"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,8 @@
     ],
     "cSpell.words": [
         "Reconstructor",
+        "aiohttp",
+        "pytest",
         "qastle"
     ]
 }

--- a/servicex/.flake8
+++ b/servicex/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 99
+ignore = W503

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -1,1 +1,2 @@
 from .servicex import get_data_async, get_data, ServiceX_Exception, ServiceXFrontEndException  # NOQA
+from .utils import clean_linq  # NOQA

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -290,14 +290,6 @@ async def get_data_cache_calc(request_id: str,
 # Cache the data that is coming back.
 _data_cache \
     = {}
-# TODO: Weak reference is always deleted right away
-# See https://stackify.com/python-garbage-collection/
-# We are creating too many objects to keep any real data around.
-# Perhaps switch to a LRU algorithm that maintains something about
-# size?
-#    = weakref.WeakValueDictionary()
-# TODO: Why does the following type ref for _data_cache cause an exception?
-# : WeakValueDictionary[str, Union[pd.DataFrame, Dict[bytes, np.ndarray], List[str]]]
 
 
 class weak_holder:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -304,8 +304,11 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
         done = False
         files_downloading = {}
         last_files_processed = 0
+        first = True
         while not done:
-            await asyncio.sleep(servicex_status_poll_time)
+            if not first:
+                await asyncio.sleep(servicex_status_poll_time)
+            first = False
             files_remaining, files_processed = await _get_transform_status(client,
                                                                            servicex_endpoint,
                                                                            request_id)

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -18,7 +18,8 @@ import uproot
 
 from .utils import (
     ServiceXFrontEndException, ServiceX_Exception, _default_wrapper_mgr,
-    _run_default_wrapper, _status_update_wrapper, _submit_or_lookup_transform)
+    _run_default_wrapper, _status_update_wrapper, _submit_or_lookup_transform,
+    _clean_linq)
 
 
 # Number of seconds to wait between polling servicex for the status of a transform job
@@ -262,6 +263,8 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
         t = _default_wrapper_mgr(datasets[0] if isinstance(datasets, list) else datasets)
         status_callback = t.update
     notifier = _status_update_wrapper(status_callback)
+
+    selection_query = _clean_linq(selection_query)
 
     # Normalize how we do the files
     if file_name_func is None:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -19,7 +19,7 @@ import uproot
 from .utils import (
     ServiceXFrontEndException, ServiceX_Exception, _default_wrapper_mgr,
     _run_default_wrapper, _status_update_wrapper, _submit_or_lookup_transform,
-    _clean_linq, _file_object_cache_filename, _file_object_cache_filename_temp,
+    clean_linq, _file_object_cache_filename, _file_object_cache_filename_temp,
     _query_is_cached)
 
 
@@ -396,7 +396,7 @@ async def get_data_async(selection_query: str, dataset: str,
         status_callback = t.update
     notifier = _status_update_wrapper(status_callback)
 
-    selection_query = _clean_linq(selection_query)
+    selection_query = clean_linq(selection_query)
 
     # Normalize how we do the files
     if file_name_func is None:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -17,12 +17,8 @@ from retry import retry
 import uproot
 
 from .utils import (
-    _default_wrapper_mgr, _run_default_wrapper, _status_update_wrapper,
-    _submit_or_lookup_transform, ServiceX_Exception, ServiceXFrontEndException)
-
-
-# Where shall we store files by default when we pull them down?
-default_file_cache_name = os.path.join(tempfile.gettempdir(), 'servicex')
+    ServiceXFrontEndException, ServiceX_Exception, _default_wrapper_mgr,
+    _run_default_wrapper, _status_update_wrapper, _submit_or_lookup_transform)
 
 
 # Number of seconds to wait between polling servicex for the status of a transform job
@@ -271,7 +267,8 @@ async def get_data_async(selection_query: str, datasets: Union[str, List[str]],
     if file_name_func is None:
         if storage_directory is None:
             def file_name(req_id: str, minio_name: str):
-                return os.path.join(default_file_cache_name, req_id,
+                import servicex.utils as sx
+                return os.path.join(sx.default_file_cache_name, req_id,
                                     santize_filename(minio_name))
             file_name_func = file_name
         else:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -102,7 +102,7 @@ def _download_file(minio_client: Minio, request_id: str, bucket_fname: str,
 
 
 @retry(delay=1, tries=10, exceptions=ResponseError)
-def protected_list_objects(client: Minio, request_id: str) -> List[str]:
+def protected_list_objects(client: Minio, request_id: str) -> Iterable[str]:
     '''
     Returns a list of files that are currently available for
     this request. Will pull the list from the disk cache if possible.
@@ -111,7 +111,7 @@ def protected_list_objects(client: Minio, request_id: str) -> List[str]:
     p = _file_object_cache_filename(request_id)
     p.parent.mkdir(parents=True, exist_ok=True)
     if p.exists():
-        return p.read_text().splitlines()
+        return filter(lambda l: len(l) > 0, p.read_text().splitlines())
 
     # Go out to actually request the list
     listing = [f.object_name for f in client.list_objects(request_id)]

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -9,7 +9,6 @@ from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Union
 import urllib
 
 import aiohttp
-from aiohttp.client import request
 import awkward
 from minio import Minio, ResponseError
 import numpy as np
@@ -372,7 +371,7 @@ async def get_data_async(selection_query: str, dataset: str,
         - The filename should be safe in the sense that a ".downloading" can be appended to
           the end of the string without causing any trouble.
     '''
-    # Parameter clean up, API saftey checking
+    # Parameter clean up, API safety checking
     if (data_type != 'pandas') \
             and (data_type != 'awkward') \
             and (data_type != 'parquet') \
@@ -467,6 +466,7 @@ async def get_data_async(selection_query: str, dataset: str,
                     else:
                         # Retry - so force us not to use the cache
                         use_cache = False
+        assert result.o is not None
         return result.o
 
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -194,13 +194,6 @@ async def _download_new_files(files_queued: Iterable[str], end_point: str,
 
     futures = {fname: asyncio.wrap_future(_download_executor.submit(do_download_and_post, fname))
                for fname in new_files}
-    # futures = {fname: _post_process_data(
-    #     data_type,
-    #     await asyncio.wrap_future(_download_executor.submit(_download_file, minio_client,
-    #                                                         request_id, fname, file_name_func,
-    #                                                         redownload_files)),
-    #     notifier)
-    #     for fname in new_files}
     return futures
 
 
@@ -245,6 +238,7 @@ async def get_data_cache_calc(request_id: str,
                 + (files_failed if files_failed is not None else 0)
             notifier.update(total=t)
         notifier.broadcast()
+
         if files_processed > last_files_processed:
             new_downloads = await _download_new_files(files_downloading.keys(),
                                                       servicex_endpoint, request_id,

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -8,9 +8,8 @@ from typing import Callable, Dict, Optional
 import aiohttp
 from tqdm.auto import tqdm
 
-from lark.reconstruct import Reconstructor
 from lark import Transformer, Token
-from qastle import parse, Parser
+from qastle import parse
 
 
 # Where shall we store files by default when we pull them down?
@@ -225,9 +224,11 @@ def _clean_linq(q: str) -> str:
                                     f'with {len(fields)} arguments - not the required 2!')
                 arg_list = [f.info for f in fields[0].info]
                 arg_mapping = {old: new_arg() for old in arg_list}
-                fields[0] = ParseTracker(f'(list {" ".join(arg_mapping[k] for k in arg_list)})',
-                                         [ParseTracker(arg_mapping[f], arg_mapping[f]) for f in arg_list])
-                fields[1] = ParseTracker(_replace_strings(fields[1].text, arg_mapping), fields[1].info)
+                fields[0] = ParseTracker(
+                    f'(list {" ".join(arg_mapping[k] for k in arg_list)})',
+                    [ParseTracker(arg_mapping[f], arg_mapping[f]) for f in arg_list])
+                fields[1] = ParseTracker(_replace_strings(fields[1].text, arg_mapping),
+                                         fields[1].info)
 
             return ParseTracker(f'({node_type} {" ".join([f.text for f in fields])})', fields)
 

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -95,7 +95,7 @@ def _run_default_wrapper(t: Optional[int], p: int, d: int, f: int) -> None:
 
 
 class _default_wrapper_mgr:
-    'Default prorgress bar'
+    'Default progress bar'
     def __init__(self, sample_name: Optional[str] = None):
         self._tqdm_p = tqdm(total=9e9, desc=sample_name, unit='file',
                             leave=True, dynamic_ncols=True,

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -1,4 +1,3 @@
-from os.path import exists
 from typing import Callable, Dict, Optional
 import os
 import tempfile

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, Optional, Awaitable
+from typing import Any, Callable, Dict, Optional
 
 import aiohttp
 from tqdm.auto import tqdm

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -97,7 +97,15 @@ def _run_default_wrapper(t: Optional[int], p: int, d: int, f: int) -> None:
 class _default_wrapper_mgr:
     'Default progress bar'
     def __init__(self, sample_name: Optional[str] = None):
-        self._tqdm_p = tqdm(total=9e9, desc=sample_name, unit='file',
+        self._tqdm_p = None
+        self._tqdm_d = None
+        self._sample_name = sample_name
+
+    def _init_tqdm(self):
+        if self._tqdm_p is not None:
+            return
+
+        self._tqdm_p = tqdm(total=9e9, desc=self._sample_name, unit='file',
                             leave=True, dynamic_ncols=True,
                             bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}]')
         self._tqdm_d = tqdm(total=9e9, desc="        Downloaded", unit='file',
@@ -120,6 +128,7 @@ class _default_wrapper_mgr:
             bar.close()
 
     def update(self, total: Optional[int], processed: int, downloaded: int, failed: int):
+        self._init_tqdm()
         self._update_bar(self._tqdm_p, total, processed, failed)
         self._update_bar(self._tqdm_d, total, downloaded, failed)
 

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -1,7 +1,12 @@
 from typing import Any, Callable, Dict, Optional
+import os
+import tempfile
 
 import aiohttp
 from tqdm.auto import tqdm
+
+# Where shall we store files by default when we pull them down?
+default_file_cache_name = os.path.join(tempfile.gettempdir(), 'servicex')
 
 
 class ServiceX_Exception(Exception):
@@ -99,7 +104,6 @@ async def _submit_or_lookup_transform(client: aiohttp.ClientSession,
     Submit a transform, or look it up in our local query database
     '''
     async with client.post(f'{servicex_endpoint}/transformation', json=json_query) as response:
-        # TODO: Make sure to throw the correct type of exception
         r = await response.json()
         if response.status != 200:
             raise ServiceX_Exception('ServiceX rejected the transformation request: '

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -106,6 +106,7 @@ _json_keys_to_ignore_for_hash = ['workers']
 
 async def _submit_or_lookup_transform(client: aiohttp.ClientSession,
                                       servicex_endpoint: str,
+                                      use_cache: bool,
                                       json_query: Dict[str, str]) -> str:
     '''
     Submit a transform, or look it up in our local query database
@@ -119,7 +120,7 @@ async def _submit_or_lookup_transform(client: aiohttp.ClientSession,
     hash = hasher.hexdigest()
 
     hash_file = Path(default_file_cache_name) / 'request-cache' / hash
-    if hash_file.exists():
+    if use_cache and hash_file.exists():
         with hash_file.open('r') as r:
             return r.readline().strip()
 

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -236,3 +236,22 @@ def _clean_linq(q: str) -> str:
     new_tree = translator().transform(tree)
     assert isinstance(new_tree, str)
     return new_tree
+
+
+def _file_object_cache_filename(request_id: str) -> Path:
+    '''
+    Return the path of the file where we will write out the cache for the
+    file objects we are downloading.
+    '''
+    global default_file_cache_name
+    return Path(default_file_cache_name) / 'object_list_cache' / request_id
+
+
+def _file_object_cache_filename_temp(request_id: str) -> Path:
+    '''
+    Return the path of the file where we will write out the cache for the
+    file objects we are downloading. This is the temp file.
+    '''
+    global default_file_cache_name
+    return Path(default_file_cache_name) / 'object_list_cache' / \
+        f'{request_id}-temp'

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -184,7 +184,7 @@ async def _submit_or_lookup_transform(client: aiohttp.ClientSession,
     return req_id
 
 
-def _clean_linq(q: str) -> str:
+def clean_linq(q: str) -> str:
     '''
     Normalize the variables in a qastle expression. Should make the
     linq expression more easily comparable even if the algorithm that

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,8 @@ setup(name="servicex",
           "retry~=0.9",
           "aiohttp~=3.6",
           "minio~=5.0",
-          "tqdm~=4.0"
+          "tqdm~=4.0",
+          "qastle==0.7"
       ],
       extras_require={
           'test': [

--- a/tests/.flake8
+++ b/tests/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 max-line-length = 1000000
+ignore = F811

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -614,9 +614,9 @@ async def test_download_cached_nonet(good_transform_request, reduce_wait_time, f
     'Make sure we do not query the network if we already have everything local'
     await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
     await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
-    f_get, f_list = files_back_1
+    _ , f_list = files_back_1
     json = good_transform_request
-    assert json['called'] == 1
+    assert json['called'] == 1, 'Expected transform request to have been made only once'
     f_list.assert_called_once(), "Only a single transform request made"
 
 

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -683,6 +683,17 @@ async def test_download_cached_awkward(good_transform_request, reduce_wait_time,
 
 
 @pytest.mark.asyncio
+async def test_simultaneous_query_not_requeued(good_transform_request, reduce_wait_time, files_back_1):
+    'Simple run with expected results'
+    a_a1 = fe.get_data_async('(valid qastle string)', 'one_ds', data_type='awkward')
+    a_a2 = fe.get_data_async('(valid qastle string)', 'one_ds', data_type='awkward')
+
+    a1, a2 = await asyncio.gather(a_a1, a_a2)
+    assert good_transform_request["called"] == 1
+    assert a1 is a2
+
+
+@pytest.mark.asyncio
 async def test_download_to_temp_dir(good_transform_request, reduce_wait_time, files_back_1):
     'Download to a specified storage directory'
     tmp = os.path.join(tempfile.gettempdir(), 'my_test_dir')

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -613,6 +613,9 @@ async def test_good_download_files_2(good_transform_request, reduce_wait_time, f
 async def test_download_cached_nonet(good_transform_request, reduce_wait_time, files_back_1):
     'Make sure we do not query the network if we already have everything local'
     await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
+    # Make sure to turn off the in-memory cache
+    import servicex.servicex as sxx
+    sxx._data_cache = {}
     await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file')
     _ , f_list = files_back_1
     json = good_transform_request

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -15,20 +15,7 @@ import pytest
 
 import servicex as fe
 
-from .utils_for_testing import good_transform_request, ClientSessionMocker  # NOQA
-
-
-@pytest.fixture(autouse=True)
-def delete_default_downloaded_files():
-    download_location = os.path.join(tempfile.gettempdir(), 'servicex-testing')
-    import servicex.servicex as sx
-    sx.default_file_cache_name = download_location
-    if os.path.exists(download_location):
-        shutil.rmtree(download_location)
-    yield
-    if os.path.exists(download_location):
-        shutil.rmtree(download_location)
-
+from .utils_for_testing import good_transform_request, ClientSessionMocker, delete_default_downloaded_files  # NOQA
 
 @pytest.fixture(scope="module")
 def reduce_wait_time():

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1,19 +1,21 @@
 import asyncio
-from json import dumps, loads
+from json import dumps
 import os
 import queue
 import re
 import shutil
+import tempfile
 from typing import List, Optional
 from unittest import mock
 from unittest.mock import MagicMock
-import tempfile
 
 from minio.error import ResponseError
 import pandas as pd
 import pytest
 
 import servicex as fe
+
+from .utils_for_testing import good_transform_request, ClientSessionMocker  # NOQA
 
 
 @pytest.fixture(autouse=True)
@@ -34,24 +36,6 @@ def reduce_wait_time():
     fe.servicex.servicex_status_poll_time = 0.01
     yield None
     fe.servicex.servicex_status_poll_time = old_value
-
-
-class ClientSessionMocker:
-    def __init__(self, text, status):
-        self._text = text
-        self.status = status
-
-    async def text(self):
-        return self._text
-
-    async def json(self):
-        return loads(self._text)
-
-    async def __aexit__(self, exc_type, exc, tb):
-        pass
-
-    async def __aenter__(self):
-        return self
 
 
 def good_copy(a, b, c):
@@ -94,10 +78,10 @@ def files_back_2(mocker):
 def files_back_4_order_1(mocker):
     mocker.patch('minio.api.Minio.list_objects',
                  return_value=[
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000002.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000003.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000004.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000002.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000003.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000004.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')
                  ])
     mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
     return None
@@ -107,10 +91,10 @@ def files_back_4_order_1(mocker):
 def files_back_4_order_2(mocker):
     mocker.patch('minio.api.Minio.list_objects',
                  return_value=[
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000003.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000004.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000002.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
-                    make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000003.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000004.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000002.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio'),
+                     make_minio_file('root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas:dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')
                  ])
     mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
     return None
@@ -159,24 +143,6 @@ def indexed_files_back(mocker):
     'Use the request id formatting to figure out how many files to deliver back'
     mocker.patch('minio.api.Minio.list_objects', new_callable=list_objects_callable)
     mocker.patch('minio.api.Minio.fget_object', side_effect=good_copy)
-
-
-@pytest.fixture()
-def good_transform_request(mocker):
-    '''
-    Setup to run a good transform request that returns a single file.
-    '''
-    called_json_data = {}
-
-    def call_post(data_dict_to_save: dict, json=None):
-        data_dict_to_save.update(json)
-        return ClientSessionMocker(dumps({"request_id": "1234-4433-111-34-22-444"}), 200)
-    mocker.patch('aiohttp.ClientSession.post', side_effect=lambda _, json: call_post(called_json_data, json=json))
-
-    r2 = ClientSessionMocker(dumps({"files-remaining": "0", "files-processed": "1"}), 200)
-    mocker.patch('aiohttp.ClientSession.get', return_value=r2)
-
-    return called_json_data
 
 
 @pytest.fixture()
@@ -251,7 +217,7 @@ async def test_good_run_single_ds_2file_pandas(good_transform_request, reduce_wa
     'Simple run with expected results'
     r = await fe.get_data_async('(valid qastle string)', 'one_ds')
     assert isinstance(r, pd.DataFrame)
-    assert len(r) == 283458*2
+    assert len(r) == 283458 * 2
 
 
 @pytest.mark.asyncio
@@ -271,7 +237,7 @@ async def test_good_run_single_ds_2file_awkward(good_transform_request, reduce_w
     assert isinstance(r, dict)
     assert len(r) == 1
     assert b'JetPt' in r
-    assert len(r[b'JetPt']) == 283458*2
+    assert len(r[b'JetPt']) == 283458 * 2
 
 
 @pytest.mark.asyncio
@@ -283,7 +249,7 @@ async def test_2awkward_combined_correctly(good_transform_request, reduce_wait_t
     import uproot_methods
     assert isinstance(r, dict)
     arr = uproot_methods.TLorentzVectorArray.from_ptetaphi(r[b'JetPt'], r[b'JetPt'], r[b'JetPt'], r[b'JetPt'])
-    assert len(arr) == 283458*2
+    assert len(arr) == 283458 * 2
 
 
 @pytest.mark.asyncio
@@ -359,7 +325,7 @@ async def test_run_with_four_queries(good_requests_indexed, reduce_wait_time, in
     assert len(all_wait) == 4
     for cnt, r in enumerate(all_wait):
         assert isinstance(r, pd.DataFrame)
-        assert len(r) == 283458*(cnt+1)
+        assert len(r) == 283458 * (cnt + 1)
 
 
 @pytest.mark.asyncio
@@ -383,7 +349,7 @@ async def test_files_downloaded_ready_in_sequence(good_transform_request_delayed
     r1 = fe.get_data_async('(valid qastle string)', 'ds_0_2')
     r = await r1
     assert isinstance(r, pd.DataFrame)
-    assert len(r) == 283458*2
+    assert len(r) == 283458 * 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -505,7 +505,7 @@ async def test_good_download_files_2(good_transform_request, reduce_wait_time, f
 
 @pytest.mark.asyncio
 async def test_download_to_temp_dir(good_transform_request, reduce_wait_time, files_back_1):
-    'Simple run with expected results'
+    'Download to a specified storage directory'
     tmp = os.path.join(tempfile.gettempdir(), 'my_test_dir')
     if os.path.exists(tmp):
         shutil.rmtree(tmp)
@@ -519,7 +519,7 @@ async def test_download_to_temp_dir(good_transform_request, reduce_wait_time, fi
 
 @pytest.mark.asyncio
 async def test_download_to_lambda_dir(good_transform_request, reduce_wait_time, files_back_1):
-    'Simple run with expected results'
+    'Download to files using a file name function callback'
     tmp = os.path.join(tempfile.gettempdir(), 'my_test_dir')
     if os.path.exists(tmp):
         shutil.rmtree(tmp)
@@ -533,20 +533,21 @@ async def test_download_to_lambda_dir(good_transform_request, reduce_wait_time, 
 
 @pytest.mark.asyncio
 async def test_download_bad_params_filerename(good_transform_request, reduce_wait_time, files_back_1):
-    'Simple run with expected results'
+    'Specify both a storage directory and a filename rename func - illegal'
     tmp = os.path.join(tempfile.gettempdir(), 'my_test_dir')
     if os.path.exists(tmp):
         shutil.rmtree(tmp)
     os.mkdir(tmp)
-    with pytest.raises(Exception):
+    with pytest.raises(Exception) as e:
         await fe.get_data_async('(valid qastle string)', 'one_ds', data_type='root-file',
                                 storage_directory=tmp,
                                 file_name_func=lambda rid, obj_name: f'{tmp}\\{clean_fname(obj_name)}')
+    assert "only specify" in str(e.value)
 
 
 @pytest.mark.asyncio
 async def test_download_already_there_files(good_transform_request, reduce_wait_time, files_back_1):
-    'Simple run with expected results'
+    'Re-run and files already existing, do not download again'
     tmp = os.path.join(tempfile.gettempdir(), 're_download_dir')
     if os.path.exists(tmp):
         shutil.rmtree(tmp)
@@ -564,7 +565,7 @@ async def test_download_already_there_files(good_transform_request, reduce_wait_
 
 @pytest.mark.asyncio
 async def test_download_not_there_files(good_transform_request, reduce_wait_time, files_back_1):
-    'Simple run with expected results'
+    'Make sure we can download to a specific file'
     tmp = os.path.join(tempfile.gettempdir(), 're_download_dir')
     if os.path.exists(tmp):
         shutil.rmtree(tmp)

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -882,7 +882,7 @@ def test_failed_iteration(bad_transform, reduce_wait_time, files_back_1):
     with pytest.raises(fe.ServiceX_Exception) as e:
         fe.get_data('(valid qastle string)', 'one_ds', status_callback=check_in)
 
-    assert len(f_total) == 1
+    assert len(f_total) == 2
     assert all(i == 2 for i in f_total)
     assert all(i == 1 for i in f_failed)
     assert "failed to transform" in str(e.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,10 @@
-from servicex.utils import _status_update_wrapper
 from typing import Optional
+
+import pytest
+
+from servicex.utils import _status_update_wrapper
+
+from .utils_for_testing import good_transform_request  # NOQA
 
 
 def test_callback_no_updates():
@@ -135,3 +140,8 @@ def test_callback_none():
     u.update(downloaded=3)
     u.update(total=12)
     u.broadcast()
+
+
+@pytest.mark.asyncio
+async def test_request_trans_once():
+    pass

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -104,6 +104,40 @@ def test_callback_everything():
     assert p_failed == 1
 
 
+def test_callback_reset():
+    'We want to restart.'
+
+    called = False
+    p_total = None
+    p_processed = None
+    p_downloaded = None
+    p_failed = None
+
+    def call_me(total: Optional[int], processed: int, downloaded: int, failed: int):
+        nonlocal called, p_total, p_processed, p_downloaded, p_failed
+        called = True
+        p_total = total
+        p_processed = processed
+        p_downloaded = downloaded
+        p_failed = failed
+
+    u = _status_update_wrapper(call_me)
+    u.update(processed=10)
+    u.update(downloaded=2)
+    u.update(failed=1)
+    u.update(total=12)
+    u.reset()
+    u.update(processed=10)
+    u.update(downloaded=2)
+    u.update(total=12)
+    u.broadcast()
+    assert called
+    assert p_total == 12
+    assert p_downloaded == 2
+    assert p_processed == 10
+    assert p_failed == 0
+
+
 def test_callback_inc_with_nothing():
     called = False
     p_total = None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -152,7 +152,7 @@ async def test_request_trans_once(good_transform_request):
         'workers': 10,
     }
     async with aiohttp.ClientSession() as client:
-        rid = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
         assert rid is not None
         req_json = good_transform_request
         assert req_json is not None
@@ -167,10 +167,25 @@ async def test_request_trans_twice(good_transform_request):
         'workers': 10,
     }
     async with aiohttp.ClientSession() as client:
-        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
-        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
+        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
 
         assert rid1 == rid2
+
+
+@pytest.mark.asyncio
+async def test_request_trans_twice_no_cache(good_transform_request):
+    json_query = {
+        'did': "dude_001",
+        'selection': "(valid qastle)",
+        'chunk-size': 1000,
+        'workers': 10,
+    }
+    async with aiohttp.ClientSession() as client:
+        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", False, json_query)
+        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", False, json_query)
+
+        assert rid1 != rid2
 
 
 @pytest.mark.asyncio
@@ -182,9 +197,9 @@ async def test_request_trans_cache_workers(good_transform_request):
         'workers': 10,
     }
     async with aiohttp.ClientSession() as client:
-        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
         json_query['workers'] = 100
-        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
 
         assert rid1 == rid2
 
@@ -198,9 +213,9 @@ async def test_request_trans_cache_selection(good_transform_request):
         'workers': 10,
     }
     async with aiohttp.ClientSession() as client:
-        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
         json_query['selection'] = '(call valid qastle)'
-        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
 
         assert rid1 != rid2
 
@@ -214,9 +229,9 @@ async def test_request_trans_cache_did(good_transform_request):
         'workers': 10,
     }
     async with aiohttp.ClientSession() as client:
-        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
         json_query['did'] = 'did_002'
-        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
 
         assert rid1 != rid2
 
@@ -230,8 +245,8 @@ async def test_request_trans_cache_unknown(good_transform_request):
         'workers': 10,
     }
     async with aiohttp.ClientSession() as client:
-        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid1 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
         json_query['fork'] = 'me'
-        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", json_query)
+        rid2 = await _submit_or_lookup_transform(client, "http://localhost:5000/servicex", True, json_query)
 
         assert rid1 != rid2

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@ import aiohttp
 
 import pytest
 
-from servicex.utils import _status_update_wrapper, _submit_or_lookup_transform, _clean_linq
+from servicex.utils import _status_update_wrapper, _submit_or_lookup_transform, clean_linq
 
 from .utils_for_testing import good_transform_request, delete_default_downloaded_files  # NOQA
 
@@ -324,42 +324,42 @@ async def test_request_trans_cache_unknown(good_transform_request):
 
 def test_clean_linq_no_lambda():
     q = '(valid qastle)'
-    assert _clean_linq(q) == q
+    assert clean_linq(q) == q
 
 
 def test_clean_linq_single_lambda():
     q = '(lambda (list e0 e1) (+ e0 e1))'
-    assert _clean_linq(q) == '(lambda (list a0 a1) (+ a0 a1))'
+    assert clean_linq(q) == '(lambda (list a0 a1) (+ a0 a1))'
 
 
 def test_clean_linq_many_args():
     q = '(lambda (list e0 e1 e2 e3 e4 e5 e6 e7 e8 e9 e10 e11) (+ e0 e1 e2 e3 e4 e5 e6 e7 e8 e9 e10 e11))'
-    assert _clean_linq(q) == '(lambda (list a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11) (+ a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11))'
+    assert clean_linq(q) == '(lambda (list a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11) (+ a0 a1 a2 a3 a4 a5 a6 a7 a8 a9 a10 a11))'
 
 
 def test_clean_linq_funny_var_names():
     q = '(lambda (list e0 e000) (+ e000 e0))'
-    assert _clean_linq(q) == '(lambda (list a0 a1) (+ a1 a0))'
+    assert clean_linq(q) == '(lambda (list a0 a1) (+ a1 a0))'
 
 
 def test_clean_linq_nested_lambda():
     q = '(lambda (list e0 e1) (+ (call (lambda (list e0) (+ e0 1)) e0) e1))'
-    assert _clean_linq(q) == '(lambda (list a1 a2) (+ (call (lambda (list a0) (+ a0 1)) a1) a2))'
+    assert clean_linq(q) == '(lambda (list a1 a2) (+ (call (lambda (list a0) (+ a0 1)) a1) a2))'
 
 
 def test_clean_linq_arb_var_names():
     q = '(lambda (list a0 f1) (+ a0 f1))'
-    assert _clean_linq(q) == '(lambda (list a0 a1) (+ a0 a1))'
+    assert clean_linq(q) == '(lambda (list a0 a1) (+ a0 a1))'
 
 
 def test_clean_linq_empty():
     q = ''
-    assert _clean_linq(q) == ""
+    assert clean_linq(q) == ""
 
 
 def test_clean_linq_too_many_lambda():
     q = '(lambda (list e0 e1) (+ e0 e1) (one too many))'
-    with pytest.raises(Exception) as e:
-        _clean_linq(q)
+    with pytest.raises(Exception):
+        clean_linq(q)
 
     assert "required 2"

--- a/tests/utils_for_testing.py
+++ b/tests/utils_for_testing.py
@@ -36,6 +36,7 @@ def good_transform_request(mocker):
         nonlocal counter
         counter = counter + 1
         return ClientSessionMocker(dumps({"request_id": f"1234-4433-111-34-22-444-{counter}"}), 200)
+
     mocker.patch('aiohttp.ClientSession.post', side_effect=lambda _, json: call_post(called_json_data, json=json))
 
     r2 = ClientSessionMocker(dumps({"files-remaining": "0", "files-processed": "1"}), 200)

--- a/tests/utils_for_testing.py
+++ b/tests/utils_for_testing.py
@@ -53,10 +53,13 @@ def delete_default_downloaded_files():
     if os.path.exists(download_location):
         shutil.rmtree(download_location)
     import servicex.servicex as ssx
-    import weakref
+    # import weakref
     # ssx._data_cache = weakref.WeakValueDictionary()
     ssx._data_cache = {}
+    ssx._query_locks = {}
     yield
     if os.path.exists(download_location):
         shutil.rmtree(download_location)
-    ssx._data_cache = weakref.WeakValueDictionary()
+    ssx._data_cache = {}
+    ssx._query_locks = {}
+    # ssx._data_cache = weakref.WeakValueDictionary()

--- a/tests/utils_for_testing.py
+++ b/tests/utils_for_testing.py
@@ -1,0 +1,38 @@
+import pytest
+from json import loads, dumps
+
+
+class ClientSessionMocker:
+    def __init__(self, text, status):
+        self._text = text
+        self.status = status
+
+    async def text(self):
+        return self._text
+
+    async def json(self):
+        return loads(self._text)
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+
+@pytest.fixture()
+def good_transform_request(mocker):
+    '''
+    Setup to run a good transform request that returns a single file.
+    '''
+    called_json_data = {}
+
+    def call_post(data_dict_to_save: dict, json=None):
+        data_dict_to_save.update(json)
+        return ClientSessionMocker(dumps({"request_id": "1234-4433-111-34-22-444"}), 200)
+    mocker.patch('aiohttp.ClientSession.post', side_effect=lambda _, json: call_post(called_json_data, json=json))
+
+    r2 = ClientSessionMocker(dumps({"files-remaining": "0", "files-processed": "1"}), 200)
+    mocker.patch('aiohttp.ClientSession.get', return_value=r2)
+
+    return called_json_data

--- a/tests/utils_for_testing.py
+++ b/tests/utils_for_testing.py
@@ -1,5 +1,8 @@
 import pytest
 from json import loads, dumps
+import os
+import tempfile
+import shutil
 
 
 class ClientSessionMocker:
@@ -26,13 +29,28 @@ def good_transform_request(mocker):
     Setup to run a good transform request that returns a single file.
     '''
     called_json_data = {}
+    counter = 0
 
     def call_post(data_dict_to_save: dict, json=None):
         data_dict_to_save.update(json)
-        return ClientSessionMocker(dumps({"request_id": "1234-4433-111-34-22-444"}), 200)
+        nonlocal counter
+        counter = counter + 1
+        return ClientSessionMocker(dumps({"request_id": f"1234-4433-111-34-22-444-{counter}"}), 200)
     mocker.patch('aiohttp.ClientSession.post', side_effect=lambda _, json: call_post(called_json_data, json=json))
 
     r2 = ClientSessionMocker(dumps({"files-remaining": "0", "files-processed": "1"}), 200)
     mocker.patch('aiohttp.ClientSession.get', return_value=r2)
 
     return called_json_data
+
+
+@pytest.fixture(autouse=True)
+def delete_default_downloaded_files():
+    download_location = os.path.join(tempfile.gettempdir(), 'servicex-testing')
+    import servicex.utils as sx
+    sx.default_file_cache_name = download_location
+    if os.path.exists(download_location):
+        shutil.rmtree(download_location)
+    yield
+    if os.path.exists(download_location):
+        shutil.rmtree(download_location)

--- a/tests/utils_for_testing.py
+++ b/tests/utils_for_testing.py
@@ -52,6 +52,11 @@ def delete_default_downloaded_files():
     sx.default_file_cache_name = download_location
     if os.path.exists(download_location):
         shutil.rmtree(download_location)
+    import servicex.servicex as ssx
+    import weakref
+    # ssx._data_cache = weakref.WeakValueDictionary()
+    ssx._data_cache = {}
     yield
     if os.path.exists(download_location):
         shutil.rmtree(download_location)
+    ssx._data_cache = weakref.WeakValueDictionary()


### PR DESCRIPTION
This makes caching available to the end-user when working with Service. The goals are:

- If the same query is made to ServiceX, that the data are not re-downloaded. This is across program restarts
- Within the same execution environment, if the data has been loaded once, it should not be reloaded (assumes data is immutable).

## Current Status

   - [x] All Features and Bug Fixes are in
   - [x] Testing outside of the unit test environment
   - [ ] Branch ahead of this one is merged into `develop` and this one rebased
   - [ ] Review by others

## Issues Contributing

WIP