### PR TITLE
Support lists of files rather than just datasets

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -86,4 +86,5 @@
         "tests",
         "--no-cov"
     ],
+    "python.pythonPath": ".venv\\Scripts\\python.exe",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-    "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.analysis.logLevel": "Information",
     "python.analysis.memory.keepLibraryAst": true,
     "python.linting.flake8Enabled": true,

--- a/README.md
+++ b/README.md
@@ -241,15 +241,15 @@ Everything is based around the `ServiceXDataset` object. Below is the documentat
 To get the data use one of the `get_data` method. They all have the same API, differing only by what they return.
 
 ```python
- |  get_data_awkward_async(self, selection_query: str) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
+ |  get_data_awkward_async(self, selection_query: str, title: Optional[str] = None) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
  |      Fetch query data from ServiceX matching `selection_query` and return it as
  |      dictionary of awkward arrays, an entry for each column. The data is uniquely
- |      ordered (the same query will always return the same order).
+ |      ordered (the same query will always return the same order). If specified, the optional title is passed to the backend and can be viewed on the status page.
  |
- |  get_data_awkward(self, selection_query: str) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
+ |  get_data_awkward(self, selection_query: str, title: Optional[str] = None) -> Dict[bytes, Union[awkward.array.jagged.JaggedArray, numpy.ndarray]]
  |      Fetch query data from ServiceX matching `selection_query` and return it as
  |      dictionary of awkward arrays, an entry for each column. The data is uniquely
- |      ordered (the same query will always return the same order).
+ |      ordered (the same query will always return the same order).  If specified, the optional title is passed to the backend and can be viewed on the status page.
 ```
 
 Each data type comes in a pair - an `async` version and a synchronous version.

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -7,6 +7,7 @@ from .utils import (  # NOQA
     StatusUpdateCallback,
     StatusUpdateFactory,
     clean_linq,
+    DatasetType,
 )
 from .servicex_adaptor import ServiceXAdaptor  # NOQA
 from .minio_adaptor import MinioAdaptor  # NOQA

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -6,6 +6,7 @@ from .utils import (  # NOQA
     ServiceXFatalTransformException,
     StatusUpdateCallback,
     StatusUpdateFactory,
+    ServiceXUnknownDataRequestID,
     clean_linq,
     DatasetType,
 )

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -145,7 +145,7 @@ class Cache:
         with f.open('r') as o:
             return json.load(o)
 
-    def remove_query(self, json: Dict[str, str]):
+    def remove_query(self, json: Dict[str, Any]):
         f = self._query_cache_file(json)
         if f.exists():
             f.unlink()

--- a/servicex/data_conversions.py
+++ b/servicex/data_conversions.py
@@ -6,7 +6,7 @@ from typing import Iterable, Optional
 import pandas as pd
 import awkward as ak
 
-from servicex.utils import ServiceXException
+from .utils import ServiceXException
 
 _conversion_pool = ThreadPoolExecutor(4)
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -246,10 +246,12 @@ class ServiceXDataset(ServiceXABC):
 
     @functools.wraps(ServiceXABC.get_data_rootfiles_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_rootfiles_async(self, selection_query: str) -> List[Path]:
-        return await self._file_return(selection_query, 'root-file')
+    async def get_data_rootfiles_async(self, selection_query: str,
+                                       title: Optional[str] = None) -> List[Path]:
+        return await self._file_return(selection_query, 'root-file', title)
 
-    async def get_data_rootfiles_stream(self, selection_query: str) \
+    async def get_data_rootfiles_stream(self, selection_query: str,
+                                        title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoPath]:
         '''Returns, as an async iterator, each completed batch of work from Servicex.
         The `StreamInfoPath` contains a path where downstream consumers can directly
@@ -265,15 +267,17 @@ class ServiceXDataset(ServiceXABC):
                                            file locally.
         '''
         async for f_info in \
-                self._stream_local_files(selection_query, 'root-files'):  # type: ignore
+                self._stream_local_files(selection_query, title, 'root-files'):  # type: ignore
             yield f_info
 
     @functools.wraps(ServiceXABC.get_data_parquet_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_parquet_async(self, selection_query: str) -> List[Path]:
-        return await self._file_return(selection_query, 'parquet')
+    async def get_data_parquet_async(self, selection_query: str,
+                                     title: Optional[str] = None) -> List[Path]:
+        return await self._file_return(selection_query, 'parquet', title)
 
-    async def get_data_parquet_stream(self, selection_query: str) \
+    async def get_data_parquet_stream(self, selection_query: str,
+                                      title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoPath]:
         '''Returns, as an async iterator, each completed batch of work from Servicex.
         The `StreamInfoPath` contains a path where downstream consumers can directly
@@ -288,22 +292,28 @@ class ServiceXDataset(ServiceXABC):
                                            a `StreamInfoPath` which can be used to access the
                                            file locally.
         '''
-        async for f_info in self._stream_local_files(selection_query, 'parquet'):  # type: ignore
+        async for f_info in self._stream_local_files(selection_query, title,
+                                                     'parquet'):  # type: ignore
             yield f_info
 
     @functools.wraps(ServiceXABC.get_data_pandas_df_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_pandas_df_async(self, selection_query: str):
+    async def get_data_pandas_df_async(self, selection_query: str,
+                                       title: Optional[str] = None):
         return self._converter.combine_pandas(await self._data_return(
-            selection_query, lambda f: self._converter.convert_to_pandas(f)))
+            selection_query, lambda f: self._converter.convert_to_pandas(f),
+            title))
 
     @functools.wraps(ServiceXABC.get_data_awkward_async, updated=())
     @_wrap_in_memory_sx_cache
-    async def get_data_awkward_async(self, selection_query: str):
+    async def get_data_awkward_async(self, selection_query: str,
+                                     title: Optional[str] = None):
         return self._converter.combine_awkward(await self._data_return(
-            selection_query, lambda f: self._converter.convert_to_awkward(f)))
+            selection_query, lambda f: self._converter.convert_to_awkward(f),
+            title))
 
-    async def get_data_awkward_stream(self, selection_query: str) \
+    async def get_data_awkward_stream(self, selection_query: str,
+                                      title: Optional[str] = None) \
             -> AsyncGenerator[StreamInfoData, None]:
         '''Returns, as an async iterator, each completed batch of work from Servicex
         as a separate `awkward` array. The data is returned in a `StreamInfoData` object.
@@ -317,11 +327,12 @@ class ServiceXDataset(ServiceXABC):
                                            a `StreamInfoData` which can be used to access the
                                            data that has been loaded from the file.
         '''
-        async for a in self._stream_return(selection_query,
+        async for a in self._stream_return(selection_query, title,
                                            lambda f: self._converter.convert_to_awkward(f)):
             yield a
 
-    async def get_data_pandas_stream(self, selection_query: str) \
+    async def get_data_pandas_stream(self, selection_query: str,
+                                     title: Optional[str] = None) \
             -> AsyncGenerator[StreamInfoData, None]:
         '''Returns, as an async iterator, each completed batch of work from Servicex
         as a separate `pandas.DataFrame` array. The data is returned in a `StreamInfoData` object.
@@ -335,11 +346,12 @@ class ServiceXDataset(ServiceXABC):
                                            a `StreamInfoData` which can be used to access the
                                            data that has been loaded from the file.
         '''
-        async for a in self._stream_return(selection_query,
+        async for a in self._stream_return(selection_query, title,
                                            lambda f: self._converter.convert_to_pandas(f)):
             yield a
 
-    async def get_data_rootfiles_url_stream(self, selection_query: str) \
+    async def get_data_rootfiles_url_stream(self, selection_query: str,
+                                            title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoUrl]:
         '''Returns, as an async iterator, each completed batch of work from ServiceX.
         The data that comes back includes a `url` that can be accessed to download the
@@ -349,10 +361,11 @@ class ServiceXDataset(ServiceXABC):
             selection_query (str): The ServiceX Selection
         '''
         async for f_info in \
-                self._stream_url_buckets(selection_query, 'root-files'):  # type: ignore
+                self._stream_url_buckets(selection_query, 'root-files', title):  # type: ignore
             yield f_info
 
-    async def get_data_parquet_url_stream(self, selection_query: str) \
+    async def get_data_parquet_url_stream(self, selection_query: str,
+                                          title: Optional[str] = None) \
             -> AsyncIterator[StreamInfoUrl]:
         '''Returns, as an async iterator, each of the files from the minio bucket,
         as the files are added there.
@@ -360,10 +373,11 @@ class ServiceXDataset(ServiceXABC):
         Args:
             selection_query (str): The ServiceX Selection
         '''
-        async for f_info in self._stream_url_buckets(selection_query, 'parquet'):  # type: ignore
+        async for f_info in self._stream_url_buckets(selection_query, 'parquet',
+                                                     title):  # type: ignore
             yield f_info
 
-    async def _file_return(self, selection_query: str, data_format: str):
+    async def _file_return(self, selection_query: str, data_format: str, title: Optional[str]):
         '''
         Given a query, return the list of files, in a unique order, that hold
         the data for the query.
@@ -376,6 +390,7 @@ class ServiceXDataset(ServiceXABC):
 
             selection_query     `qastle` data that makes up the selection request.
             data_format         The file-based data format (root or parquet)
+            title               The title assigned to this transform request.
 
         Returns:
 
@@ -385,17 +400,19 @@ class ServiceXDataset(ServiceXABC):
         async def convert_to_file(f: Path) -> Path:
             return f
 
-        return await self._data_return(selection_query, convert_to_file, data_format)
+        return await self._data_return(selection_query, convert_to_file, title, data_format)
 
     @on_exception(backoff.constant, ServiceXUnknownRequestID, interval=0.1, max_tries=3)
     @on_exception(backoff.constant, ServiceXUnknownDataRequestID, interval=0.1, max_tries=2)
-    async def _stream_url_buckets(self, selection_query: str, data_format: str) \
+    async def _stream_url_buckets(self, selection_query: str, data_format: str,
+                                  title: Optional[str]) \
             -> AsyncGenerator[StreamInfoUrl, None]:
         '''Get a list of files back for a request
 
         Args:
             selection_query (str): The selection query we are to do
             data_format (str): The requested file format
+            title (Optional[str]): The title of transform to pass to ServiceX
 
         Yields:
             AsyncIterator[Dict[str, str]]: A tuple of the minio bucket and file in that bucket.
@@ -403,7 +420,7 @@ class ServiceXDataset(ServiceXABC):
                                              bucket: The minio bucket name
                                              file: the completed file in the bucket
         '''
-        query = self._build_json_query(selection_query, data_format)
+        query = self._build_json_query(selection_query, data_format, title)
 
         async with aiohttp.ClientSession() as client:
 
@@ -448,6 +465,7 @@ class ServiceXDataset(ServiceXABC):
 
     async def _data_return(self, selection_query: str,
                            converter: Callable[[Path], Awaitable[Any]],
+                           title: Optional[str],
                            data_format: str = 'root-file') -> List[Any]:
         '''Given a query, return the data, in a unique order, that hold
         the data for the query.
@@ -461,6 +479,8 @@ class ServiceXDataset(ServiceXABC):
             selection_query     `qastle` data that makes up the selection request.
             converter           A `Callable` that will convert the data returned from
                                 `ServiceX` as a set of files.
+            title               Title to send to the backend service
+            data_format         The data format that we want to render in
 
         Returns:
 
@@ -469,7 +489,7 @@ class ServiceXDataset(ServiceXABC):
         '''
         all_data = {
             f.file: f.data
-            async for f in self._stream_return(selection_query, converter, data_format)
+            async for f in self._stream_return(selection_query, title, converter, data_format)
         }
 
         # Convert them to the proper format
@@ -481,6 +501,7 @@ class ServiceXDataset(ServiceXABC):
         return ordered_data
 
     async def _stream_return(self, selection_query: str,
+                             title: Optional[str],
                              converter: Callable[[Path], Awaitable[Any]],
                              data_format: str = 'root-file') -> AsyncIterator[StreamInfoData]:
         '''Given a query, return the data, in the order it arrives back
@@ -503,13 +524,14 @@ class ServiceXDataset(ServiceXABC):
         '''
         as_data = (StreamInfoData(f.file, await asyncio.ensure_future(converter(f.path)))
                    async for f in
-                   self._stream_local_files(selection_query, data_format))  # type: ignore
+                   self._stream_local_files(selection_query, title, data_format))  # type: ignore
 
         async for r in as_data:
             yield r
 
     @on_exception(backoff.constant, ServiceXUnknownRequestID, interval=0.1, max_tries=3)
     async def _stream_local_files(self, selection_query: str,
+                                  title: Optional[str],
                                   data_format: str = 'root-file') \
             -> AsyncGenerator[StreamInfoPath, None]:
         '''
@@ -536,14 +558,15 @@ class ServiceXDataset(ServiceXABC):
         # Get all the files
         as_files = \
             (f async for f in
-             self._get_files(selection_query, data_format, notifier))  # type: ignore
+             self._get_files(selection_query, data_format, notifier, title))  # type: ignore
 
         async for name, a_path in as_files:
             yield StreamInfoPath(name, Path(await a_path))
 
     @on_exception(backoff.constant, ServiceXUnknownDataRequestID, interval=0.1, max_tries=2)
     async def _get_files(self, selection_query: str, data_type: str,
-                         notifier: _status_update_wrapper) \
+                         notifier: _status_update_wrapper,
+                         title: Optional[str]) \
             -> AsyncIterator[Tuple[str, Awaitable[Path]]]:
         '''
         Return a list of files from servicex as they have been downloaded to this machine. The
@@ -562,6 +585,7 @@ class ServiceXDataset(ServiceXABC):
             selection_query             The query string to send to ServiceX
             data_type                   The type of data that we want to come back.
             notifier                    Status callback to let our progress be advertised
+            title                       Title to pass to servicex backend.
 
         Returns
             Awaitable[Path]             An awaitable that is a path. When it completes, the
@@ -569,7 +593,7 @@ class ServiceXDataset(ServiceXABC):
                                         This is returned this way so a number of downloads can run
                                         simultaneously.
         '''
-        query = self._build_json_query(selection_query, data_type)
+        query = self._build_json_query(selection_query, data_type, title)
 
         async with aiohttp.ClientSession() as client:
 
@@ -757,7 +781,8 @@ class ServiceXDataset(ServiceXABC):
             logging.getLogger(__name__).info(f'Running servicex query for '
                                              f'{request_id} took {run_time} (no files downloaded)')
 
-    def _build_json_query(self, selection_query: str, data_type: str) -> Dict[str, str]:
+    def _build_json_query(self, selection_query: str, data_type: str, title: Optional[str]) \
+            -> Dict[str, str]:
         '''
         Returns a list of locally written files for a given selection query.
 
@@ -781,6 +806,9 @@ class ServiceXDataset(ServiceXABC):
         # Optional items
         if self._image is not None:
             json_query['image'] = self._image
+
+        if title is not None:
+            json_query['title'] = title
 
         logging.getLogger(__name__).debug(f'JSON to be sent to servicex: {str(json_query)}')
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -5,7 +5,7 @@ import time
 from datetime import timedelta
 from pathlib import Path
 from typing import (Any, AsyncGenerator, AsyncIterator, Awaitable, Callable,
-                    Dict, List, Optional, Tuple, Union)
+                    Dict, Iterable, List, Optional, Tuple, Union)
 
 import aiohttp
 import backoff
@@ -21,7 +21,7 @@ from .servicex_adaptor import (ServiceXAdaptor, transform_status_stream,
                                trap_servicex_failures)
 from .servicex_utils import _wrap_in_memory_sx_cache
 from .servicexabc import ServiceXABC
-from .utils import (ServiceXException, ServiceXFailedFileTransform,
+from .utils import (DatasetType, ServiceXException, ServiceXFailedFileTransform,
                     ServiceXFatalTransformException,
                     ServiceXUnknownDataRequestID, ServiceXUnknownRequestID,
                     StatusUpdateFactory, _run_default_wrapper,
@@ -137,7 +137,7 @@ class ServiceXDataset(ServiceXABC):
     function.
     '''
     def __init__(self,
-                 dataset: str,
+                 dataset: DatasetType,
                  backend_type: Optional[str] = None,
                  image: str = None,
                  max_workers: int = 20,
@@ -782,7 +782,7 @@ class ServiceXDataset(ServiceXABC):
                                              f'{request_id} took {run_time} (no files downloaded)')
 
     def _build_json_query(self, selection_query: str, data_type: str, title: Optional[str]) \
-            -> Dict[str, str]:
+            -> Dict[str, Union[str, Iterable[str]]]:
         '''
         Returns a list of locally written files for a given selection query.
 
@@ -794,14 +794,19 @@ class ServiceXDataset(ServiceXABC):
             - Internal routine.
         '''
         # Items that must always be present
-        json_query: Dict[str, str] = {
-            "did": self._dataset,
+        json_query: Dict[str, Union[str, Iterable[str]]] = {
             "selection": selection_query,
             "result-destination": "object-store",
             "result-format": 'parquet' if data_type == 'parquet' else "root-file",
             "chunk-size": '1000',
             "workers": str(self._max_workers)
         }
+
+        # Add the appropriate did
+        if isinstance(self._dataset, str):
+            json_query['did'] = self._dataset
+        else:
+            json_query['file-list'] = self._dataset
 
         # Optional items
         if self._image is not None:

--- a/servicex/servicex_config.py
+++ b/servicex/servicex_config.py
@@ -4,7 +4,7 @@ from typing import Optional, Tuple, cast
 from confuse.core import ConfigView
 
 from servicex.ConfigSettings import ConfigSettings
-from servicex.utils import ServiceXException
+from .utils import ServiceXException
 
 
 class ServiceXConfigAdaptor:

--- a/servicex/servicexabc.py
+++ b/servicex/servicexabc.py
@@ -72,7 +72,8 @@ class ServiceXABC(ABC):
         return _status_update_wrapper(self._status_callback_factory(self._dataset, downloading))
 
     @abstractmethod
-    async def get_data_rootfiles_async(self, selection_query: str) -> List[Path]:
+    async def get_data_rootfiles_async(self, selection_query: str,
+                                       title: Optional[str] = None) -> List[Path]:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
         a list of root files. The files are uniquely ordered (the same query will always
@@ -80,13 +81,15 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             root_files          The list of root files
         '''
 
     @abstractmethod
-    async def get_data_pandas_df_async(self, selection_query: str) -> pd.DataFrame:
+    async def get_data_pandas_df_async(self, selection_query: str,
+                                       title: Optional[str] = None) -> pd.DataFrame:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
         a pandas dataframe. The data is uniquely ordered (the same query will always
@@ -94,6 +97,7 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             df                  The pandas dataframe
@@ -104,7 +108,8 @@ class ServiceXABC(ABC):
         '''
 
     @abstractmethod
-    async def get_data_awkward_async(self, selection_query: str) \
+    async def get_data_awkward_async(self, selection_query: str,
+                                     title: Optional[str] = None) \
             -> Dict[bytes, ak.Array]:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
@@ -113,6 +118,7 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             a                   Dictionary of jagged arrays (as needed), one for each
@@ -121,7 +127,8 @@ class ServiceXABC(ABC):
         '''
 
     @abstractmethod
-    async def get_data_parquet_async(self, selection_query: str) -> List[Path]:
+    async def get_data_parquet_async(self, selection_query: str,
+                                     title: Optional[str] = None) -> List[Path]:
         '''
         Fetch query data from ServiceX matching `selection_query` and return it as
         a list of parquet files. The files are uniquely ordered (the same query will always
@@ -129,6 +136,7 @@ class ServiceXABC(ABC):
 
         Arguments:
             selection_query     The `qastle` string specifying the data to be queried
+            title               Title reported to the ServiceX backend for status reporting
 
         Returns:
             root_files          The list of parquet files

--- a/servicex/servicexabc.py
+++ b/servicex/servicexabc.py
@@ -7,6 +7,7 @@ import awkward as ak
 import pandas as pd
 
 from .utils import (
+    DatasetType,
     StatusUpdateFactory,
     _null_progress_feedback,
     _run_default_wrapper,
@@ -25,7 +26,7 @@ class ServiceXABC(ABC):
     '''
 
     def __init__(self,
-                 dataset: str,
+                 dataset: DatasetType,
                  image: Optional[str] = None,
                  max_workers: int = 20,
                  status_callback_factory: Optional[StatusUpdateFactory] = _run_default_wrapper,

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -5,7 +5,7 @@ from pathlib import Path, PurePath
 import re
 import tempfile
 import threading
-from typing import AsyncIterator, Callable, Dict, List, Optional, Tuple
+from typing import AsyncIterator, Callable, Dict, Iterable, Optional, Tuple, Union
 
 import aiohttp
 from confuse.core import ConfigView
@@ -98,6 +98,14 @@ def sanitize_filename(fname: str):
                 .replace(':', '_')
 
 
+# Datasets can be specified in mulitple ways
+# to ServiceX. This datatype encapuslates them
+# all.
+DatasetType = Union[
+    str,  # A single URI with a scheme (e.g. rucio://did_name)
+    Iterable[str]  # A list of http:// or root:// files to be directly accessed
+]
+
 StatusUpdateCallback = Callable[[Optional[int], int, int, int], None]
 # The sig of the call-back. Arguments are:
 # 1. Processed
@@ -105,7 +113,7 @@ StatusUpdateCallback = Callable[[Optional[int], int, int, int], None]
 # 1. Remaining
 # 1. Failed
 
-StatusUpdateFactory = Callable[[str, bool], StatusUpdateCallback]
+StatusUpdateFactory = Callable[[DatasetType, bool], StatusUpdateCallback]
 # Factory method that returns a factory that can run the status callback
 # First argument is a string, second argument is True if a download progress
 # bar can be displayed as well.
@@ -209,7 +217,7 @@ async def stream_unique_updates_only(stream: AsyncIterator[TransformTuple]):
             yield p
 
 
-def _run_default_wrapper(ds_name: str, downloading: bool) -> StatusUpdateCallback:
+def _run_default_wrapper(ds_name: DatasetType, downloading: bool) -> StatusUpdateCallback:
     '''Create a feedback object for everyone to use to pass feedback to. Uses tqdm (default).
 
     Args:
@@ -222,7 +230,7 @@ def _run_default_wrapper(ds_name: str, downloading: bool) -> StatusUpdateCallbac
     return _default_wrapper_mgr(ds_name, downloading).update
 
 
-def _null_progress_feedback(ds_name: str, downloading: bool) -> None:
+def _null_progress_feedback(ds_name: DatasetType, downloading: bool) -> None:
     '''
     Internal routine to create a feedback object that does not
     give anyone feedback!
@@ -232,7 +240,7 @@ def _null_progress_feedback(ds_name: str, downloading: bool) -> None:
 
 class _default_wrapper_mgr:
     'Default progress bar'
-    def __init__(self, sample_name: Optional[str] = None, show_download_bar: bool = True):
+    def __init__(self, sample_name: Optional[DatasetType] = None, show_download_bar: bool = True):
         self._tqdm_p: Optional[tqdm] = None
         self._tqdm_d: Optional[tqdm] = None
         self._show_download_progress = show_download_bar
@@ -242,7 +250,13 @@ class _default_wrapper_mgr:
         if self._tqdm_p is not None:
             return
 
-        self._tqdm_p = tqdm(total=9e9, desc=self._sample_name, unit='file',
+        if self._sample_name is not None:
+            name = self._sample_name if isinstance(self._sample_name, str) \
+                else ' '.join(self._sample_name)
+        else:
+            name = '<none>'
+
+        self._tqdm_p = tqdm(total=9e9, desc=name, unit='file',
                             leave=False, dynamic_ncols=True,
                             bar_format='{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}]')
         if self._show_download_progress:
@@ -292,13 +306,17 @@ def _query_cache_hash(json_query: Dict[str, str]) -> str:
     return hash
 
 
-def _string_hash(s_list: List[str]) -> str:
+def _string_hash(s_list: Iterable[Union[str, Iterable[str]]]) -> str:
     '''
     Return a hash for an input list of strings.
     '''
     hasher = blake2b(digest_size=20)
     for v in s_list:
-        hasher.update(v.encode())
+        if isinstance(v, str):
+            hasher.update(v.encode())
+        else:
+            for v1 in v:
+                hasher.update(v1.encode())
     hash = hasher.hexdigest()
     return hash
 

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -144,10 +144,6 @@ class _status_update_wrapper:
     def failed(self) -> int:
         return self._failed
 
-    @property
-    def downloaded(self) -> Optional[int]:
-        return self._downloaded
-
     def broadcast(self):
         'Send an update back to the system'
         if self._callback is not None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,6 +1,6 @@
 import string
 import random
-from servicex.utils import ServiceXException
+from servicex import ServiceXException
 import pytest
 
 from servicex.cache import Cache, ignore_cache

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -725,6 +725,48 @@ async def test_max_workers_spec(mocker, good_awkward_file_data):
 
 
 @pytest.mark.asyncio
+async def test_title_spec(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset('localds://mc16_tev:13',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)', title='fork_spoon')
+
+    called = mock_servicex_adaptor.query_json
+    assert called['title'] == 'fork_spoon'
+
+
+@pytest.mark.asyncio
+async def test_notitle_spec(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset('localds://mc16_tev:13',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    called = mock_servicex_adaptor.query_json
+    assert 'title' not in called
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("n_ds, n_query", [(1, 4), (4, 1), (1, 100), (100, 1), (4, 4), (20, 20)])
 async def test_nqueries_on_n_ds(n_ds: int, n_query: int, mocker):
     'Run some number of queries on some number of datasets'

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1,25 +1,23 @@
 import asyncio
-from contextlib import contextmanager
 import os
+from contextlib import contextmanager
 from pathlib import Path
-
-import asyncmock
-from servicex.servicex import StreamInfoPath, StreamInfoUrl
-from servicex.cache import Cache
-
-from confuse.core import Configuration
-from servicex.servicex_config import ServiceXConfigAdaptor
-from servicex.data_conversions import DataConverterAdaptor
 from typing import Optional
 
+import asyncmock
 import pandas as pd
 import pytest
-
 import servicex as fe
+from confuse.core import Configuration
+from servicex import (DatasetType, ServiceXException,
+                      ServiceXFatalTransformException,
+                      ServiceXUnknownDataRequestID, ServiceXUnknownRequestID)
+from servicex.cache import Cache
+from servicex.data_conversions import DataConverterAdaptor
 from servicex.minio_adaptor import MinioAdaptorFactory
-from servicex.utils import (
-    DatasetType, ServiceXException, ServiceXFatalTransformException, ServiceXUnknownDataRequestID,
-    ServiceXUnknownRequestID, log_adaptor)
+from servicex.servicex import StreamInfoPath, StreamInfoUrl
+from servicex.servicex_config import ServiceXConfigAdaptor
+from servicex.utils import log_adaptor
 
 from .conftest import (MockMinioAdaptor, MockServiceXAdaptor,  # NOQA
                        build_cache_mock)

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -18,7 +18,7 @@ import pytest
 import servicex as fe
 from servicex.minio_adaptor import MinioAdaptorFactory
 from servicex.utils import (
-    ServiceXException, ServiceXFatalTransformException, ServiceXUnknownDataRequestID,
+    DatasetType, ServiceXException, ServiceXFatalTransformException, ServiceXUnknownDataRequestID,
     ServiceXUnknownRequestID, log_adaptor)
 
 from .conftest import (MockMinioAdaptor, MockServiceXAdaptor,  # NOQA
@@ -725,6 +725,50 @@ async def test_max_workers_spec(mocker, good_awkward_file_data):
 
 
 @pytest.mark.asyncio
+async def test_did_set(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset('localds://mc16_tev:13',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    called = mock_servicex_adaptor.query_json
+    assert called['did'] == 'localds://mc16_tev:13'
+    assert 'file-list' not in called
+
+
+@pytest.mark.asyncio
+async def test_file_list_set(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset(['http://file1.root', 'http://flie2.root'],
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    called = mock_servicex_adaptor.query_json
+    assert called['file-list'] == ['http://file1.root', 'http://flie2.root']
+    assert 'did' not in called
+
+
+@pytest.mark.asyncio
 async def test_title_spec(mocker, good_awkward_file_data):
     mock_cache = build_cache_mock(mocker)
     mock_logger = mocker.MagicMock(spec=log_adaptor)
@@ -848,7 +892,7 @@ def test_callback_is_downloading(mocker):
     ds_name = None
     ds_downloading = None
 
-    def build_it(ds: str, downloading: bool):
+    def build_it(ds: DatasetType, downloading: bool):
         nonlocal ds_name, ds_downloading
         ds_name = ds
         ds_downloading = downloading
@@ -882,7 +926,7 @@ async def test_callback_is_not_downloading(mocker):
     ds_name = None
     ds_downloading = None
 
-    def build_it(ds: str, downloading: bool):
+    def build_it(ds: DatasetType, downloading: bool):
         nonlocal ds_name, ds_downloading
         ds_name = ds
         ds_downloading = downloading

--- a/tests/test_servicex_adaptor.py
+++ b/tests/test_servicex_adaptor.py
@@ -1,5 +1,5 @@
 from json import dumps
-from servicex.utils import ServiceXFatalTransformException
+from servicex import ServiceXFatalTransformException
 from typing import Optional, Union
 
 import aiohttp

--- a/tests/test_servicex_config.py
+++ b/tests/test_servicex_config.py
@@ -2,7 +2,7 @@ import pytest
 
 from servicex.ConfigSettings import ConfigSettings
 from servicex.servicex_config import ServiceXConfigAdaptor
-from servicex.utils import ServiceXException
+from servicex import ServiceXException
 
 
 def test_default_ctor():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@ from servicex.utils import (
     stream_status_updates,
     stream_unique_updates_only,
     write_query_log,
+    log_adaptor,
     default_client_session
 )
 
@@ -81,6 +82,14 @@ def test_log_file_write_minutes(log_location_file):
     assert log_location_file.exists()
     t = log_location_file.read_text().split('\n')[1]
     assert t == '123,10,0,120.0,1'
+
+
+def test_log_adaptor(log_location_file):
+    log_adaptor.write_query_log('123', 10, 0, timedelta(seconds=20), True,
+                                path_to_log_dir=log_location_file.parent)
+    assert log_location_file.exists()
+    t = log_location_file.read_text().split('\n')[1]
+    assert t == '123,10,0,20.0,1'
 
 
 def test_log_file_write_2lines(log_location_file):


### PR DESCRIPTION
Fixes #170

Support lists of files as a dataset name. This will allow randomly located files to be sent to ServiceX for processing.