### PR TITLE
Add URL property to StreamInfoPath

### DIFF
--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -100,6 +100,15 @@ class StreamInfoPath(StreamInfoBase):
         '''
         return self._path
 
+    @property
+    def url(self) -> str:
+        '''URI to the locally downloaded file.
+
+        Returns:
+            str: The URI of the transformed data for this file.
+        '''
+        return self._path.as_uri()
+
 
 class StreamInfoData(StreamInfoBase):
     '''Contains information about results that are streamed back from ServiceX.

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -587,6 +587,7 @@ async def test_stream_parquet_files(mocker):
     assert lst[0].file == 'one_minio_entry'
     assert 'foo' in lst[0].path.parts
     assert 'bar.root' in lst[0].path.parts
+    assert "file://" in lst[0].url
 
     assert mock_servicex_adaptor.query_json['result-format'] == 'parquet'
 

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import contextmanager
+import os
 from pathlib import Path
 
 import asyncmock
@@ -569,7 +570,8 @@ async def test_stream_parquet_files_from_minio(mocker):
 @pytest.mark.asyncio
 async def test_stream_parquet_files(mocker):
     'Get a parquet file pulling back minio info as it arrives'
-    mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
+    file_path = '/foo/bar.root' if os.name != 'nt' else r'c:\foo\bar.root'
+    mock_cache = build_cache_mock(mocker, data_file_return=file_path)
     mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
     mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
     mock_logger = mocker.MagicMock(spec=log_adaptor)


### PR DESCRIPTION
# Problem 
If we switch from `stream_result_file_urls` to `stream_result_files` in the Local executor, we want the interface to the returned objects to be the same

Fixes #161 

# Approach
Added URL property to StreamInfoPath that returns a `file://` URI to the downloaded file