### PR TITLE
Allow single http/root as a input data

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,20 @@ If you'd like to be able to submit multiple queries and have them run on the `Se
 
 For documentation of `get_data` and `get_data_async` see the `servicex.py` source file.
 
+### How to specify the input data
+
+How you specify the input data, and what data can be ingested, is ultimately defined by the configuration of the `ServiceX` backend you are running against. This `servicex`
+library supports the following:
+
+- A Dataset Identifer (DID): For example, `rucio://mc16a_13TeV:my_dataset`, or `cernopendata://1507`, both of which are resolved to a list of
+files (in one case, a set of ATLAS data files, and in the other some CMS Run 1 AOD files).
+- A single file located at a `http` or `root` endpoint: For example, `root://myfile.root` or `http://myfile.root`. ServiceX must be able to
+access these files without special permissions.
+- A list of files located at `http` or `root` endpoints: For example, `[root://myfile1.root, http://myfile2.root]`. ServiceX must be able to
+access these files without special permissions.
+- [depreciated] A bare (DID): this is an unadorned identifier, and is routed to the backend's default DID resolver. The default
+is defined at runtime. It is depreciated because a backend configuraiton change can break your code.
+
 ### The Local Data Cache
 
 To speed things up - especially when you run the same query multiple times, the `servicex` package will cache queries data that comes back from Servicex. You can control where this is stored with the `cache_path` in the configuration file (see below). By default it is written in the temp direcotry of your system, under a `servicex_{USER}` directory. The cache is unbound: it will continuously fill up. You can delete it at any time that you aren't processing data: data will be re-downloaded or re-transformed in `ServiceX`.

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -825,9 +825,13 @@ class ServiceXDataset(ServiceXABC):
             "workers": str(self._max_workers)
         }
 
-        # Add the appropriate did
+        # Add the appropriate did.
+        # Capture full did as well as single item files (see  #178)
         if isinstance(self._dataset, str):
-            json_query['did'] = self._dataset
+            if self._dataset[0:7].lower() in ['root://', 'http://']:
+                json_query['file-list'] = [self._dataset]
+            else:
+                json_query['did'] = self._dataset
         else:
             json_query['file-list'] = self._dataset
 

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -102,7 +102,7 @@ def sanitize_filename(fname: str):
 # to ServiceX. This datatype encapuslates them
 # all.
 DatasetType = Union[
-    str,  # A single URI with a scheme (e.g. rucio://did_name)
+    str,  # A single URI with a scheme (e.g. rucio://did_name, http://, root://)
     Iterable[str]  # A list of http:// or root:// files to be directly accessed
 ]
 

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -809,6 +809,50 @@ async def test_file_list_set(mocker, good_awkward_file_data):
 
 
 @pytest.mark.asyncio
+async def test_file_list_http(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset('http://file1.root',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    called = mock_servicex_adaptor.query_json
+    assert called['file-list'] == ['http://file1.root']
+    assert 'did' not in called
+
+
+@pytest.mark.asyncio
+async def test_file_list_root(mocker, good_awkward_file_data):
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=['one_minio_entry'])
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset('root://file1.root',
+                            servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+                            minio_adaptor=mock_minio_adaptor,  # type: ignore
+                            cache_adaptor=mock_cache,
+                            data_convert_adaptor=data_adaptor,
+                            local_log=mock_logger,
+                            max_workers=50)
+    await ds.get_data_rootfiles_async('(valid qastle string)')
+
+    called = mock_servicex_adaptor.query_json
+    assert called['file-list'] == ['root://file1.root']
+    assert 'did' not in called
+
+
+@pytest.mark.asyncio
 async def test_title_spec(mocker, good_awkward_file_data):
     mock_cache = build_cache_mock(mocker)
     mock_logger = mocker.MagicMock(spec=log_adaptor)


### PR DESCRIPTION
Fixes #178

* You can use `http://` or `root://` as a dataset identifier and it will process a single file
* Updated documentation to specify how to access data.