### PR TITLE
Export StreamInfoPath from the root __init__ file

### DIFF
--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -1,4 +1,4 @@
-from .servicex import ServiceXDataset, StreamInfoUrl  # NOQA
+from .servicex import ServiceXDataset, StreamInfoUrl, StreamInfoPath  # NOQA
 from .utils import (  # NOQA
     ServiceXException,
     ServiceXUnknownRequestID,


### PR DESCRIPTION
Fixes #179

* Make it easy to import StreamInfoPath, not just StreamInfoUrl.