### PR TITLE
Support Missing Query Cache Status Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ with ds.ignore_cache():
 do_query(ds)  # Cache is not ignored
 ```
 
+#### Deleting Files from the local Data Cache
+
+Besides telling the `servicex` library to ignore the cache in the above ways, you can also delete files from the local cache.
+The local cache directory is split up into sub-directories. Deleting files from each of the directories:
+
+- `query_cache` - this directory contains the mapping between the query text (or its hash) and the ServiceX backend's `request-id`. If you delete a file from here, it is as if the query was never made, and is the same as using the ignore methods above.
+- `query_cache_status` - contains the last retreived status from the backend. Deleting this will cause the library to refresh the missing status. This file is updated continuosly until the query is completed.
+- `file_list_cache` - Each file contains a json list of all the files in the `minio` bucket for a partiuclar request id. Deleting a file from this directory is not supported.
+-`data` - This directory contains the files that have been downloaded locally. Once all files have been downloaded for a query, deleting a file from this directory is not supported.
+
 ## Configuration
 
 The `servicex` library searches for configuration information in several locations to determine what end-point it should connect to:

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ do_query(ds)  # Cache is not ignored
 
 #### Deleting Files from the local Data Cache
 
+It is not recommended to alter the cache. The software expects the cache to be in a certain state, and radomly altering it can lead to unexpected effects.
+
 Besides telling the `servicex` library to ignore the cache in the above ways, you can also delete files from the local cache.
 The local cache directory is split up into sub-directories. Deleting files from each of the directories:
 

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -145,6 +145,17 @@ class Cache:
         with f.open('r') as o:
             return json.load(o)
 
+    def query_status_exists(self, request_id: str) -> bool:
+        """Returns true if the query status file exists on the local machine.
+
+        Args:
+            request_id (str): The request-id to look up
+
+        Returns:
+            bool: True if present, false otherwise.
+        """
+        return self._query_status_cache_file(request_id).exists()
+
     def remove_query(self, json: Dict[str, Any]):
         f = self._query_cache_file(json)
         if f.exists():

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -141,7 +141,7 @@ class Cache:
         '''
         f = self._query_status_cache_file(request_id)
         if not f.exists():
-            raise ServiceXException(f'Not cache information for query {request_id}')
+            raise ServiceXException(f'No cache information for query {request_id}')
         with f.open('r') as o:
             return json.load(o)
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -450,6 +450,10 @@ class ServiceXDataset(ServiceXABC):
             # Get a request id - which might be cached, but if not, submit it.
             request_id = await self._get_request_id(client, query)
 
+            # Make sure cache status exists (user could have deleted, see #176)
+            if not self._cache.query_status_exists(request_id):
+                await self._update_query_status(client, request_id)
+
             # Get the minio adaptor we are going to use for downloading.
             minio_adaptor = self._minio_adaptor \
                 .from_best(self._cache.lookup_query_status(request_id))
@@ -622,6 +626,10 @@ class ServiceXDataset(ServiceXABC):
 
             # Get a request id - which might be cached, but if not, submit it.
             request_id = await self._get_request_id(client, query)
+
+            # Make sure cache status exists (user could have deleted, see #176)
+            if not self._cache.query_status_exists(request_id):
+                await self._update_query_status(client, request_id)
 
             # Get the minio adaptor we are going to use for downloading.
             minio_adaptor = self._minio_adaptor \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -163,6 +163,8 @@ def build_cache_mock(mocker, query_cache_return: str = None,
 
     if query_status_lookup_return is not None:
         c.lookup_query_status.return_value = query_status_lookup_return
+    
+    c.query_status_exists.return_value = True
 
     return c
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -187,6 +187,7 @@ def test_query_cache_status(tmp_path):
 
     info = {'request_id': '111-222-333', 'key': 'bogus'}
     c.set_query_status(info)
+    assert c.query_status_exists('111-222-333')
     info1 = c.lookup_query_status('111-222-333')
     assert info1['key'] == 'bogus'
 
@@ -194,6 +195,7 @@ def test_query_cache_status(tmp_path):
 def test_query_cache_status_bad(tmp_path):
     c = Cache(tmp_path)
 
+    assert not c.query_status_exists('111-222-333')
     with pytest.raises(ServiceXException):
         c.lookup_query_status('111-222-333')
 


### PR DESCRIPTION
Query cache status files can now be deleted by the user (or some other agent):

* Recover if the status is missing by re-querying the backend
* Add documentation to talk a little bit about how the cache works


Fixes #176