### PR TITLE
Probe for viable data return formats

### DIFF
--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -232,8 +232,31 @@ class ServiceXDataset(ServiceXABC):
         self._session_generator = session_generator if session_generator is not None \
             else default_client_session
 
+        self._return_types = [config.get_default_returned_datatype(backend_type)]
         self._converter = data_convert_adaptor if data_convert_adaptor is not None \
-            else DataConverterAdaptor(config.get_default_returned_datatype(backend_type))
+            else DataConverterAdaptor(self._return_types[0])
+
+    def first_supported_datatype(self, datatypes: Union[List[str], str]) -> Optional[str]:
+        """Return the first datatype format that this dataset/servicex instance can return.
+
+        Different instances of `ServiceX` are capable of returning different datatypes. Pass in
+        the datatypes that your app supports, and this will return the first one that the servicex
+        backend can return.
+
+        Args:
+            datatypes (Union[List[str], str]): A single or list of datatypes that are supported by
+                                               your app.
+
+        Returns:
+            str: The first datatype that is supported. If none of them are, then `None` is
+            returned.
+        """
+        datatypes = [datatypes] if isinstance(datatypes, str) else datatypes
+        for dt in datatypes:
+            if dt in self._return_types:
+                return dt
+
+        return None
 
     def ignore_cache(self):
         '''Return a context manager that, as long as it is held, will cause any queries against just

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -121,6 +121,48 @@ def test_ignore_cache_on_ds(mocker):
     assert got_called
 
 
+def test_get_datatypes_good(mocker):
+    'Test that we return a good datatype'
+
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.settings = Configuration('servicex', 'servicex')
+    config.get_servicex_adaptor_config.return_value = ('http://no-way.dude',
+                                                       'no_spoon_there_is')
+    config.get_default_returned_datatype.return_value = 'root'
+
+    r = fe.ServiceXDataset('localds://dude', "uproot-ftw", config_adaptor=config)
+
+    assert r.first_supported_datatype(['root', 'parquet']) == 'root'
+
+
+def test_get_datatypes_single(mocker):
+    'Test that we return a good datatype'
+
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.settings = Configuration('servicex', 'servicex')
+    config.get_servicex_adaptor_config.return_value = ('http://no-way.dude',
+                                                       'no_spoon_there_is')
+    config.get_default_returned_datatype.return_value = 'root'
+
+    r = fe.ServiceXDataset('localds://dude', "uproot-ftw", config_adaptor=config)
+
+    assert r.first_supported_datatype('root') == 'root'
+
+
+def test_get_datatypes_bad(mocker):
+    'Test that we return a good datatype'
+
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.settings = Configuration('servicex', 'servicex')
+    config.get_servicex_adaptor_config.return_value = ('http://no-way.dude',
+                                                       'no_spoon_there_is')
+    config.get_default_returned_datatype.return_value = 'root'
+
+    r = fe.ServiceXDataset('localds://dude', "uproot-ftw", config_adaptor=config)
+
+    assert r.first_supported_datatype('forking') is None
+
+
 @pytest.mark.asyncio
 async def test_minio_back(mocker):
     'Get a root file with a single file'


### PR DESCRIPTION
Fixes #180

* Adds the method `first_supported_datatype`. Given a list of data formats your app supports, it will return the first one that this servicex instance can return