### PR TITLE
Backend Download and Query Cache Updates

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,6 +23,12 @@
             "command": "powershell",
             "args": ["-Command", "& .vscode/push-to-pypi.ps1"],
             "problemMatcher": []
+        },
+        {
+            "label": "Run Code Coverage",
+            "type": "shell",
+            "command": ". .venv/scripts/activate.ps1 ; coverage-3.9.exe run -m pytest",
+            "problemMatcher": []
         }
     ]
 }

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ The local cache directory is split up into sub-directories. Deleting files from 
 
 - `query_cache` - this directory contains the mapping between the query text (or its hash) and the ServiceX backend's `request-id`. If you delete a file from here, it is as if the query was never made, and is the same as using the ignore methods above.
 - `query_cache_status` - contains the last retreived status from the backend. Deleting this will cause the library to refresh the missing status. This file is updated continuosly until the query is completed.
-- `file_list_cache` - Each file contains a json list of all the files in the `minio` bucket for a partiuclar request id. Deleting a file from this directory is not supported.
--`data` - This directory contains the files that have been downloaded locally. Once all files have been downloaded for a query, deleting a file from this directory is not supported.
+- `file_list_cache` - Each file contains a json list of all the files in the `minio` bucket for a partiuclar request id. Deleting a file from this directory will cause the frontend to re-download the complete list of files (the file in this directory isn't created until all files have been downloaded).
+-`data` - This directory contains the files that have been downloaded locally. If you delete a data file from this directory, it will trigger a re-download. Note that if the servicex endpoint doesn't know about the origianl query, or the minio bucket is missing, it will force the transform being re-run from scratch.
 
 ## Configuration
 

--- a/servicex/minio_adaptor.py
+++ b/servicex/minio_adaptor.py
@@ -105,7 +105,12 @@ class MinioAdaptor:
         def do_copy() -> None:
             temp_file = output_file.parent / f'{output_file.name}.temp'
             try:
+                log = logging.getLogger(__name__)
+                log.debug(f'Starting download of minio file for request {request_id}, '
+                          f'file {bucket_fname}.')
                 self._client.fget_object(request_id, bucket_fname, str(temp_file))
+                log.debug(f'Finished download of minio file for request {request_id}, '
+                          f'file {bucket_fname}.')
                 temp_file.rename(output_file)
             except Exception as e:
                 raise ServiceXException(

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -486,6 +486,7 @@ class ServiceXDataset(ServiceXABC):
             except ServiceXFatalTransformException as e:
                 transform_status = await self._servicex_adaptor.get_query_status(client,
                                                                                  request_id)
+                self._cache.remove_query(query)
                 raise ServiceXFatalTransformException(
                     f'ServiceX Fatal Error: {transform_status["failure-info"]}') from e
 
@@ -667,6 +668,7 @@ class ServiceXDataset(ServiceXABC):
             except ServiceXFatalTransformException as e:
                 transform_status = await self._servicex_adaptor.get_query_status(client,
                                                                                  request_id)
+                self._cache.remove_query(query)
                 raise ServiceXFatalTransformException(
                     f'ServiceX Fatal Error: {transform_status["failure-info"]}') from e
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -701,7 +701,7 @@ class ServiceXDataset(ServiceXABC):
         info = await self._servicex_adaptor.get_query_status(client, request_id)
         self._cache.set_query_status(info)
 
-    async def _get_cached_files(self, cached_files: List[Tuple[str, str]],
+    async def _get_cached_files(self, cached_files: List[Tuple[str, Path]],
                                 notifier: _status_update_wrapper):
         '''
         Return the list of files as an iterator that we have pulled from the cache
@@ -710,7 +710,7 @@ class ServiceXDataset(ServiceXABC):
         loop = asyncio.get_event_loop()
         for f, p in cached_files:
             path_future = loop.create_future()
-            path_future.set_result(Path(p))
+            path_future.set_result(p)
             notifier.inc(downloaded=1)
             yield f, path_future
 
@@ -732,10 +732,10 @@ class ServiceXDataset(ServiceXABC):
             notifier.broadcast()
             return final_path
 
-        file_object_list = []
+        file_object_list: List[Tuple[str, Path]] = []
         async for f in stream:
             copy_to_path = self._cache.data_file_location(request_id, f)
-            file_object_list.append((f, str(copy_to_path)))
+            file_object_list.append((f, copy_to_path))
 
             yield f, do_copy(copy_to_path)
 

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -121,10 +121,12 @@ class ServiceXAdaptor:
                                             f'{status} - {t}')
 
             # Dump the messages out to the logger if there are any!
+            # Keep the output under control - only dump the first 20 errors (see #188)
             errors = (await response.json())["errors"]
             log = logging.getLogger(__name__)
-            for e in errors:
-                log.warning(f'Error transforming file: {e["file"]}')
+            log.warning(f'Transform {request_id} had {len(errors)} errors:')
+            for e in errors[:20]:
+                log.warning(f'  Error transforming file: {e["file"]}')
                 for ln in e["info"].split('\n'):
                     log.warning(f'  -> {ln}')
 

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -457,8 +457,9 @@ def get_configured_cache_path(config: ConfigView) -> Path:
 
 # Below is copied and very lightly modified from the backoff library
 # See https://github.com/litl/backoff/issues/131
-from backoff import full_jitter, _sync  # noqa: E402
-import sys  # noqa: E402
+
+
+from backoff import full_jitter  # noqa: E402
 from backoff._common import (  # noqa: E402
     _prepare_logger,
     _config_handlers,
@@ -466,13 +467,13 @@ from backoff._common import (  # noqa: E402
     _log_backoff,
     _maybe_call,
     _init_wait_gen,
-    _next_wait
+    _next_wait,
 )
 import logging  # noqa: E402
 from backoff._async import (  # noqa: E402
     _ensure_coroutines,
     _ensure_coroutine,
-    _call_handlers
+    _call_handlers,
 )
 import asyncio  # noqa: E402
 import functools  # noqa: E402
@@ -529,7 +530,7 @@ def retry_exception_itr(target, wait_gen, exception,
 
                 try:
                     seconds = _next_wait(wait, jitter, elapsed, max_time_)
-                except StopIteration:
+                except StopIteration:  # pragma: no cover
                     await _call_handlers(on_giveup, *details)
                     raise e
 
@@ -575,17 +576,6 @@ def on_exception_itr(wait_gen,
         on_giveup_ = _config_handlers(
             on_giveup, _log_giveup, logger_, giveup_log_level
         )
-
-        retry = None
-        if sys.version_info[:2] >= (3, 5):   # pragma: python=3.5
-            import asyncio
-
-            if asyncio.iscoroutinefunction(target):
-                import backoff._async
-                retry = backoff._async.retry_exception
-
-        if retry is None:
-            retry = _sync.retry_exception
 
         return retry_exception_itr(target, wait_gen, exception,
                                    max_tries, max_time, jitter, giveup,

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -455,7 +455,8 @@ def get_configured_cache_path(config: ConfigView) -> Path:
     p.mkdir(exist_ok=True, parents=True)
     return p
 
-
+# Below is copied and very lightly modified from the backoff library
+# See https://github.com/litl/backoff/issues/131
 from backoff import full_jitter, _sync  # noqa: E402
 import sys  # noqa: E402
 from backoff._common import (  # noqa: E402

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,8 @@ setup(name="servicex",
               'autopep8',
               'twine',
               'asyncmock',
-              'jupyterlab'
+              'jupyterlab',
+              'ipywidgets'
           ] + extra_test_packages,
       },
       classifiers=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,7 +126,7 @@ __g_inmem_value = None
 
 
 def build_cache_mock(mocker, query_cache_return: str = None,
-                     files: Optional[List[Tuple[str, str]]] = None,
+                     files: Optional[List[Tuple[str, Path]]] = None,
                      in_memory: Any = None,
                      make_in_memory_work: bool = False,
                      data_file_return: str = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,10 +92,14 @@ class MockServiceXAdaptor:
 
 
 class MockMinioAdaptor(MinioAdaptor):
-    def __init__(self, mocker: MockFixture, files: List[str] = []):
+    def __init__(self,
+                 mocker: MockFixture,
+                 files: List[str] = [],
+                 exception_on_access: Optional[Exception] = None):
         self._files = files
         self.mock_download_file = mocker.Mock()
         self._access_called_with = None
+        self._exception_on_access = exception_on_access
         pass
 
     async def download_file(self, request_id: str, minio_object_name: str, final_path: Path):
@@ -107,6 +111,10 @@ class MockMinioAdaptor(MinioAdaptor):
 
     def get_access_url(self, request_id: str, object_name: str) -> str:
         self._access_called_with = (request_id, object_name)
+        if self._exception_on_access is not None:
+            e = self._exception_on_access
+            self._exception_on_access = None
+            raise e
         return "http://the.url.com"
 
     @property
@@ -163,7 +171,7 @@ def build_cache_mock(mocker, query_cache_return: str = None,
 
     if query_status_lookup_return is not None:
         c.lookup_query_status.return_value = query_status_lookup_return
-    
+
     c.query_status_exists.return_value = True
 
     return c

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -172,12 +172,15 @@ def test_data_file_location_twice(tmp_path):
 
 
 def test_data_file_bad_file(tmp_path):
+    'Check a very long bad filename to make sure it is santized'
     c = Cache(tmp_path)
     p = c.data_file_location(
         '123-456', 'root:::dcache-atlas-xrootd-wan.desy.de:1094::pnfs:desy.de:atlas'
         ':dq2:atlaslocalgroupdisk:rucio:mc15_13TeV:8a:f1:DAOD_STDM3.05630052'
         '._000001.pool.root.198fbd841d0a28cb0d9dfa6340c890273-1.part.minio')
     assert not p.exists()
+    # If the follow fails, on windows, it could be because very-long-pathnames are not
+    # enabled.
     p.touch()
     assert p.exists()
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import string
 import random
 from servicex import ServiceXException
@@ -77,25 +78,48 @@ def test_files_miss(tmp_path):
     assert c.lookup_files('1234') is None
 
 
-def test_files_hit(tmp_path):
+def test_files_hit(tmp_path: Path):
     c = Cache(tmp_path)
-    c.set_files('1234', [('hi', '1'), ('there', '1')])
-    assert c.lookup_files('1234') == [['hi', '1'], ['there', '1']]
+    f1 = tmp_path / 'f1.root'
+    f2 = tmp_path / 'f2.root'
+    f1.touch()
+    f2.touch()
+    c.set_files('1234', [('hi', f1), ('there', f2)])
+    assert c.lookup_files('1234') == [('hi', f1), ('there', f2)]
 
 
-def test_ic_files_hit(tmp_path):
+def test_files_deleted_data_file(tmp_path: Path):
+    c = Cache(tmp_path)
+    f1 = tmp_path / 'f1.root'
+    f2 = tmp_path / 'f2.root'
+    f1.touch()
+    f2.touch()
+    c.set_files('1234', [('hi', f1), ('there', f2)])
+    f2.unlink()
+    assert c.lookup_files('1234') is None
+
+
+def test_ic_files_hit(tmp_path: Path):
     'The file list should not be affected by cache ignores'
     c = Cache(tmp_path)
-    c.set_files('1234', [('hi', '1'), ('there', '1')])
+    f1 = tmp_path / 'f1.root'
+    f2 = tmp_path / 'f2.root'
+    f1.touch()
+    f2.touch()
+    c.set_files('1234', [('hi', f1), ('there', f2)])
     with ignore_cache():
-        assert c.lookup_files('1234') == [['hi', '1'], ['there', '1']]
+        assert c.lookup_files('1234') == [('hi', f1), ('there', f2)]
 
 
 def test_files_hit_reloaded(tmp_path):
     c1 = Cache(tmp_path)
-    c1.set_files('1234', [('hi', '1'), ('there', '1')])
+    f1 = tmp_path / 'f1.root'
+    f2 = tmp_path / 'f2.root'
+    f1.touch()
+    f2.touch()
+    c1.set_files('1234', [('hi', f1), ('there', f2)])
     c2 = Cache(tmp_path)
-    assert c2.lookup_files('1234') == [['hi', '1'], ['there', '1']]
+    assert c2.lookup_files('1234') == [('hi', f1), ('there', f2)]
 
 
 def test_memory_miss(tmp_path):

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1310,15 +1310,17 @@ async def test_servicex_in_progress_lock_cleared(mocker, short_status_poll_time)
 
 
 @pytest.mark.asyncio
-async def test_download_cached_nonet(mocker):
+async def test_download_cached_nonet(mocker, tmp_path: Path):
     '''
     Check that we do not use the network if we have already cached a file.
         - Cache is populated
         - the status calls are not made more than for the first time
         - the calls to minio are only made the first time (the list_objects, for example)
     '''
+    f1 = tmp_path / 'file1.root'
+    f1.touch()
     mock_cache = build_cache_mock(mocker, query_cache_return='123-455',
-                                  files=[('f1', 'file1.root')])
+                                  files=[('f1', f1)])
     mock_logger = mocker.MagicMock(spec=log_adaptor)
     mock_bomb = mocker.Mock(side_effect=RuntimeError('should not be called'))
     mock_servicex_adaptor = MockServiceXAdaptor(mocker, "XXX-XXX",
@@ -1433,14 +1435,16 @@ async def test_good_minio_factory_from_best(mocker):
 
 
 @pytest.mark.asyncio
-async def test_user_deleted_query_status_files(mocker):
+async def test_user_deleted_query_status_files(mocker, tmp_path: Path):
     '''
     1. User has made this query before, and everything was cached correctly
     2. User deletes the query status file only
     3. System should re-query the status and replace the file.
     '''
+    f1 = tmp_path / 'file1.root'
+    f1.touch()
     mock_cache = build_cache_mock(mocker, query_cache_return='123-455',
-                                  files=[('f1', 'file1.root')])
+                                  files=[('f1', f1)])
     mock_cache.query_status_exists.return_value = False
 
     mock_logger = mocker.MagicMock(spec=log_adaptor)

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -588,6 +588,8 @@ async def test_stream_bad_transform_run_root_files_from_minio(mocker):
             lst.append(f_info)
 
     assert 'Fatal Error' in str(e.value)
+    # Make sure there is no cache entry for this fatal error. (see #189)
+    assert mock_cache.remove_query.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -1273,6 +1275,8 @@ async def test_good_run_root_bad_DID(mocker):
         await ds.get_data_rootfiles_async('(valid qastle string)')
 
     assert 'DID Not found mc15' in str(e.value)
+    # Make sure the query is not cached (see #189)
+    assert mock_cache.remove_query.call_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1126,8 +1126,9 @@ async def test_servicex_gone_when_redownload_request(mocker, short_status_poll_t
     2. The files are not yet all in the cache.
     3. We call to get the status, and there is a "not known" error.
     4. The query in the cache should have been removed.
+    5. The query is called again.
+    6. A "too many exceptions" occurs and we return with the crash.
 
-    This will force the system to re-start the query next time it is called.
     '''
     mock_cache = build_cache_mock(mocker, query_cache_return='123-456')
     mock_logger = mocker.MagicMock(spec=log_adaptor)
@@ -1151,7 +1152,7 @@ async def test_servicex_gone_when_redownload_request(mocker, short_status_poll_t
     assert 'resubmit' in str(e.value)
 
     mock_cache.set_query.assert_not_called()
-    mock_cache.remove_query.assert_called_once()
+    assert mock_cache.remove_query.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -608,3 +608,39 @@ async def test_async_itr_exception_not_first():
 
     assert count == 1
     assert 'hi' in str(e)
+
+
+@pytest.mark.asyncio()
+async def test_async_itr_exception_all():
+    count = 0
+
+    @on_exception_itr(backoff.constant, ValueError, interval=0.01, max_tries=2)
+    async def return_two():
+        nonlocal count
+        count = count + 1
+        raise ValueError('hi')
+        yield 1
+
+    with pytest.raises(ValueError) as e:
+        [item async for item in return_two()]
+
+    assert count == 2
+    assert 'hi' in str(e)
+
+
+@pytest.mark.asyncio()
+async def test_async_itr_exception_all_wait_iter():
+    count = 0
+
+    @on_exception_itr(backoff.constant, ValueError, interval=0.01, max_tries=2)
+    async def return_two():
+        nonlocal count
+        count = count + 1
+        raise ValueError('hi')
+        yield 1
+
+    with pytest.raises(ValueError) as e:
+        [item async for item in return_two()]
+
+    assert count == 2
+    assert 'hi' in str(e)


### PR DESCRIPTION
* If SX knows about the transform, but minio does not, trigger new request
* If the streaming url hits an exception before getting any files, enable a new request
* If there is a fatal transform error, keep cache empty so it can be easily re-run
* If the user deletes a data file from the cache, automatically re-download it.
* When a lot of errors come back from ServiceX, only dump the first 20
* Added info logging messages to help track when we are downloading files

The second was actually supposed to have been working previously, but due to how async iterators work, it was not.

Fixes #86
Fixes #189
Fixes #193 
Fixes #188
Works on #187