### PR TITLE
Bring ServiceX Frontend inline with ServiceX 1.0 RC2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,9 +5,6 @@
     "python.analysis.logLevel": "Information",
     "python.analysis.memory.keepLibraryAst": true,
     "python.linting.flake8Enabled": true,
-    "python.testing.pytestArgs": [
-        "--no-cov"
-    ],
     "cSpell.words": [
         "AOD's",
         "AZNLOCTEQ",
@@ -30,6 +27,7 @@
         "codecov",
         "dcache",
         "desy",
+        "dont",
         "fget",
         "fname",
         "inmem",
@@ -60,11 +58,15 @@
         "servicexabc",
         "setuptools",
         "sslhep",
+        "stfc",
         "tcut",
         "tqdm",
         "unittests",
         "xaod",
         "xrootd"
     ],
-    "python.analysis.typeCheckingMode": "basic"
+    "python.analysis.typeCheckingMode": "basic",
+    "python.testing.pytestArgs": [
+        "--no-cov"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -57,6 +57,7 @@
         "servicex",
         "servicexabc",
         "setuptools",
+        "slateci",
         "sslhep",
         "stfc",
         "tcut",

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Create a `.servicex` file, in the `yaml` format, in the appropriate place for yo
 ```yaml
 api_endpoint:
   endpoint: <your-endpoint>
-  username: <api-username>
+  email: <api-email>
   password: <api-password>
 
   minio_endpoint: <minio-endpoint>
@@ -49,7 +49,7 @@ api_endpoint:
 ```
 All strings are expanded using python's [os.path.expand](https://docs.python.org/3/library/os.path.html#os.path.expandvars) method - so `$NAME` and `${NAME}` will work to expand existing environment variables.
 
-Finally, you can create the objects `ServiceXAdaptor` and `MinioAdaptor` by hand in your code, passing them as arguments to `ServiceXDataset` and inject custom endpoints and usernames and passwords, avoiding the configuration system. This is probably only useful for advanced users.
+Finally, you can create the objects `ServiceXAdaptor` and `MinioAdaptor` by hand in your code, passing them as arguments to `ServiceXDataset` and inject custom endpoints and credentials, avoiding the configuration system. This is probably only useful for advanced users.
 
 ## Usage
 

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -3,6 +3,7 @@ from .utils import (  # NOQA
     ServiceXException,
     ServiceXUnknownRequestID,
     ServiceXFailedFileTransform,
+    ServiceXFatalTransformException,
     StatusUpdateCallback,
     StatusUpdateFactory,
     clean_linq,

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 
-from .utils import _query_cache_hash, sanitize_filename
+from .utils import ServiceXException, _query_cache_hash, sanitize_filename
 
 
 class Cache:
@@ -81,6 +81,8 @@ class Cache:
 
         '''
         f = self._query_status_cache_file(request_id)
+        if not f.exists():
+            raise ServiceXException(f'Not cache information for query {request_id}')
         with f.open('r') as o:
             return json.load(o)
 

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -38,6 +38,10 @@ class Cache:
         h = _query_cache_hash(json)
         return self._path / 'query_cache' / h
 
+    def _query_status_cache_file(self, request_id: str) -> Path:
+        'Return the query cache file'
+        return self._path / 'query_cache_status' / request_id
+
     def _files_cache_file(self, id: str) -> Path:
         'Return the file that contains the list of files'
         return self._path / 'file_list_cache' / id
@@ -55,6 +59,30 @@ class Cache:
         f.parent.mkdir(parents=True, exist_ok=True)
         with f.open('w') as o:
             o.write(f'{v}\n')
+
+    def set_query_status(self, query_info: Dict[str, str]):
+        '''Cache a query status (json dict)
+
+        Args:
+            query_info (Dict[str, str]): The info we should cache. Must contain `request_id`.
+        '''
+        assert 'request_id' in query_info, \
+            "Internal error - request_id should always be part of info returned"
+        f = self._query_status_cache_file(query_info['request_id'])
+        f.parent.mkdir(parents=True, exist_ok=True)
+        with f.open('w') as o:
+            json.dump(query_info, o)
+
+    def lookup_query_status(self, request_id: str) -> Dict[str, str]:
+        '''Returns the info from the last time the query status was cached.
+
+        Args:
+            request_id (str): Request id we should look up.
+
+        '''
+        f = self._query_status_cache_file(request_id)
+        with f.open('r') as o:
+            return json.load(o)
 
     def remove_query(self, json: Dict[str, str]):
         f = self._query_cache_file(json)

--- a/servicex/config_default.yaml
+++ b/servicex/config_default.yaml
@@ -3,7 +3,7 @@
 
 api_endpoint:
   endpoint: http://localhost:5000
-  # username: xxx
+  # email: xxx
   # password: yyy
 
   minio_endpoint: localhost:9000

--- a/servicex/minio_adaptor.py
+++ b/servicex/minio_adaptor.py
@@ -147,7 +147,7 @@ class MinioAdaptorFactory:
         if self._config_adaptor is not None:
             logging.getLogger(__name__).debug('Using the config-file minio_adaptor')
             return self._config_adaptor
-        raise Exception("Do not know how to create a Minio Login info")
+        raise ServiceXException("Do not know how to create a Minio Login info")
 
     def _from_config(self, c: ConfigView) -> MinioAdaptor:
         '''Extract the Minio config information from the config file(s). This will be used

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -37,7 +37,7 @@ class ServiceXDataset(ServiceXABC):
     '''
     def __init__(self,
                  dataset: str,
-                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:130_reset_cwd',
+                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:29_dont_truncate_error_logs',  # NOQA
                  max_workers: int = 20,
                  servicex_adaptor: ServiceXAdaptor = None,
                  minio_adaptor: Union[MinioAdaptor, MinioAdaptorFactory] = None,
@@ -262,6 +262,7 @@ class ServiceXDataset(ServiceXABC):
 
             except ServiceXFailedFileTransform as e:
                 self._cache.remove_query(query)
+                self._servicex_adaptor.dump_query_errors(client, request_id)
                 raise ServiceXException(f'Failed to transform all files in {request_id}') from e
 
     async def _get_request_id(self, client: aiohttp.ClientSession, query: Dict[str, Any]) -> str:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -254,6 +254,9 @@ class ServiceXDataset(ServiceXABC):
                 async for r in stream_local_files:
                     yield r
 
+                # Cache the final status
+                await self._update_query_status(client, request_id)
+
             except ServiceXUnknownRequestID as e:
                 self._cache.remove_query(query)
                 raise ServiceXException('ServiceX instance does not know about cached query '
@@ -263,16 +266,29 @@ class ServiceXDataset(ServiceXABC):
                 self._cache.remove_query(query)
                 raise ServiceXException(f'Failed to transform all files in {request_id}') from e
 
-    async def _get_request_id(self, client: aiohttp.ClientSession, query: Dict[str, Any]):
+    async def _get_request_id(self, client: aiohttp.ClientSession, query: Dict[str, Any]) -> str:
         '''
         For this query, fetch the request id. If we have it cached, use that. Otherwise, query
         ServiceX for a enw one (and cache it for later use).
         '''
         request_id = self._cache.lookup_query(query)
         if request_id is None:
-            request_id = await self._servicex_adaptor.submit_query(client, query)
+            request_info = await self._servicex_adaptor.submit_query(client, query)
+            request_id = request_info['request_id']
             self._cache.set_query(query, request_id)
+            self._cache.set_query_status(request_info)
         return request_id
+
+    async def _update_query_status(self, client: aiohttp.ClientSession,
+                                   request_id: str):
+        '''Fetch the status from servicex and cache it locally, over
+        writing what was there before.
+
+        Args:
+            request_id (str): Request id of the status to fetch and cache.
+        '''
+        info = await self._servicex_adaptor.get_query_status(client, request_id)
+        self._cache.set_query_status(info)
 
     async def _get_cached_files(self, cached_files: List[Tuple[str, str]],
                                 notifier: _status_update_wrapper):
@@ -340,7 +356,7 @@ class ServiceXDataset(ServiceXABC):
             async for info in stream_downloaded:
                 yield info
 
-        except BaseException:
+        except Exception:
             good = False
             raise
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -1,42 +1,33 @@
 # Main front end interface
 import asyncio
-from datetime import timedelta
 import functools
 import logging
-from pathlib import Path
 import time
-from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
-from typing import AsyncIterator
+from datetime import timedelta
+from pathlib import Path
+from typing import (Any, AsyncIterator, Awaitable, Callable, Dict, List,
+                    Optional, Tuple, Union)
 
 import aiohttp
-from backoff import on_exception
 import backoff
+from backoff import on_exception
 from confuse import ConfigView
 
-from .ConfigSettings import ConfigSettings
 from .cache import Cache
+from .ConfigSettings import ConfigSettings
 from .data_conversions import _convert_root_to_awkward, _convert_root_to_pandas
-from .minio_adaptor import MinioAdaptor, find_new_bucket_files, minio_adaptor_factory
-from .servicex_adaptor import (
-    ServiceXAdaptor,
-    servicex_adaptor_factory,
-    transform_status_stream,
-    trap_servicex_failures,
-)
+from .minio_adaptor import (MinioAdaptor, MinioAdaptorFactory,
+                            find_new_bucket_files)
+from .servicex_adaptor import (ServiceXAdaptor, servicex_adaptor_factory,
+                               transform_status_stream, trap_servicex_failures)
 from .servicex_utils import _wrap_in_memory_sx_cache
 from .servicexabc import ServiceXABC
-from .utils import (
-    ServiceXException,
-    ServiceXFailedFileTransform,
-    ServiceXUnknownRequestID,
-    StatusUpdateFactory,
-    _run_default_wrapper,
-    _status_update_wrapper,
-    default_client_session, get_configured_cache_path,
-    log_adaptor,
-    stream_status_updates,
-    stream_unique_updates_only,
-)
+from .utils import (ServiceXException, ServiceXFailedFileTransform,
+                    ServiceXUnknownRequestID, StatusUpdateFactory,
+                    _run_default_wrapper, _status_update_wrapper,
+                    default_client_session, get_configured_cache_path,
+                    log_adaptor, stream_status_updates,
+                    stream_unique_updates_only)
 
 
 class ServiceXDataset(ServiceXABC):
@@ -46,10 +37,10 @@ class ServiceXDataset(ServiceXABC):
     '''
     def __init__(self,
                  dataset: str,
-                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:v0.4',
+                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:130_reset_cwd',
                  max_workers: int = 20,
                  servicex_adaptor: ServiceXAdaptor = None,
-                 minio_adaptor: MinioAdaptor = None,
+                 minio_adaptor: Union[MinioAdaptor, MinioAdaptorFactory] = None,
                  cache_adaptor: Optional[Cache] = None,
                  status_callback_factory: Optional[StatusUpdateFactory] = _run_default_wrapper,
                  local_log: log_adaptor = None,
@@ -109,9 +100,12 @@ class ServiceXDataset(ServiceXABC):
         self._servicex_adaptor = servicex_adaptor
 
         if not minio_adaptor:
-            self._minio_adaptor = minio_adaptor_factory(config)
+            self._minio_adaptor = MinioAdaptorFactory(config)
         else:
-            self._minio_adaptor = minio_adaptor
+            if isinstance(minio_adaptor, MinioAdaptor):
+                self._minio_adaptor = MinioAdaptorFactory(always_return=minio_adaptor)
+            else:
+                self._minio_adaptor = minio_adaptor
 
         self._log = log_adaptor() if local_log is None else local_log
 
@@ -242,13 +236,17 @@ class ServiceXDataset(ServiceXABC):
             # Get a request id - which might be cached, but if not, submit it.
             request_id = await self._get_request_id(client, query)
 
+            # Get the minio adaptor we are going to use for downloading.
+            minio_adaptor = self._minio_adaptor \
+                .from_best(self._cache.lookup_query_status(request_id))
+
             # Look up the cache, and then fetch an iterator going thorugh the results
             # from either servicex or the cache, depending.
             try:
                 cached_files = self._cache.lookup_files(request_id)
                 stream_local_files = self._get_cached_files(cached_files, notifier) \
                     if cached_files is not None \
-                    else self._get_files_from_servicex(request_id, client, query, notifier)
+                    else self._get_files_from_servicex(request_id, client, minio_adaptor, notifier)
 
                 # Reflect the files back up a level.
                 async for r in stream_local_files:
@@ -276,7 +274,7 @@ class ServiceXDataset(ServiceXABC):
             request_info = await self._servicex_adaptor.submit_query(client, query)
             request_id = request_info['request_id']
             self._cache.set_query(query, request_id)
-            self._cache.set_query_status(request_info)
+            await self._update_query_status(client, request_id)
         return request_id
 
     async def _update_query_status(self, client: aiohttp.ClientSession,
@@ -305,6 +303,7 @@ class ServiceXDataset(ServiceXABC):
 
     async def _download_a_file(self, stream: AsyncIterator[str],
                                request_id: str,
+                               minio_adaptor: MinioAdaptor,
                                notifier: _status_update_wrapper) \
             -> AsyncIterator[Tuple[str, Awaitable[Path]]]:
         '''
@@ -312,9 +311,10 @@ class ServiceXDataset(ServiceXABC):
         The copy can take a while, so send it off to another thread - don't pause queuing up other
         files to download.
         '''
+
         async def do_copy(final_path):
             assert request_id is not None
-            await self._minio_adaptor.download_file(request_id, f, final_path)
+            await minio_adaptor.download_file(request_id, f, final_path)
             notifier.inc(downloaded=1)
             notifier.broadcast()
             return final_path
@@ -330,7 +330,7 @@ class ServiceXDataset(ServiceXABC):
 
     async def _get_files_from_servicex(self, request_id: str,
                                        client: aiohttp.ClientSession,
-                                       query: Dict[str, str],
+                                       minio_adaptor: MinioAdaptor,
                                        notifier: _status_update_wrapper):
         '''
         Fetch query result files from `servicex`. Given the `request_id` we will download
@@ -347,9 +347,10 @@ class ServiceXDataset(ServiceXABC):
             stream_unique = stream_unique_updates_only(stream_watched)
 
             # Next, download the files as they are found (and return them):
-            stream_new_object = find_new_bucket_files(self._minio_adaptor, request_id,
+            stream_new_object = find_new_bucket_files(minio_adaptor, request_id,
                                                       stream_unique)
-            stream_downloaded = self._download_a_file(stream_new_object, request_id, notifier)
+            stream_downloaded = self._download_a_file(stream_new_object, request_id,
+                                                      minio_adaptor, notifier)
 
             # Return the files to anyone that wants them!
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -37,7 +37,7 @@ class ServiceXDataset(ServiceXABC):
     '''
     def __init__(self,
                  dataset: str,
-                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:29_dont_truncate_error_logs',  # NOQA
+                 image: str = 'sslhep/servicex_func_adl_xaod_transformer:v1.0.0-rc.2',  # NOQA
                  max_workers: int = 20,
                  servicex_adaptor: ServiceXAdaptor = None,
                  minio_adaptor: Union[MinioAdaptor, MinioAdaptorFactory] = None,

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -25,21 +25,20 @@ def servicex_adaptor_factory(c: ConfigView):
     endpoint = c['api_endpoint']['endpoint'].as_str_expanded()
 
     # We can default these to "None"
-    username = c['api_endpoint']['username'].as_str_expanded() if 'username' in c['api_endpoint'] \
-        else None
+    email = c['api_endpoint']['email'].as_str_expanded() if 'email' in c['api_endpoint'] else None
     password = c['api_endpoint']['password'].as_str_expanded() if 'password' in c['api_endpoint'] \
         else None
-    return ServiceXAdaptor(endpoint, username, password)
+    return ServiceXAdaptor(endpoint, email, password)
 
 
 # Low level routines for interacting with a ServiceX instance via the WebAPI
 class ServiceXAdaptor:
-    def __init__(self, endpoint, username=None, password=None):
+    def __init__(self, endpoint, email=None, password=None):
         '''
         Authenticated access to ServiceX
         '''
         self._endpoint = endpoint
-        self._username = username
+        self._email = email
         self._password = password
 
         self._token = None
@@ -48,7 +47,7 @@ class ServiceXAdaptor:
     async def _login(self, client: aiohttp.ClientSession):
         url = f'{self._endpoint}/login'
         async with client.post(url, json={
-            'username': self._username,
+            'email': self._email,
             'password': self._password
         }) as response:
             status = response.status
@@ -60,7 +59,7 @@ class ServiceXAdaptor:
                 raise ServiceXException(f'ServiceX login request rejected: {status}')
 
     async def _get_authorization(self, client: aiohttp.ClientSession):
-        if self._username:
+        if self._email:
             now = datetime.utcnow().timestamp()
             if not self._token or jwt.decode(self._token, verify=False)['exp'] - now < 0:
                 await self._login(client)

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -10,6 +10,7 @@ from google.auth import jwt
 from .utils import (
     ServiceXException,
     ServiceXFailedFileTransform,
+    ServiceXFatalTransformException,
     ServiceXUnknownRequestID,
     TransformTuple,
 )
@@ -150,7 +151,7 @@ class ServiceXAdaptor:
                     log.warning(f'  -> {ln}')
 
     @staticmethod
-    def _get_transform_stat(info: Dict[str, str], stat_name: str):
+    def _get_transform_stat(info: Dict[str, str], stat_name: str) -> Optional[int]:
         'Return the info from a servicex status reply, protecting against bad internet returns'
         return None \
             if ((stat_name not in info) or (info[stat_name] is None)) \
@@ -172,7 +173,11 @@ class ServiceXAdaptor:
         Arguments:
 
             endpoint            Web API address where servicex lives
-            request_id         The id of the request to check up on
+            request_id          The id of the request to check up on
+
+        Raises:
+
+            ServiceXException   If the status returns `Fatal`.
 
         Returns:
 
@@ -195,6 +200,11 @@ class ServiceXAdaptor:
                                                f' - http error {status}')
             info = await response.json()
             logging.getLogger(__name__).debug(f'Status response for {request_id}: {info}')
+
+            if 'status' in info and info['status'] == 'Fatal':
+                raise ServiceXFatalTransformException(f'Transform status for {request_id}'
+                                                      ' is marked "Fatal".')
+
             files_remaining = self._get_transform_stat(info, 'files-remaining')
             files_failed = self._get_transform_stat(info, 'files-skipped')
             files_processed = self._get_transform_stat(info, 'files-processed')

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -24,8 +24,10 @@ def servicex_adaptor_factory(c: ConfigView):
     endpoint = c['api_endpoint']['endpoint'].as_str_expanded()
 
     # We can default these to "None"
-    username = c['api_endpoint']['username'].as_str_expanded() if 'username' in c['api_endpoint'] else None
-    password = c['api_endpoint']['password'].as_str_expanded() if 'password' in c['api_endpoint'] else None
+    username = c['api_endpoint']['username'].as_str_expanded() if 'username' in c['api_endpoint'] \
+        else None
+    password = c['api_endpoint']['password'].as_str_expanded() if 'password' in c['api_endpoint'] \
+        else None
     return ServiceXAdaptor(endpoint, username, password)
 
 
@@ -116,6 +118,36 @@ class ServiceXAdaptor:
 
             r = await response.json()
             return r
+
+    async def dump_query_errors(self, client: aiohttp.ClientSession,
+                                request_id: str):
+        '''Dumps to the logging system any error messages we find from ServiceX.
+
+        Args:
+            client (aiohttp.ClientSession): Client along which to send queries.
+            request_id (str): Fetch all errors from there.
+        '''
+
+        headers = await self._get_authorization(client)
+        async with client.get(f'{self._endpoint}/servicex/transformation/{request_id}/errors',
+                              headers=headers) as response:
+            status = response.status
+            if status != 200:
+                t = await response.text()
+                if "Request not found" in t:
+                    raise ServiceXUnknownRequestID(f'Unable to get errors for request {request_id}'
+                                                   f': {status} - {t}')
+                else:
+                    raise ServiceXException(f'Failed to get request errors for {request_id}: '
+                                            f'{status} - {t}')
+
+            # Dump the messages out to the logger if there are any!
+            errors = (await response.json())["errors"]
+            log = logging.getLogger(__name__)
+            for e in errors:
+                log.warning(f'Error transforming file: {e["file"]}')
+                for ln in e["info"].split('\n'):
+                    log.warning(f'  -> {ln}')
 
     @staticmethod
     def _get_transform_stat(info: Dict[str, str], stat_name: str):

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -61,6 +61,12 @@ class ServiceXException(Exception):
         super().__init__(self, msg)
 
 
+class ServiceXFatalTransformException(Exception):
+    'Raised when something has gone wrong in the ServiceX remote service'
+    def __init__(self, msg):
+        super().__init__(self, msg)
+
+
 class ServiceXUnknownRequestID(Exception):
     'Raised when we try to access ServiceX with a request ID it does not know about'
     def __init__(self, msg):

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -343,7 +343,7 @@ def clean_linq(q: str) -> str:
 
             if node_type == 'lambda':
                 if len(fields) != 2:
-                    raise Exception(f'The qastle "{q}" is not valid - found a lambda expression'
+                    raise ServiceXException(f'The qastle "{q}" is not valid - found a lambda expression'
                                     f'with {len(fields)} arguments - not the required 2!')
                 arg_list = [f.info for f in fields[0].info]
                 arg_mapping = {old: new_arg() for old in arg_list}

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -343,8 +343,9 @@ def clean_linq(q: str) -> str:
 
             if node_type == 'lambda':
                 if len(fields) != 2:
-                    raise ServiceXException(f'The qastle "{q}" is not valid - found a lambda expression'
-                                    f'with {len(fields)} arguments - not the required 2!')
+                    raise ServiceXException(
+                        f'The qastle "{q}" is not valid - found a lambda '
+                        f'expression with {len(fields)} arguments - not the required 2!')
                 arg_list = [f.info for f in fields[0].info]
                 arg_mapping = {old: new_arg() for old in arg_list}
                 fields[0] = ParseTracker(

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if sys.version_info[1] < 8:
     extra_test_packages.append('asyncmock')
 
 setup(name="servicex",
-      version='2.0.0-beta.10',
+      version='2.0.0-beta.11',
       packages=['servicex'],
       scripts=[],
       description="Front-end for the ServiceX Data Server",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,7 @@ class ClientSessionMocker:
 
 class MockServiceXAdaptor:
     def __init__(self, mocker: MockFixture, request_id: str, mock_transform_status: Mock = None,
-                 mock_query: Mock = None):
+                 mock_query: Mock = None, mock_transform_query_status: Mock = None):
         self.request_id = request_id
         self._endpoint = "http://localhost:5000"
         self.requests_made = 0
@@ -60,7 +60,11 @@ class MockServiceXAdaptor:
             if mock_transform_status \
             else mocker.Mock(return_value=(0, 1, 0))
 
-        self.dump_query_errors = mocker.MagicMock(return_value=None)
+        self.query_status = mock_transform_query_status \
+            if mock_transform_query_status \
+            else None
+
+        self.dump_query_errors_count = 0
 
     async def submit_query(self, client: aiohttp.ClientSession,
                            json_query: Dict[str, str]) -> str:
@@ -73,10 +77,15 @@ class MockServiceXAdaptor:
         return self.transform_status()
 
     async def get_query_status(self, client, request_id):
-        return {
-            'request_id': request_id,
-            'dude': 'way',
-        }
+        if self.query_status is None:
+            return {
+                'request_id': request_id,
+                'dude': 'way',
+            }
+        return self.query_status()
+
+    async def dump_query_errors(self, client, request_id):
+        self.dump_query_errors_count += 1
 
 
 class MockMinioAdaptor(MinioAdaptor):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,6 +60,8 @@ class MockServiceXAdaptor:
             if mock_transform_status \
             else mocker.Mock(return_value=(0, 1, 0))
 
+        self.dump_query_errors = mocker.MagicMock(return_value=None)
+
     async def submit_query(self, client: aiohttp.ClientSession,
                            json_query: Dict[str, str]) -> str:
         self.query_json = json_query

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from json import loads
 from pathlib import Path
+from servicex.minio_adaptor import MinioAdaptor
 from typing import Any, Dict, List, Optional, Tuple
 from unittest.mock import Mock
 
@@ -76,7 +77,7 @@ class MockServiceXAdaptor:
         }
 
 
-class MockMinioAdaptor:
+class MockMinioAdaptor(MinioAdaptor):
     def __init__(self, mocker: MockFixture, files: List[str] = []):
         self._files = files
         self.mock_download_file = mocker.Mock()
@@ -97,7 +98,8 @@ def build_cache_mock(mocker, query_cache_return: str = None,
                      files: Optional[List[Tuple[str, str]]] = None,
                      in_memory: Any = None,
                      make_in_memory_work: bool = False,
-                     data_file_return: str = None) -> Cache:
+                     data_file_return: str = None,
+                     query_status_lookup_return: Optional[Dict[str, str]] = None) -> Cache:
     c = mocker.MagicMock(spec=Cache)
 
     if in_memory is None:
@@ -135,6 +137,9 @@ def build_cache_mock(mocker, query_cache_return: str = None,
         c.data_file_location.side_effect = data_file_return_generator
     else:
         c.data_file_location.return_value = data_file_return
+
+    if query_status_lookup_return is not None:
+        c.lookup_query_status.return_value = query_status_lookup_return
 
     return c
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,7 +49,7 @@ class MockServiceXAdaptor:
         def do_unique_id():
             id = self.request_id.format(self.requests_made)
             self.requests_made += 1
-            return id
+            return {'request_id': id}
 
         self.query = mock_query \
             if mock_query \
@@ -68,6 +68,12 @@ class MockServiceXAdaptor:
             -> Tuple[Optional[int], int, Optional[int]]:
         # remaining, processed, skipped
         return self.transform_status()
+
+    async def get_query_status(self, client, request_id):
+        return {
+            'request_id': request_id,
+            'dude': 'way',
+        }
 
 
 class MockMinioAdaptor:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+from servicex.utils import ServiceXException
 import pytest
 
 from servicex.cache import Cache
@@ -128,5 +129,5 @@ def test_query_cache_status(tmp_path):
 def test_query_cache_status_bad(tmp_path):
     c = Cache(tmp_path)
 
-    with pytest.raises(Exception):
+    with pytest.raises(ServiceXException):
         c.lookup_query_status('111-222-333')

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -114,3 +114,19 @@ def test_data_file_bad_file(tmp_path):
     assert not p.exists()
     p.touch()
     assert p.exists()
+
+
+def test_query_cache_status(tmp_path):
+    c = Cache(tmp_path)
+
+    info = {'request_id': '111-222-333', 'key': 'bogus'}
+    c.set_query_status(info)
+    info1 = c.lookup_query_status('111-222-333')
+    assert info1['key'] == 'bogus'
+
+
+def test_query_cache_status_bad(tmp_path):
+    c = Cache(tmp_path)
+
+    with pytest.raises(Exception):
+        c.lookup_query_status('111-222-333')

--- a/tests/test_minio_adaptor.py
+++ b/tests/test_minio_adaptor.py
@@ -167,7 +167,7 @@ async def test_find_new_bucket_1_files(mocker):
 
 def test_factory_no_inputs():
     f = MinioAdaptorFactory()
-    with pytest.raises(Exception):
+    with pytest.raises(ServiceXException):
         # Should fail b.c. no way to figure out what to create!
         f.from_best()
 

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1,19 +1,18 @@
 import asyncio
 from pathlib import Path
-from servicex.minio_adaptor import MinioAdaptorFactory
 from typing import Optional
 
 import pandas as pd
 import pytest
 
 import servicex as fe
-from servicex.utils import ServiceXException, ServiceXUnknownRequestID, log_adaptor
+from servicex.minio_adaptor import MinioAdaptorFactory
+from servicex.utils import (
+    ServiceXException, ServiceXFatalTransformException,
+    ServiceXUnknownRequestID, log_adaptor)
 
-from .conftest import (  # NOQA
-    MockMinioAdaptor,
-    MockServiceXAdaptor,
-    build_cache_mock,
-)
+from .conftest import (MockMinioAdaptor, MockServiceXAdaptor,  # NOQA
+                       build_cache_mock)
 
 
 def clean_fname(fname: str):
@@ -538,7 +537,49 @@ async def test_servicex_transformer_failure_errors_dumped(mocker, short_status_p
         # Will fail with one skipped file.
         await ds.get_data_rootfiles_async('(valid qastle string)')
 
-    mock_servicex_adaptor.dump_query_errors.assert_called_once()
+    assert mock_servicex_adaptor.dump_query_errors_count == 1
+
+
+@pytest.mark.asyncio
+async def test_good_run_root_bad_DID(mocker):
+    'Get a root file with a single file'
+    mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
+
+    fatal_transform_status = {
+        "request_id": "24e59fa2-e1d7-4831-8c7e-82b2efc7c658",
+        "did": "mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_0000",  # NOQA
+        "columns": "Electrons.pt(), Electrons.eta(), Electrons.phi(), Electrons.e(), Muons.pt(), Muons.eta(), Muons.phi(), Muons.e()",  # NOQA
+        "selection": None,
+        "tree-name": None,
+        "image": "sslhep/servicex_func_adl_xaod_transformer:130_reset_cwd",
+        "chunk-size": 7000,
+        "workers": 1,
+        "result-destination": "kafka",
+        "result-format": "arrow",
+        "kafka-broker": "servicex-kafka-1.slateci.net:19092",
+        "workflow-name": "straight_transform",
+        "generated-code-cm": None,
+        "status": "Fatal",
+        "failure-info": "DID Not found mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_0000"  # NOQA
+    }
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456",
+        mock_transform_status=mocker.MagicMock(side_effect=ServiceXFatalTransformException('DID was BAD')),  # NOQA
+        mock_transform_query_status=mocker.MagicMock(return_value=fatal_transform_status))
+
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+
+    ds = fe.ServiceXDataset('localds://mc16_tev:13',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            local_log=mock_logger)
+
+    with pytest.raises(ServiceXFatalTransformException) as e:
+        await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    assert 'DID Not found mc15' in str(e.value)
+
 
 @pytest.mark.asyncio
 async def test_servicex_in_progress_lock_cleared(mocker, short_status_poll_time):

--- a/tests/test_servicex_adaptor.py
+++ b/tests/test_servicex_adaptor.py
@@ -191,12 +191,12 @@ async def test_status_with_login(mocker):
                'files-processed': 0})], [200]))
 
     sa = ServiceXAdaptor(endpoint='http://localhost:5000/sx',
-                         username="test",
+                         email="test@example.com",
                          password="foobar")
 
     await sa.get_transform_status(client, '123-123-123-444')
     client.post.assert_called_with("http://localhost:5000/sx/login",
-                                   json={'password': 'foobar', 'username': 'test'})
+                                   json={'password': 'foobar', 'email': 'test@example.com'})
 
     client.get.assert_called_with(
         "http://localhost:5000/sx/servicex/transformation/123-123-123-444/status",
@@ -315,7 +315,7 @@ async def test_submit_good_with_login(mocker):
         dumps({'request_id': "111-222-333-444"})], [200, 200]))
 
     sa = ServiceXAdaptor(endpoint='http://localhost:5000/sx',
-                         username="test",
+                         email="test@example.com",
                          password="foobar")
 
     await sa.submit_query(client, {'hi': 'there'})
@@ -326,7 +326,7 @@ async def test_submit_good_with_login(mocker):
     # Verify the login POST
     _, args, kwargs = r[0]
     assert args[0] == 'http://localhost:5000/sx/login'
-    assert kwargs['json']['username'] == 'test'
+    assert kwargs['json']['email'] == 'test@example.com'
     assert kwargs['json']['password'] == 'foobar'
 
     # Verify the Submit POST
@@ -346,7 +346,7 @@ async def test_submit_good_with_login_existing_token(mocker):
         dumps({'request_id': "222-333-444-555"})], [200, 200, 200]))
 
     sa = ServiceXAdaptor(endpoint='http://localhost:5000/sx',
-                         username="test",
+                         email="test@example.com",
                          password="foobar")
 
     mocker.patch('google.auth.jwt.decode', return_value={'exp': float('inf')})  # Never expires
@@ -363,7 +363,7 @@ async def test_submit_good_with_login_existing_token(mocker):
     # Verify the login POST
     _, args, kwargs = r[0]
     assert args[0] == 'http://localhost:5000/sx/login'
-    assert kwargs['json']['username'] == 'test'
+    assert kwargs['json']['email'] == 'test@example.com'
     assert kwargs['json']['password'] == 'foobar'
 
     # Verify the Submit POST
@@ -391,7 +391,7 @@ async def test_submit_good_with_login_expired_token(mocker):
         dumps({'request_id': "222-333-444-555"})], [200, 200, 200, 200]))
 
     sa = ServiceXAdaptor(endpoint='http://localhost:5000/sx',
-                         username="test",
+                         email="test@example.com",
                          password="foobar")
 
     mocker.patch('google.auth.jwt.decode', return_value={'exp': 0})  # Always expired
@@ -409,7 +409,7 @@ async def test_submit_good_with_login_expired_token(mocker):
     # Verify the login POST
     _, args, kwargs = r[0]
     assert args[0] == 'http://localhost:5000/sx/login'
-    assert kwargs['json']['username'] == 'test'
+    assert kwargs['json']['email'] == 'test@example.com'
     assert kwargs['json']['password'] == 'foobar'
 
     # Verify the Submit POST
@@ -420,7 +420,7 @@ async def test_submit_good_with_login_expired_token(mocker):
     # Verify the second login POST
     _, args, kwargs = r[2]
     assert args[0] == 'http://localhost:5000/sx/login'
-    assert kwargs['json']['username'] == 'test'
+    assert kwargs['json']['email'] == 'test@example.com'
     assert kwargs['json']['password'] == 'foobar'
 
     # Verify the second Submit POST
@@ -456,7 +456,7 @@ async def test_submit_good_with_bad_login(mocker):
         dumps({'message': 'Wrong credentials'}), 401))
 
     sa = ServiceXAdaptor(endpoint='http://localhost:5000/sx',
-                         username="test",
+                         email="test@example.com",
                          password="XXXXX")
 
     with pytest.raises(ServiceXException) as e:
@@ -502,12 +502,12 @@ def test_servicex_adaptor_settings():
     c = Configuration('bogus', 'bogus')
     c.clear()
     c['api_endpoint']['endpoint'] = 'http://my-left-foot.com:5000'
-    c['api_endpoint']['username'] = 'thegoodplace'
+    c['api_endpoint']['email'] = 'thegoodplace@example.com'
     c['api_endpoint']['password'] = 'forkingshirtballs'
 
     sx = servicex_adaptor_factory(c)
     assert sx._endpoint == 'http://my-left-foot.com:5000'
-    assert sx._username == 'thegoodplace'
+    assert sx._email == 'thegoodplace@example.com'
     assert sx._password == 'forkingshirtballs'
 
 
@@ -516,7 +516,7 @@ def test_servicex_adaptor_settings_env():
     c = Configuration('bogus', 'bogus')
     c.clear()
     c['api_endpoint']['endpoint'] = '${ENDPOINT}:5000'
-    c['api_endpoint']['username'] = '${SXUSER}'
+    c['api_endpoint']['email'] = '${SXUSER}'
     c['api_endpoint']['password'] = '${SXPASS}'
 
     from os import environ
@@ -526,7 +526,7 @@ def test_servicex_adaptor_settings_env():
 
     sx = servicex_adaptor_factory(c)
     assert sx._endpoint == 'http://tachi.com:5000'
-    assert sx._username == 'Holden'
+    assert sx._email == 'Holden'
     assert sx._password == 'protomolecule'
 
 


### PR DESCRIPTION
RC2 of ServiceX released a bunch of features. This PR adds features to make them accessible to the user:

- #79 - Fetches the /transformation endpoint data
- #80 - Uses minio auth information from the /transformation endpoint data
- #82 - When a file fails to transform, dump transform logs of failed pods to the logger.warning.
- #30 - If the DID look up fails (or simlar error), report error message to use from /transform status
- ServiceX_App/34 - The ServiceX app now uses email/password to authenticate.

Goal would be to merge this along with other changes into master as version 1.1 once approved.