### PR TITLE
Better management of endpoints and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,16 @@ The API access information is normally placed in a configuration file (see the s
 
 ```yaml
 api_endpoints:
-  - endpoint: <your-endpoint>
+  - name: <your-endpoint-name>
+    endpoint: <your-endpoint>
     token: <api-token>
     type: xaod
+    
 ```
 
 All strings are expanded using python's [os.path.expand](https://docs.python.org/3/library/os.path.html#os.path.expandvars) method - so `$NAME` and `${NAME}` will work to expand existing environment variables.
 
-You can list multiple end points by repeating the block of 4 dictionary items, but using a different type. For example, `uproot`.
+You can list multiple end points by repeating the block of dictionary items, but using a different name.
 
 Finally, you can create the objects `ServiceXAdaptor` and `MinioAdaptor` by hand in your code, passing them as arguments to `ServiceXDataset` and inject custom endpoints and credentials, avoiding the configuration system. This is probably only useful for advanced users.
 
@@ -212,7 +214,7 @@ Everything is based around the `ServiceXDataset` object. Below is the documentat
 
 ```python
   ServiceXDataset(dataset: str,
-                 backend_type: Optional[str] = None,
+                 backend_name: Optional[str] = None,
                  image: str = 'sslhep/servicex_func_adl_xaod_transformer:v0.4',
                  max_workers: int = 20,
                  servicex_adaptor: ServiceXAdaptor = None,
@@ -228,7 +230,7 @@ Everything is based around the `ServiceXDataset` object. Below is the documentat
       Arguments
 
           dataset                     Name of a dataset from which queries will be selected.
-          backend_type                The type of backend. Used only if we need to find an
+          backend_name                The type of backend. Used only if we need to find an
                                       end-point. If we do not have a `servicex_adaptor` then this
                                       will default to xaod, unless you have any endpoint listed
                                       in your servicex file. It will default to best match there,

--- a/scripts/run_test.py
+++ b/scripts/run_test.py
@@ -14,7 +14,7 @@ from servicex.servicex_adaptor import ServiceXAdaptor
 async def run_query(endpoint: Optional[ServiceXAdaptor], dest: str) -> None:
     ds = ServiceXDataset(
         "mc16_13TeV:mc16_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.deriv.DAOD_STDM3.e3601_e5984_s3126_r10201_r10210_p3975_tid20425969_00",  # NOQA
-        backend_type='xaod',
+        backend_name='xaod',
         max_workers=100,
         servicex_adaptor=endpoint)
 

--- a/servicex/config_default.yaml
+++ b/servicex/config_default.yaml
@@ -3,6 +3,8 @@
 
 api_endpoints:
   - endpoint: http://localhost:5000
+    name: default
+    type: xaod
     # token: xxx
 
 # This is the path of the cache. The "/tmp" will be translated, platform appropriate, and

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -140,7 +140,7 @@ class ServiceXDataset(ServiceXABC):
     '''
     def __init__(self,
                  dataset: DatasetType,
-                 backend_type: Optional[str] = None,
+                 backend_name: Optional[str] = None,
                  image: str = None,
                  max_workers: int = 20,
                  servicex_adaptor: ServiceXAdaptor = None,
@@ -158,7 +158,7 @@ class ServiceXDataset(ServiceXABC):
         Arguments
 
             dataset                     Name of a dataset from which queries will be selected.
-            backend_type                The type of backend. Used only if we need to find an
+            backend_name                The type of backend. Used only if we need to find an
                                         end-point. If we do not have a `servicex_adaptor` then this
                                         will default to xaod, unless you have any endpoint listed
                                         in your servicex file. It will default to best match there,
@@ -217,7 +217,7 @@ class ServiceXDataset(ServiceXABC):
 
         if not servicex_adaptor:
             # Given servicex adaptor is none, this should be ok. Fixes type checkers
-            end_point, token = config.get_servicex_adaptor_config(backend_type)
+            end_point, token = config.get_servicex_adaptor_config(backend_name)
             servicex_adaptor = ServiceXAdaptor(end_point, token)
         self._servicex_adaptor = servicex_adaptor
 
@@ -234,7 +234,7 @@ class ServiceXDataset(ServiceXABC):
         self._session_generator = session_generator if session_generator is not None \
             else default_client_session
 
-        self._return_types = [config.get_default_returned_datatype(backend_type)]
+        self._return_types = [config.get_default_returned_datatype(backend_name)]
         self._converter = data_convert_adaptor if data_convert_adaptor is not None \
             else DataConverterAdaptor(self._return_types[0])
 

--- a/servicex/servicex_config.py
+++ b/servicex/servicex_config.py
@@ -107,7 +107,12 @@ class ServiceXConfigAdaptor:
         # If we have a good name, look for exact match
         if backend_name is not None:
             for ep in endpoints:
-                if ep['type'].exists() and ep['type'].as_str_expanded() == backend_name:
+                if ep['name'].exists() and ep['name'].as_str_expanded() == backend_name:
+                    return extract_info(ep)
+            for ep in endpoints:
+                if ep['type'].exists() \
+                        and not ep['name'].exists() \
+                        and ep['type'].as_str_expanded() == backend_name:
                     return extract_info(ep)
 
         # See if one is unlabeled.

--- a/tests/test_servicex_config.py
+++ b/tests/test_servicex_config.py
@@ -159,7 +159,7 @@ def test_sx_adaptor_settings_backend_name_requested_with_unlabeled_type(caplog):
     assert endpoint == 'http://my-left-foot.com:5000'
     assert token == 'forkingshirtballs.thegoodplace.bortles'
 
-    assert caplog.record_tuples[0][2] == "No 'xaod' backend type found, " \
+    assert caplog.record_tuples[0][2] == "No 'xaod' backend name found, " \
                                          "using http://my-left-foot.com:5000 - please add to " \
                                          "the configuration file (e.g. servicex.yaml)"
 

--- a/tests/test_servicex_config.py
+++ b/tests/test_servicex_config.py
@@ -95,6 +95,73 @@ def test_sx_adaptor_settings(caplog):
     assert len(caplog.record_tuples) == 0
 
 
+def test_sx_adaptor_settings_name(caplog):
+    from confuse import Configuration
+    c = Configuration('bogus', 'bogus')
+    c.clear()
+    c['api_endpoints'] = [
+        {
+            'type': 'my-type',
+            'name': 'my-fork',
+            'endpoint': 'http://my-left-foot.com:5000',
+            'token': 'forkingshirtballs.thegoodplace.bortles'
+        }
+    ]
+    x = ServiceXConfigAdaptor(c)
+    endpoint, token = x.get_servicex_adaptor_config('my-fork')
+
+    assert endpoint == 'http://my-left-foot.com:5000'
+    assert token == 'forkingshirtballs.thegoodplace.bortles'
+
+    assert len(caplog.record_tuples) == 0
+
+
+def test_sx_adaptor_settings_name_not_type(caplog):
+    from confuse import Configuration
+    c = Configuration('bogus', 'bogus')
+    c.clear()
+    c['api_endpoints'] = [
+        {
+            'type': 'my-type1',
+            'name': 'my-fork1',
+            'endpoint': 'http://my-left-foot1.com:5000',
+            'token': 'forkingshirtballs.thegoodplace.bortles'
+        },
+        {
+            'type': 'my-type2',
+            'name': 'my-type1',
+            'endpoint': 'http://my-left-foot2.com:5000',
+            'token': 'forkingshirtballs.thegoodplace.bortles'
+        },
+    ]
+    x = ServiceXConfigAdaptor(c)
+    endpoint, token = x.get_servicex_adaptor_config('my-type1')
+
+    assert endpoint == 'http://my-left-foot2.com:5000'
+    assert token == 'forkingshirtballs.thegoodplace.bortles'
+
+    assert len(caplog.record_tuples) == 0
+
+
+def test_sx_adaptor_settings_name_worng(caplog):
+    from confuse import Configuration
+    c = Configuration('bogus', 'bogus')
+    c.clear()
+    c['api_endpoints'] = [
+        {
+            'type': 'my-type',
+            'name': 'my-fork',
+            'endpoint': 'http://my-left-foot.com:5000',
+            'token': 'forkingshirtballs.thegoodplace.bortles'
+        }
+    ]
+    x = ServiceXConfigAdaptor(c)
+    with pytest.raises(ServiceXException) as e:
+        x.get_servicex_adaptor_config('my-type')
+
+    assert 'Unable to find type my-type' in str(e)
+
+
 def test_sx_adaptor_settings_no_backend_name_requested(caplog):
     'Request None for a backend name'
     from confuse import Configuration


### PR DESCRIPTION
Will now look for a name in the `api_endpoint` rather than just a `type` when doing the lookup.

Fixes #194