### PR TITLE
Truncate filenames to avoid ones that are too long

### DIFF
--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -1,6 +1,4 @@
 import json
-from os import path
-
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 from contextlib import contextmanager
@@ -184,10 +182,7 @@ class Cache:
         OSError: [Errno 63] File name too long error Assume that the most unique part of
         the name is the right hand side
         '''
-        parent = Path(path.join(self._path, 'data', request_id))
+        parent = self._path / 'data' / request_id
         parent.mkdir(parents=True, exist_ok=True)
         sanitized = sanitize_filename(data_name)
-        return Path(path.join(
-            parent,
-            sanitized[-1 * (MAX_PATH_LEN - len(parent.name)):]
-        ))
+        return parent / sanitized[-1 * (MAX_PATH_LEN - len(parent.name)):]

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -1,4 +1,6 @@
 import json
+from os import path
+
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Any
 from contextlib import contextmanager
@@ -6,6 +8,9 @@ from contextlib import contextmanager
 from .utils import ServiceXException, _query_cache_hash, sanitize_filename
 
 _ignore_cache = False
+
+# Make sure that generated download path names are below this to avoid os errors
+MAX_PATH_LEN = 235
 
 
 @contextmanager
@@ -175,6 +180,14 @@ class Cache:
         '''
         Return the path to the file that should be written out for this
         data_name. This is where the output file should get stored.
+        Truncate the leftmost characters from filenames to avoid throwing a
+        OSError: [Errno 63] File name too long error Assume that the most unique part of
+        the name is the right hand side
         '''
-        (self._path / 'data' / request_id).mkdir(parents=True, exist_ok=True)
-        return self._path / 'data' / request_id / sanitize_filename(data_name)
+        parent = Path(path.join(self._path, 'data', request_id))
+        parent.mkdir(parents=True, exist_ok=True)
+        sanitized = sanitize_filename(data_name)
+        return Path(path.join(
+            parent,
+            sanitized[-1 * (MAX_PATH_LEN - len(parent.name)):]
+        ))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,5 @@
+import string
+import random
 from servicex.utils import ServiceXException
 import pytest
 
@@ -146,6 +148,18 @@ def test_data_file_location(tmp_path):
     p.touch()
     assert p.exists()
     assert str(p).startswith(str(tmp_path))
+
+
+def test_data_file_location_long_path(tmp_path):
+    c = Cache(tmp_path)
+    letters = string.ascii_lowercase
+    file_significant_name = 'junk.root'
+    long_file_name = ''.join(random.choice(letters) for i in range(230))
+
+    p = c.data_file_location('123-456', long_file_name+file_significant_name)
+
+    assert(len(p.name) == 235 - len(p.parent.name))
+    assert p.name.endswith(file_significant_name)
 
 
 def test_data_file_location_twice(tmp_path):


### PR DESCRIPTION
# Problem
CMS NanoAOD files can wind up with really long names. This causes errors when they are downloaded from Minio.

This is solution to #128 

# Approach
* Establish a `MAX_PATH_LEN`
* In the Minio adaptor truncate the filename from the left to keep (when combined with the parent path) within the limit.

This assumes that for a dataset, the rightmost characters are most unique.
