### PR TITLE
Add tree_name for uproot ServiceX

### DIFF
--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -36,12 +36,13 @@ class ServiceXDataset(ServiceXABC):
                  servicex_adaptor: ServiceXAdaptor = None,
                  minio_adaptor: MinioAdaptor = None,
                  image: str = 'sslhep/servicex_func_adl_xaod_transformer:v0.4',
+                 tree_name: str = None,
                  storage_directory: Optional[str] = None,
                  file_name_func: Optional[Callable[[str, str], Path]] = None,
                  max_workers: int = 20,
                  status_callback_factory: Optional[StatusUpdateFactory] = _run_default_wrapper,
                  cache_adaptor: Cache = None):
-        ServiceXABC.__init__(self, dataset, image, storage_directory, file_name_func,
+        ServiceXABC.__init__(self, dataset, image, tree_name, storage_directory, file_name_func,
                              max_workers, status_callback_factory)
 
         # Eventually will want to parse local files for config info.
@@ -293,6 +294,7 @@ class ServiceXDataset(ServiceXABC):
         '''
         json_query: Dict[str, str] = {
             "did": self._dataset,
+            "tree-name": self._tree_name,
             "selection": selection_query,
             "image": self._image,
             "result-destination": "object-store",

--- a/servicex/servicexabc.py
+++ b/servicex/servicexabc.py
@@ -30,6 +30,7 @@ class ServiceXABC(ABC):
     def __init__(self,
                  dataset: str,
                  image: str = 'sslhep/servicex_func_adl_xaod_transformer:v0.4',
+                 tree_name: str = None,
                  storage_directory: Optional[str] = None,
                  file_name_func: Optional[Callable[[str, str], Path]] = None,
                  max_workers: int = 20,
@@ -40,6 +41,7 @@ class ServiceXABC(ABC):
         Arguments
 
             dataset                     Name of a dataset from which queries will be selected.
+            tree_name                   TTree name for uproot transformer
             service_endpoint            Where the ServiceX web API is found
             image                       Name of transformer image to use to transform the data
             storage_directory           Location to cache data that comes back from ServiceX. Data
@@ -64,6 +66,7 @@ class ServiceXABC(ABC):
         '''
         self._dataset = dataset
         self._image = image
+        self._tree_name = tree_name
         self._max_workers = max_workers
 
         # We can't create the notifier until the actual query,


### PR DESCRIPTION
Temporary support for Uproot ServiceX until `tree-name` can be passed from the qastle query.