### PR TITLE
Detect transformation Fatal Status and report to user (#30)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,7 @@
         "servicex",
         "servicexabc",
         "setuptools",
+        "slateci",
         "sslhep",
         "stfc",
         "tcut",

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -3,6 +3,7 @@ from .utils import (  # NOQA
     ServiceXException,
     ServiceXUnknownRequestID,
     ServiceXFailedFileTransform,
+    ServiceXFatalTransformException,
     StatusUpdateCallback,
     StatusUpdateFactory,
     clean_linq,

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -61,6 +61,12 @@ class ServiceXException(Exception):
         super().__init__(self, msg)
 
 
+class ServiceXFatalTransformException(Exception):
+    'Raised when something has gone wrong in the ServiceX remote service'
+    def __init__(self, msg):
+        super().__init__(self, msg)
+
+
 class ServiceXUnknownRequestID(Exception):
     'Raised when we try to access ServiceX with a request ID it does not know about'
     def __init__(self, msg):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,6 +87,7 @@ class MockServiceXAdaptor:
     async def dump_query_errors(self, client, request_id):
         self.dump_query_errors_count += 1
 
+
 class MockMinioAdaptor(MinioAdaptor):
     def __init__(self, mocker: MockFixture, files: List[str] = []):
         self._files = files

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1,19 +1,18 @@
 import asyncio
 from pathlib import Path
-from servicex.minio_adaptor import MinioAdaptorFactory
 from typing import Optional
 
 import pandas as pd
 import pytest
 
 import servicex as fe
-from servicex.utils import ServiceXException, ServiceXUnknownRequestID, log_adaptor
+from servicex.minio_adaptor import MinioAdaptorFactory
+from servicex.utils import (
+    ServiceXException, ServiceXFatalTransformException,
+    ServiceXUnknownRequestID, log_adaptor)
 
-from .conftest import (  # NOQA
-    MockMinioAdaptor,
-    MockServiceXAdaptor,
-    build_cache_mock,
-)
+from .conftest import (MockMinioAdaptor, MockServiceXAdaptor,  # NOQA
+                       build_cache_mock)
 
 
 def clean_fname(fname: str):
@@ -538,7 +537,49 @@ async def test_servicex_transformer_failure_errors_dumped(mocker, short_status_p
         # Will fail with one skipped file.
         await ds.get_data_rootfiles_async('(valid qastle string)')
 
-    mock_servicex_adaptor.dump_query_errors.assert_called_once()
+    assert mock_servicex_adaptor.dump_query_errors_count == 1
+
+
+@pytest.mark.asyncio
+async def test_good_run_root_bad_DID(mocker):
+    'Get a root file with a single file'
+    mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
+
+    fatal_transform_status = {
+        "request_id": "24e59fa2-e1d7-4831-8c7e-82b2efc7c658",
+        "did": "mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_0000",  # NOQA
+        "columns": "Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e(), Muons.pt(), Muons.eta(), Muons.phi(), Muons.e()",  # NOQA
+        "selection": None,
+        "tree-name": None,
+        "image": "sslhep/servicex_func_adl_xaod_transformer:130_reset_cwd",
+        "chunk-size": 7000,
+        "workers": 1,
+        "result-destination": "kafka",
+        "result-format": "arrow",
+        "kafka-broker": "servicex-kafka-1.slateci.net:19092",
+        "workflow-name": "straight_transform",
+        "generated-code-cm": None,
+        "status": "Fatal",
+        "failure-info": "DID Not found mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_0000"  # NOQA
+    }
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456",
+        mock_transform_status=mocker.MagicMock(side_effect=ServiceXFatalTransformException('DID was BAD')),  # NOQA
+        mock_transform_query_status=mocker.MagicMock(return_value=fatal_transform_status))
+
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+
+    ds = fe.ServiceXDataset('localds://mc16_tev:13',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            local_log=mock_logger)
+
+    with pytest.raises(ServiceXFatalTransformException) as e:
+        await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    assert 'DID Not found mc15' in str(e.value)
+
 
 @pytest.mark.asyncio
 async def test_servicex_in_progress_lock_cleared(mocker, short_status_poll_time):


### PR DESCRIPTION
- If status: Fatal comes back from a /status query, throw an exception
- Grab data from the transform get endpoint to get the full error text and include it in the exception for the user.

Fixes #30
