### PR TITLE
Support passing an optional request title

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.analysis.logLevel": "Information",
     "python.analysis.memory.keepLibraryAst": true,
     "python.linting.flake8Enabled": true,

--- a/README.md
+++ b/README.md
@@ -241,15 +241,15 @@ Everything is based around the `ServiceXDataset` object. Below is the documentat
 To get the data use one of the `get_data` method. They all have the same API, differing only by what they return.
 
 ```python
- |  get_data_awkward_async(self, selection_query: str) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
+ |  get_data_awkward_async(self, selection_query: str, title: Optional[str] = None) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
  |      Fetch query data from ServiceX matching `selection_query` and return it as
  |      dictionary of awkward arrays, an entry for each column. The data is uniquely
- |      ordered (the same query will always return the same order).
+ |      ordered (the same query will always return the same order). If specified, the optional title is passed to the backend and can be viewed on the status page.
  |
- |  get_data_awkward(self, selection_query: str) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
+ |  get_data_awkward(self, selection_query: str, title: Optional[str] = None) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
  |      Fetch query data from ServiceX matching `selection_query` and return it as
  |      dictionary of awkward arrays, an entry for each column. The data is uniquely
- |      ordered (the same query will always return the same order).
+ |      ordered (the same query will always return the same order).  If specified, the optional title is passed to the backend and can be viewed on the status page.
 ```
 
 Each data type comes in a pair - an `async` version and a synchronous version.

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -246,10 +246,12 @@ class ServiceXDataset(ServiceXABC):
 
     @functools.wraps(ServiceXABC.get_data_rootfiles_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_rootfiles_async(self, selection_query: str) -> List[Path]:
-        return await self._file_return(selection_query, 'root-file')
+    async def get_data_rootfiles_async(self, selection_query: str,
+                                       title: Optional[str] = None) -> List[Path]:
+        return await self._file_return(selection_query, 'root-file', title)
 
-    async def get_data_rootfiles_stream(self, selection_query: str) \
+    async def get_data_rootfiles_stream(self, selection_query: str,
+                                        title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoPath]:
         '''Returns, as an async iterator, each completed batch of work from Servicex.
         The `StreamInfoPath` contains a path where downstream consumers can directly
@@ -265,15 +267,17 @@ class ServiceXDataset(ServiceXABC):
                                            file locally.
         '''
         async for f_info in \
-                self._stream_local_files(selection_query, 'root-files'):  # type: ignore
+                self._stream_local_files(selection_query, title, 'root-files'):  # type: ignore
             yield f_info
 
     @functools.wraps(ServiceXABC.get_data_parquet_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_parquet_async(self, selection_query: str) -> List[Path]:
-        return await self._file_return(selection_query, 'parquet')
+    async def get_data_parquet_async(self, selection_query: str,
+                                     title: Optional[str] = None) -> List[Path]:
+        return await self._file_return(selection_query, 'parquet', title)
 
-    async def get_data_parquet_stream(self, selection_query: str) \
+    async def get_data_parquet_stream(self, selection_query: str,
+                                      title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoPath]:
         '''Returns, as an async iterator, each completed batch of work from Servicex.
         The `StreamInfoPath` contains a path where downstream consumers can directly
@@ -288,22 +292,28 @@ class ServiceXDataset(ServiceXABC):
                                            a `StreamInfoPath` which can be used to access the
                                            file locally.
         '''
-        async for f_info in self._stream_local_files(selection_query, 'parquet'):  # type: ignore
+        async for f_info in self._stream_local_files(selection_query, title,
+                                                     'parquet'):  # type: ignore
             yield f_info
 
     @functools.wraps(ServiceXABC.get_data_pandas_df_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_pandas_df_async(self, selection_query: str):
+    async def get_data_pandas_df_async(self, selection_query: str,
+                                       title: Optional[str] = None):
         return self._converter.combine_pandas(await self._data_return(
-            selection_query, lambda f: self._converter.convert_to_pandas(f)))
+            selection_query, lambda f: self._converter.convert_to_pandas(f),
+            title))
 
     @functools.wraps(ServiceXABC.get_data_awkward_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_awkward_async(self, selection_query: str):
+    async def get_data_awkward_async(self, selection_query: str,
+                                     title: Optional[str] = None):
         return self._converter.combine_awkward(await self._data_return(
-            selection_query, lambda f: self._converter.convert_to_awkward(f)))
+            selection_query, lambda f: self._converter.convert_to_awkward(f),
+            title))
 
-    async def get_data_awkward_stream(self, selection_query: str) \
+    async def get_data_awkward_stream(self, selection_query: str,
+                                      title: Optional[str] = None) \
             -> AsyncGenerator[StreamInfoData, None]:
         '''Returns, as an async iterator, each completed batch of work from Servicex
         as a separate `awkward` array. The data is returned in a `StreamInfoData` object.
@@ -317,11 +327,12 @@ class ServiceXDataset(ServiceXABC):
                                            a `StreamInfoData` which can be used to access the
                                            data that has been loaded from the file.
         '''
-        async for a in self._stream_return(selection_query,
+        async for a in self._stream_return(selection_query, title,
                                            lambda f: self._converter.convert_to_awkward(f)):
             yield a
 
-    async def get_data_pandas_stream(self, selection_query: str) \
+    async def get_data_pandas_stream(self, selection_query: str,
+                                     title: Optional[str] = None) \
             -> AsyncGenerator[StreamInfoData, None]:
         '''Returns, as an async iterator, each completed batch of work from Servicex
         as a separate `pandas.DataFrame` array. The data is returned in a `StreamInfoData` object.
@@ -335,11 +346,12 @@ class ServiceXDataset(ServiceXABC):
                                            a `StreamInfoData` which can be used to access the
                                            data that has been loaded from the file.
         '''
-        async for a in self._stream_return(selection_query,
+        async for a in self._stream_return(selection_query, title,
                                            lambda f: self._converter.convert_to_pandas(f)):
             yield a
 
-    async def get_data_rootfiles_url_stream(self, selection_query: str) \
+    async def get_data_rootfiles_url_stream(self, selection_query: str,
+                                            title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoUrl]:
         '''Returns, as an async iterator, each completed batch of work from ServiceX.
         The data that comes back includes a `url` that can be accessed to download the
@@ -349,10 +361,11 @@ class ServiceXDataset(ServiceXABC):
             selection_query (str): The ServiceX Selection
         '''
         async for f_info in \
-                self._stream_url_buckets(selection_query, 'root-files'):  # type: ignore
+                self._stream_url_buckets(selection_query, 'root-files', title):  # type: ignore
             yield f_info
 
-    async def get_data_parquet_url_stream(self, selection_query: str) \
+    async def get_data_parquet_url_stream(self, selection_query: str,
+                                          title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoUrl]:
         '''Returns, as an async iterator, each of the files from the minio bucket,
         as the files are added there.
@@ -360,10 +373,11 @@ class ServiceXDataset(ServiceXABC):
         Args:
             selection_query (str): The ServiceX Selection
         '''
-        async for f_info in self._stream_url_buckets(selection_query, 'parquet'):  # type: ignore
+        async for f_info in self._stream_url_buckets(selection_query, 'parquet',
+                                                     title):  # type: ignore
             yield f_info
 
-    async def _file_return(self, selection_query: str, data_format: str):
+    async def _file_return(self, selection_query: str, data_format: str, title: Optional[str]):
         '''
         Given a query, return the list of files, in a unique order, that hold
         the data for the query.
@@ -376,6 +390,7 @@ class ServiceXDataset(ServiceXABC):
 
             selection_query     `qastle` data that makes up the selection request.
             data_format         The file-based data format (root or parquet)
+            title               The title assigned to this transform request.
 
         Returns:
 
@@ -385,17 +400,19 @@ class ServiceXDataset(ServiceXABC):
         async def convert_to_file(f: Path) -> Path:
             return f
 
-        return await self._data_return(selection_query, convert_to_file, data_format)
+        return await self._data_return(selection_query, convert_to_file, title, data_format)
 
     @on_exception(backoff.constant, ServiceXUnknownRequestID, interval=0.1, max_tries=3)
     @on_exception(backoff.constant, ServiceXUnknownDataRequestID, interval=0.1, max_tries=2)
-    async def _stream_url_buckets(self, selection_query: str, data_format: str) \
+    async def _stream_url_buckets(self, selection_query: str, data_format: str,
+                                  title: Optional[str]) \
             -> AsyncGenerator[StreamInfoUrl, None]:
         '''Get a list of files back for a request
 
         Args:
             selection_query (str): The selection query we are to do
             data_format (str): The requested file format
+            title (Optional[str]): The title of transform to pass to ServiceX
 
         Yields:
             AsyncIterator[Dict[str, str]]: A tuple of the minio bucket and file in that bucket.
@@ -403,7 +420,7 @@ class ServiceXDataset(ServiceXABC):
                                              bucket: The minio bucket name
                                              file: the completed file in the bucket
         '''
-        query = self._build_json_query(selection_query, data_format)
+        query = self._build_json_query(selection_query, data_format, title)
 
         async with aiohttp.ClientSession() as client:
 
@@ -448,6 +465,7 @@ class ServiceXDataset(ServiceXABC):
 
     async def _data_return(self, selection_query: str,
                            converter: Callable[[Path], Awaitable[Any]],
+                           title: Optional[str],
                            data_format: str = 'root-file') -> List[Any]:
         '''Given a query, return the data, in a unique order, that hold
         the data for the query.
@@ -461,6 +479,8 @@ class ServiceXDataset(ServiceXABC):
             selection_query     `qastle` data that makes up the selection request.
             converter           A `Callable` that will convert the data returned from
                                 `ServiceX` as a set of files.
+            title               Title to send to the backend service
+            data_format         The data format that we want to render in
 
         Returns:
 
@@ -469,7 +489,7 @@ class ServiceXDataset(ServiceXABC):
         '''
         all_data = {
             f.file: f.data
-            async for f in self._stream_return(selection_query, converter, data_format)
+            async for f in self._stream_return(selection_query, title, converter, data_format)
         }
 
         # Convert them to the proper format
@@ -481,6 +501,7 @@ class ServiceXDataset(ServiceXABC):
         return ordered_data
 
     async def _stream_return(self, selection_query: str,
+                             title: Optional[str],
                              converter: Callable[[Path], Awaitable[Any]],
                              data_format: str = 'root-file') -> AsyncIterator[StreamInfoData]:
         '''Given a query, return the data, in the order it arrives back
@@ -503,13 +524,14 @@ class ServiceXDataset(ServiceXABC):
         '''
         as_data = (StreamInfoData(f.file, await asyncio.ensure_future(converter(f.path)))
                    async for f in
-                   self._stream_local_files(selection_query, data_format))  # type: ignore
+                   self._stream_local_files(selection_query, title, data_format))  # type: ignore
 
         async for r in as_data:
             yield r
 
     @on_exception(backoff.constant, ServiceXUnknownRequestID, interval=0.1, max_tries=3)
     async def _stream_local_files(self, selection_query: str,
+                                  title: Optional[str],
                                   data_format: str = 'root-file') \
             -> AsyncGenerator[StreamInfoPath, None]:
         '''
@@ -536,14 +558,15 @@ class ServiceXDataset(ServiceXABC):
         # Get all the files
         as_files = \
             (f async for f in
-             self._get_files(selection_query, data_format, notifier))  # type: ignore
+             self._get_files(selection_query, data_format, notifier, title))  # type: ignore
 
         async for name, a_path in as_files:
             yield StreamInfoPath(name, Path(await a_path))
 
     @on_exception(backoff.constant, ServiceXUnknownDataRequestID, interval=0.1, max_tries=2)
     async def _get_files(self, selection_query: str, data_type: str,
-                         notifier: _status_update_wrapper) \
+                         notifier: _status_update_wrapper,
+                         title: Optional[str]) \
             -> AsyncIterator[Tuple[str, Awaitable[Path]]]:
         '''
         Return a list of files from servicex as they have been downloaded to this machine. The
@@ -562,6 +585,7 @@ class ServiceXDataset(ServiceXABC):
             selection_query             The query string to send to ServiceX
             data_type                   The type of data that we want to come back.
             notifier                    Status callback to let our progress be advertised
+            title                       Title to pass to servicex backend.
 
         Returns
             Awaitable[Path]             An awaitable that is a path. When it completes, the
@@ -569,7 +593,7 @@ class ServiceXDataset(ServiceXABC):
                                         This is returned this way so a number of downloads can run
                                         simultaneously.
         '''
-        query = self._build_json_query(selection_query, data_type)
+        query = self._build_json_query(selection_query, data_type, title)
 
         async with aiohttp.ClientSession() as client:
 
@@ -757,7 +781,8 @@ class ServiceXDataset(ServiceXABC):
             logging.getLogger(__name__).info(f'Running servicex query for '
                                              f'{request_id} took {run_time} (no files downloaded)')
 
-    def _build_json_query(self, selection_query: str, data_type: str) -> Dict[str, str]:
+    def _build_json_query(self, selection_query: str, data_type: str, title: Optional[str]) \
+            -> Dict[str, str]:
         '''
         Returns a list of locally written files for a given selection query.
 
@@ -781,6 +806,9 @@ class ServiceXDataset(ServiceXABC):
         # Optional items
         if self._image is not None:
             json_query['image'] = self._image
+
+        if title is not None:
+            json_query['title'] = title
 
         logging.getLogger(__name__).debug(f'JSON to be sent to servicex: {str(json_query)}')
 

--- a/servicex/servicexabc.py
+++ b/servicex/servicexabc.py
@@ -72,7 +72,8 @@ class ServiceXABC(ABC):
         return _status_update_wrapper(self._status_callback_factory(self._dataset, downloading))
 
     @abstractmethod
-    async def get_data_rootfiles_async(self, selection_query: str) -> List[Path]:
+    async def get_data_rootfiles_async(self, selection_query: str,
+                                       title: Optional[str] = None) -> List[Path]:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
         a list of root files. The files are uniquely ordered (the same query will always
@@ -80,13 +81,15 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             root_files          The list of root files
         '''
 
     @abstractmethod
-    async def get_data_pandas_df_async(self, selection_query: str) -> pd.DataFrame:
+    async def get_data_pandas_df_async(self, selection_query: str,
+                                       title: Optional[str] = None) -> pd.DataFrame:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
         a pandas dataframe. The data is uniquely ordered (the same query will always
@@ -94,6 +97,7 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             df                  The pandas dataframe
@@ -104,7 +108,8 @@ class ServiceXABC(ABC):
         '''
 
     @abstractmethod
-    async def get_data_awkward_async(self, selection_query: str) \
+    async def get_data_awkward_async(self, selection_query: str,
+                                     title: Optional[str] = None) \
             -> Dict[bytes, ak.Array]:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
@@ -113,6 +118,7 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             a                   Dictionary of jagged arrays (as needed), one for each
@@ -121,7 +127,8 @@ class ServiceXABC(ABC):
         '''
 
     @abstractmethod
-    async def get_data_parquet_async(self, selection_query: str) -> List[Path]:
+    async def get_data_parquet_async(self, selection_query: str,
+                                     title: Optional[str] = None) -> List[Path]:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
         a list of parquet files. The files are uniquely ordered (the same query will always
@@ -129,6 +136,7 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             root_files          The list of parquet files

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -725,6 +725,48 @@ async def test_max_workers_spec(mocker, good_awkward_file_data):
 
 
 @pytest.mark.asyncio
+async def test_title_spec(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset('localds://mc16_tev:13',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)', title='fork_spoon')
+
+    called = mock_servicex_adaptor.query_json
+    assert called['title'] == 'fork_spoon'
+
+
+@pytest.mark.asyncio
+async def test_notitle_spec(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset('localds://mc16_tev:13',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    called = mock_servicex_adaptor.query_json
+    assert 'title' not in called
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("n_ds, n_query", [(1, 4), (4, 1), (1, 100), (100, 1), (4, 4), (20, 20)])
 async def test_nqueries_on_n_ds(n_ds: int, n_query: int, mocker):
     'Run some number of queries on some number of datasets'


### PR DESCRIPTION
Completes work on https://github.com/ssl-hep/ServiceX/issues/269 - which added the title to the backend.

* The title is passed in as an optional argument to any of the `get_xxxx` calls
* By default no title is passed - and ServiceX will call the request "Untitled".

Fixes #163