### PR TITLE
Look at parent directories for configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ do_query(ds)  # Cache is not ignored
 As mentioned above, the `.servicex` file is read to pull a configuration. The search path for this file:
 
 1. Your current working directory
-2. Your home directory
+2. Any working directory above your current working directory.
+3. Your home directory
 
 The file can be named any of the following (ordered by precedence):
 

--- a/servicex/ConfigSettings.py
+++ b/servicex/ConfigSettings.py
@@ -21,14 +21,30 @@ class ConfigSettings(Configuration):
         '''
         Look for a '.xxx" file in the local directory
         '''
-        self._add_from_path(Path(f'{self.appname}.yaml'))
-        self._add_from_path(Path(f'{self.appname}.yml'))
-        self._add_from_path(Path(f'.{self.appname}'))
+        self._add_from_path(Path(f'{self.appname}.yaml'), walk_up_tree=True)
+        self._add_from_path(Path(f'{self.appname}.yml'), walk_up_tree=True)
+        self._add_from_path(Path(f'.{self.appname}'), walk_up_tree=True)
 
-    def _add_from_path(self, p: Path):
-        if p.exists():
-            yaml_data = yaml_util.load_yaml(p, loader=self.loader) or {}
-            self.add(ConfigSource(yaml_data, str(p.resolve())))
+    # def _add_from_path(self, p: Path):
+    #     if p.exists():
+    #         yaml_data = yaml_util.load_yaml(p, loader=self.loader) or {}
+    #         self.add(ConfigSource(yaml_data, str(p.resolve())))
+
+    def _add_from_path(self, p: Path, walk_up_tree: bool = False):
+        p.resolve()
+        name = p.name
+        dir = p.parent.resolve()
+        while True:
+            f = dir / name
+            if f.exists():
+                yaml_data = yaml_util.load_yaml(f, loader=self.loader) or {}
+                self.add(ConfigSource(yaml_data, str(f)))
+                break
+            if not walk_up_tree:
+                break
+            if dir == dir.parent:
+                break
+            dir = dir.parent
 
     def _add_home_source(self):
         '''

--- a/tests/test_ConfigSettings.py
+++ b/tests/test_ConfigSettings.py
@@ -48,3 +48,59 @@ def test_home_file_default(confuse_config):
 
     finally:
         config_file.unlink()
+
+
+def test_local_more_important_than_home(confuse_config):
+    'Make sure that we pick the local directory over the home one'
+    local_config_file = Path('.servicex_test_settings')
+    home_config_file = Path.home() / '.servicex_test_settings'
+    try:
+        with home_config_file.open('w') as f:
+            f.write('testing_value: 30\n')
+        with local_config_file.open('w') as f:
+            f.write('testing_value: 20\n')
+
+        confuse_config.clear()
+        confuse_config.read()
+
+        assert get_it(confuse_config) == 20
+
+    finally:
+        local_config_file.unlink()
+        home_config_file.unlink()
+
+
+def test_one_level_up(confuse_config):
+    'Make sure the config file that is one file up is found'
+    config_file = Path('.').resolve().parent / ('.servicex_test_settings')
+    try:
+        with config_file.open('w') as f:
+            f.write('testing_value: 30\n')
+
+        confuse_config.clear()
+        confuse_config.read()
+
+        assert get_it(confuse_config) == 30
+
+    finally:
+        config_file.unlink()
+
+
+def test_local_more_importnat_than_one_level_up(confuse_config):
+    'Assure that our local file is found first'
+    one_up_config_file = Path('.').resolve().parent / ('.servicex_test_settings')
+    config_file = Path('.').resolve() / ('.servicex_test_settings')
+    try:
+        with config_file.open('w') as f:
+            f.write('testing_value: 30\n')
+        with one_up_config_file.open('w') as f:
+            f.write('testing_value: 20\n')
+
+        confuse_config.clear()
+        confuse_config.read()
+
+        assert get_it(confuse_config) == 30
+
+    finally:
+        config_file.unlink()
+        one_up_config_file.unlink()


### PR DESCRIPTION
The locations that a .servicex or servicex.yaml file can be found are now:

- Your current working directory
- Any directory above your current working directory**
- Your home directory

** Added by this MR.

This MR also adds a test to make sure that a config file in yoru current working directory takes precedence over something found in your home directory.

Fixes #65
Fixes #63
