### PR TITLE
Print out container errors during failed transformations

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -30,6 +30,7 @@
         "codecov",
         "dcache",
         "desy",
+        "dont",
         "fget",
         "fname",
         "inmem",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,6 @@
     "python.analysis.logLevel": "Information",
     "python.analysis.memory.keepLibraryAst": true,
     "python.linting.flake8Enabled": true,
-    "python.testing.pytestArgs": [
-        "--no-cov"
-    ],
     "cSpell.words": [
         "AOD's",
         "AZNLOCTEQ",
@@ -61,11 +58,15 @@
         "servicexabc",
         "setuptools",
         "sslhep",
+        "stfc",
         "tcut",
         "tqdm",
         "unittests",
         "xaod",
         "xrootd"
     ],
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "python.testing.pytestArgs": [
+        "--no-cov"
+    ]
 }

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -262,6 +262,7 @@ class ServiceXDataset(ServiceXABC):
 
             except ServiceXFailedFileTransform as e:
                 self._cache.remove_query(query)
+                self._servicex_adaptor.dump_query_errors(client, request_id)
                 raise ServiceXException(f'Failed to transform all files in {request_id}') from e
 
     async def _get_request_id(self, client: aiohttp.ClientSession, query: Dict[str, Any]) -> str:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -37,7 +37,7 @@ class ServiceXDataset(ServiceXABC):
     '''
     def __init__(self,
                  dataset: str,
-                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:130_reset_cwd',
+                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:29_dont_truncate_error_logs',  # NOQA
                  max_workers: int = 20,
                  servicex_adaptor: ServiceXAdaptor = None,
                  minio_adaptor: Union[MinioAdaptor, MinioAdaptorFactory] = None,

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -143,11 +143,11 @@ class ServiceXAdaptor:
 
             # Dump the messages out to the logger if there are any!
             errors = (await response.json())["errors"]
-            l = logging.getLogger(__name__)
+            log = logging.getLogger(__name__)
             for e in errors:
-                l.warning(f'Error transforming file: {e["file"]}')
+                log.warning(f'Error transforming file: {e["file"]}')
                 for ln in e["info"].split('\n'):
-                    l.warning(f'  -> {ln}')
+                    log.warning(f'  -> {ln}')
 
     @staticmethod
     def _get_transform_stat(info: Dict[str, str], stat_name: str):

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -24,8 +24,10 @@ def servicex_adaptor_factory(c: ConfigView):
     endpoint = c['api_endpoint']['endpoint'].as_str_expanded()
 
     # We can default these to "None"
-    username = c['api_endpoint']['username'].as_str_expanded() if 'username' in c['api_endpoint'] else None
-    password = c['api_endpoint']['password'].as_str_expanded() if 'password' in c['api_endpoint'] else None
+    username = c['api_endpoint']['username'].as_str_expanded() if 'username' in c['api_endpoint'] \
+        else None
+    password = c['api_endpoint']['password'].as_str_expanded() if 'password' in c['api_endpoint'] \
+        else None
     return ServiceXAdaptor(endpoint, username, password)
 
 
@@ -116,6 +118,36 @@ class ServiceXAdaptor:
 
             r = await response.json()
             return r
+
+    async def dump_query_errors(self, client: aiohttp.ClientSession,
+                                request_id: str):
+        '''Dumps to the logging system any error messages we find from ServiceX.
+
+        Args:
+            client (aiohttp.ClientSession): Client along which to send queries.
+            request_id (str): Fetch all errors from there.
+        '''
+
+        headers = await self._get_authorization(client)
+        async with client.get(f'{self._endpoint}/servicex/transformation/{request_id}/errors',
+                              headers=headers) as response:
+            status = response.status
+            if status != 200:
+                t = await response.text()
+                if "Request not found" in t:
+                    raise ServiceXUnknownRequestID(f'Unable to get errors for request {request_id}'
+                                                   f': {status} - {t}')
+                else:
+                    raise ServiceXException(f'Failed to get request errors for {request_id}: '
+                                            f'{status} - {t}')
+
+            # Dump the messages out to the logger if there are any!
+            errors = (await response.json())["errors"]
+            l = logging.getLogger(__name__)
+            for e in errors:
+                l.warning(f'Error transforming file: {e["file"]}')
+                for ln in e["info"].split('\n'):
+                    l.warning(f'  -> {ln}')
 
     @staticmethod
     def _get_transform_stat(info: Dict[str, str], stat_name: str):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,8 @@ class MockServiceXAdaptor:
             if mock_transform_status \
             else mocker.Mock(return_value=(0, 1, 0))
 
+        self.dump_query_errors = mocker.MagicMock(return_value=None)
+
     async def submit_query(self, client: aiohttp.ClientSession,
                            json_query: Dict[str, str]) -> str:
         self.query_json = json_query

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -514,7 +514,6 @@ async def test_servicex_transformer_failure_reload(mocker, short_status_poll_tim
     mock_cache.remove_query.assert_called_once()
 
 
-
 @pytest.mark.asyncio
 async def test_servicex_transformer_failure_errors_dumped(mocker, short_status_poll_time):
     '''

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -514,6 +514,33 @@ async def test_servicex_transformer_failure_reload(mocker, short_status_poll_tim
     mock_cache.remove_query.assert_called_once()
 
 
+
+@pytest.mark.asyncio
+async def test_servicex_transformer_failure_errors_dumped(mocker, short_status_poll_time):
+    '''
+    1. Start a transform
+    2. A file is marked as failing
+    3. Make sure that the dump errors is called.
+    '''
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    transform_status = mocker.MagicMock(return_value=(0, 0, 1))
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456",
+                                                mock_transform_status=transform_status)
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+
+    ds = fe.ServiceXDataset('http://one-ds',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            local_log=mock_logger)
+
+    with pytest.raises(fe.ServiceXException):
+        # Will fail with one skipped file.
+        await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    mock_servicex_adaptor.dump_query_errors.assert_called_once()
+
 @pytest.mark.asyncio
 async def test_servicex_in_progress_lock_cleared(mocker, short_status_poll_time):
     '''

--- a/tests/test_servicex_adaptor.py
+++ b/tests/test_servicex_adaptor.py
@@ -519,7 +519,7 @@ async def test_fetch_errors_for_bad_bad_bad(mocker):
     client.get = mocker.Mock(return_value=ClientSessionMocker("Internal Error", 500))
 
     x = ServiceXAdaptor('http://localhost:5000')
-    with pytest.raises(ServiceXUnknownRequestID):
+    with pytest.raises(ServiceXException):
         await x.dump_query_errors(client, '111-222-333')
 
 

--- a/tests/test_servicex_adaptor.py
+++ b/tests/test_servicex_adaptor.py
@@ -501,3 +501,47 @@ def test_servicex_adaptor_settings_env():
     assert sx._endpoint == 'http://tachi.com:5000'
     assert sx._username == 'Holden'
     assert sx._password == 'protomolecule'
+
+
+@pytest.mark.asyncio
+async def test_fetch_errors_for_bad_req_id(mocker):
+    client = mocker.MagicMock()
+    client.get = mocker.Mock(return_value=ClientSessionMocker("Request not found", 404))
+
+    x = ServiceXAdaptor('http://localhost:5000')
+    with pytest.raises(ServiceXUnknownRequestID):
+        await x.dump_query_errors(client, '111-222-333')
+
+
+@pytest.mark.asyncio
+async def test_fetch_errors_for_bad_bad_bad(mocker):
+    client = mocker.MagicMock()
+    client.get = mocker.Mock(return_value=ClientSessionMocker("Internal Error", 500))
+
+    x = ServiceXAdaptor('http://localhost:5000')
+    with pytest.raises(ServiceXUnknownRequestID):
+        await x.dump_query_errors(client, '111-222-333')
+
+
+@pytest.mark.asyncio
+async def test_fetch_errors_for_req_good(mocker, caplog):
+    client = mocker.MagicMock()
+    rtn = {
+        "errors": [
+            {
+                "pod-name": "transformer-8716d52a-974e-4f1d-beed-3425485d8f9b-f9785979892dp4",
+                "file": "root://xrootd.echo.stfc.ac.uk:1094/atlas:datadisk/rucio/mc16_13TeV/bf/23/DAOD_STDM3.20425969._000001.pool.root.1",  # NOQA
+                "events": 0,
+                "info": "error: Failed to transform input file root://xrootd.echo.stfc.ac.uk:1094/atlas:datadisk/rucio/mc16_13TeV/7e/e5/DAOD_STDM3.20425969._000077.pool.root.1: Output\nAnother line",  # NOQA
+            }
+        ]
+    }
+    client.get = mocker.Mock(return_value=ClientSessionMocker(dumps(rtn), 200))
+
+    x = ServiceXAdaptor('http://localhost:5000')
+    await x.dump_query_errors(client, '111-222-333')
+    client.get.assert_called_with('http://localhost:5000/servicex/transformation/111-222-333/errors', headers={})  # NOQA
+
+    warning_messages = (r for r in caplog.records if r.levelname == "WARNING")
+
+    assert sum((1 for w in warning_messages)) > 0


### PR DESCRIPTION
- Ability to bring back transform errors by querying ServiceX
- Errors are dumpped to the logger, at the `warning` level.
- If any files fail to transform, all transform errors are dumpped locally

Fixes #67
