### PR TITLE
update to change awkward arrays to load lazily

### DIFF
--- a/servicex/data_conversions.py
+++ b/servicex/data_conversions.py
@@ -66,7 +66,7 @@ async def _convert_root_to_awkward(file: Path):
         f_in = uproot.open(file)
         try:
             r = f_in[f_in.keys()[0]]
-            return r.arrays()  # type: ignore
+            return r.lazyarrays()  # type: ignore
         finally:
             f_in._context.source.close()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,7 +176,7 @@ def good_awkward_file_data(mocker):
     import awkward as awk
 
     async def good_awkward_data(fname: str):
-        df = {b'JetPt': awk.fromiter([0, 1, 2, 3, 4, 5])}
+        df = {'JetPt': awk.fromiter([0, 1, 2, 3, 4, 5])}
         return df
 
     mocker.patch('servicex.servicex._convert_root_to_awkward', side_effect=good_awkward_data)

--- a/tests/test_data_conversions.py
+++ b/tests/test_data_conversions.py
@@ -13,7 +13,4 @@ async def test_root_to_pandas(good_root_file_path):
 @pytest.mark.asyncio
 async def test_root_to_awkward(good_root_file_path):
     df = await _convert_root_to_awkward(good_root_file_path)
-    assert isinstance(df, dict)
-    assert len(df) == 1
-    assert b'JetPt' in df
-    assert len(df[b'JetPt']) == 283458
+    assert len(df['JetPt']) == 283458

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -232,8 +232,8 @@ async def test_good_run_single_ds_1file_awkward(mocker, good_awkward_file_data):
     r = await ds.get_data_awkward_async('(valid qastle string)')
     assert isinstance(r, dict)
     assert len(r) == 1
-    assert b'JetPt' in r
-    assert len(r[b'JetPt']) == 6
+    assert 'JetPt' in r
+    assert len(r['JetPt']) == 6
 
 
 @pytest.mark.asyncio
@@ -270,8 +270,8 @@ async def test_good_run_single_ds_2file_awkward(mocker, good_awkward_file_data):
     r = await ds.get_data_awkward_async('(valid qastle string)')
     assert isinstance(r, dict)
     assert len(r) == 1
-    assert b'JetPt' in r
-    assert len(r[b'JetPt']) == 6 * 2
+    assert 'JetPt' in r
+    assert len(r['JetPt']) == 6 * 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
These changes will update the awkward data converter. It will now convert data to `LazyArray` objects. This change also updates the data_conversion tests to reflect that a `LazyArray` is a different type of object from the previous `Array` dictionaries.