### PR TITLE
Default data cache location is per-user

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ For documentation of `get_data` and `get_data_async` see the `servicex.py` sourc
 
 ### The Local Cache
 
-To speed things up - especially when you run the same query multiple times, the `servicex` package will cache queries data that comes back from Servicex. You can control where this is stored with the `cache_path` in the `.servicex` file (see below).
+To speed things up - especially when you run the same query multiple times, the `servicex` package will cache queries data that comes back from Servicex. You can control where this is stored with the `cache_path` in the configuration file (see below).
 
 There are times when you want the system to ignore the cache when it is running. You can do this by using `ignore_cache()`:
 
@@ -138,6 +138,7 @@ As mentioned above, the `.servicex` file is read to pull a configuration. The se
 1. Your current working directory
 2. Any working directory above your current working directory.
 3. Your home directory
+4. Any other directory searched by the python [`confuse`](https://confuse.readthedocs.io/en/latest/usage.html#search-paths) library. This includes a machine's `/etc` directory on Linux.
 
 The file can be named any of the following (ordered by precedence):
 
@@ -147,7 +148,7 @@ The file can be named any of the following (ordered by precedence):
 
 The file can contain an `api_endpoint` as mentioned above. In addition the other following things can be put in:
 
-- `cache_path`: Location where queries, data, and a record of queries are written. This should be an absolute path the person running the library has r/w access to. On windows, make sure to escape `\` - and best to follow standard `yaml` conventions and put the path in quotes - especially if it contains a space. Top level yaml item (don't indent it accidentally!). Defaults to `/tmp/servicex` (with the temp directory as appropriate for your platform) Examples:
+- `cache_path`: Location where queries, data, and a record of queries are written. This should be an absolute path the person running the library has r/w access to. On windows, make sure to escape `\` - and best to follow standard `yaml` conventions and put the path in quotes - especially if it contains a space. Top level yaml item (don't indent it accidentally!). Defaults to `/tmp/servicex_<username>` (with the temp directory as appropriate for your platform) Examples:
   - Windows: `cache_path: "C:\\Users\\gordo\\Desktop\\cacheme"`
   - Linux: `cache_path: "/home/servicex-cache"`
 

--- a/servicex/config_default.yaml
+++ b/servicex/config_default.yaml
@@ -5,8 +5,9 @@ api_endpoints:
   - endpoint: http://localhost:5000
     # token: xxx
 
-# This is the path of the cache. The "/tmp" will be translated, platform appropriate.
-cache_path: /tmp/servicex
+# This is the path of the cache. The "/tmp" will be translated, platform appropriate, and
+# the env variable USER will be replaced.
+cache_path: /tmp/servicex_${USER}
 
 # This is a dummy value, here only to make sure that unit testing
 # works properly before package release.

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from hashlib import blake2b
+import os
 from pathlib import Path, PurePath
 import re
 import tempfile
@@ -386,6 +387,13 @@ def get_configured_cache_path(config: ConfigView) -> Path:
     assert config["cache_path"].exists(), 'Cannot find default config - install is broken'
     s_path = config["cache_path"].as_str_expanded()
     assert isinstance(s_path, str)
+
+    # If they have tried to use the USER or UserName as an expansion, and it has failed, then
+    # translate it to maintain harmony across platforms.
+    if '${USER}' in s_path and 'UserName' in os.environ:
+        s_path = s_path.replace('${USER}', os.environ['UserName'])
+    if '${UserName}' in s_path and 'USER' in os.environ:
+        s_path = s_path.replace('${UserName}', os.environ['USER'])
 
     p_p = PurePath(s_path)
     if len(p_p.parts) > 1 and p_p.parts[1] == 'tmp':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,6 +3,7 @@ import tempfile
 from typing import Optional
 import aiohttp
 from pathlib import Path
+import os
 
 import pytest
 
@@ -498,3 +499,39 @@ def test_configured_cache_location():
     # Should default to temp directory - should work on all platforms!
     assert p.exists()
     assert str(p) == str(here)
+
+
+def test_cache_expansion_user():
+    '''On windows this will expand one way, and on linux another. So need to be a little careful here!
+    '''
+    from confuse import Configuration
+    c = Configuration('bogus', 'bogus')
+    c.clear()
+    c['cache_path'] = '/tmp/servicex_${USER}'
+
+    # Get the right answer, depending on the definition of USER
+    u_name = os.environ['USER'] if 'USER' in os.environ else os.environ['UserName']
+    path_name = f'servicex_{u_name}'
+
+    p = get_configured_cache_path(c)
+
+    # Should default to temp directory - should work on all platforms!
+    assert p.name == path_name
+
+
+def test_cache_expansion_username():
+    '''On windows this will expand one way, and on linux another. So need to be a little careful here!
+    '''
+    from confuse import Configuration
+    c = Configuration('bogus', 'bogus')
+    c.clear()
+    c['cache_path'] = '/tmp/servicex_${UserName}'
+
+    # Get the right answer, depending on the definition of USER
+    u_name = os.environ['USER'] if 'USER' in os.environ else os.environ['UserName']
+    path_name = f'servicex_{u_name}'
+
+    p = get_configured_cache_path(c)
+
+    # Should default to temp directory - should work on all platforms!
+    assert p.name == path_name


### PR DESCRIPTION
- The default cache location on linux is now `/tmp/servicex_<user>`, and on windows similar, but in the `TEMP` directory (which is already per-user).
- Also updated the docs to note that on linux the `/etc/servicex` directory is searched for a file since the `confuse` python config library is getting used.

Fixes #147
