### PR TITLE
Implement an Analysis Cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,35 @@ on:
   - cron:  '1 0 * * *'
 
 jobs:
+  flake8:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@master
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+    - name: Install dependencies
+      env:
+        servicex_version: 1.0a1
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install --no-cache-dir -e .[test]
+        pip list
+    - name: Lint with Flake8
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        flake8 --exclude=tests/* --ignore=E501,W503
+    - name: Check for vulnerable libraries
+      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+      run: |
+        pip install safety
+        pip freeze | safety check
+
   test:
+    needs:
+      - flake8
 
     strategy:
       matrix:
@@ -29,15 +57,6 @@ jobs:
         python -m pip install --upgrade pip setuptools wheel
         pip install --no-cache-dir -e .[test]
         pip list
-    - name: Lint with Flake8
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      run: |
-        flake8 --exclude=tests/* --ignore=E501,W503
-    - name: Check for vulnerable libraries
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      run: |
-        pip install safety
-        pip freeze | safety check
     - name: Test with pytest
       run: |
         python -m pytest

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ do_query(ds)  # Cache is not ignored
 The `servicex` library can write out a local file which will map queries to backend `request-id`'s. This file can then be used on other machines to reference the same data in the backend. The advantage is that the backend does not need to re-run the query - the `servicex` library need only download it again. When a user uses multiple machines or shares analysis code with an analysis team, this is a much more efficient use of resources.
 
 - By default the library looks for a file `servicex_query_cache.json` in the current working directory, or a parent directory
-- To trigger the creation and updating of a cache file call the function `update_local_query_cache()`. If you like you can pass in a filename. By default it will use `servicex_query_cache.json` in the local directory. The file will be both used for look-ups and will be updated with all subsequent queries.
+- To trigger the creation and updating of a cache file call the function `update_local_query_cache()`. If you like you can pass in a filename/path. By default it will use `servicex_query_cache.json` in the local directory. The file will be both used for look-ups and will be updated with all subsequent queries.
 
 In many cases a user will have multiple machines or analysis facilities. Being able to share this cache accross machines will have the same benifits. In the config file one can specify a directory. If this is then shared by dropbox, or OneDrive, or gDrive, or CERNBox, then the query cache files inside it can be picked up and used on other machines (or team members). See the config section below to specify a common directory.
 

--- a/README.md
+++ b/README.md
@@ -142,25 +142,25 @@ with ds.ignore_cache():
 do_query(ds)  # Cache is not ignored
 ```
 
-#### Analysis And Machine Query Cache
+#### Analysis And Query Cache
 
-The `servicex` library can write out a local file which will map queries to backend `request-id`'s. This file can then be used on other machines to reference the same data in the backend. The advantage is that the backend does not need to re-run the query - the `servicex` library need only download it again. When a user uses multiple machines or shares analysis code with an analysis team, this is a much more efficient use of resources.
+The `servicex` library can write out a local file which will map queries to backend `request-id`'s. This file can then be used on other people, checked into repositories, etc., to reference the same data in the backend. The advantage is that the backend does not need to re-run the query - the `servicex` library need only download it again. When a user uses multiple machines or shares analysis code with an analysis team, this is a much more efficient use of resources.
 
-- By default the library looks for a file `servicex_query_cache.json` in the current working directory, or a parent directory
-- To trigger the creation and updating of a cache file call the function `update_local_query_cache()`. If you like you can pass in a filename/path. By default it will use `servicex_query_cache.json` in the local directory. The file will be both used for look-ups and will be updated with all subsequent queries.
+- By default the library looks for a file `servicex_query_cache.json` in the current working directory, or a parent directory of the current working directory.
+- To trigger the creation and updating of a cache file call the function `update_local_query_cache()`. If you like you can pass in a filename/path. By default it will use `servicex_query_cache.json` in the local directory. The file will be both used for look-ups and will be updated with all subsequent queries. Except under very special cases, it is suggested that one users the filename `servicex_query_cache.json`.
+- If that file is present when a query is run, it will attempt to download the data from the endpoint, only resubmitting the query if the endpoint doesn't know about the query. As long as the file `servicex_query_cache.json` is in the current working directory (or above), it will be picked up automatically: no need to call `update_local_query_cache()`.
 
-In many cases a user will have multiple machines or analysis facilities. Being able to share this cache accross machines will have the same benifits. In the config file one can specify a directory. If this is then shared by dropbox, or OneDrive, or gDrive, or CERNBox, then the query cache files inside it can be picked up and used on other machines (or team members). See the config section below to specify a common directory.
+The cache search order is as follows:
 
-- The local query cache is used first
-- If nothing is found there, then a search occurs for an analysis query cache
-- If nothing is found there, then the list of machine query cache directories is searched. And in there, they are searched in reverse date order (newst first).
-- If there is a list of machine query cache directories, this library will write out a machine file of any new queries it submits.
+- The analysis query cache is searched first.
+- If nothing is found there, then the local query cache is used next.
+- If nothing is found there, then the query is resubmitted.
 
 _Note_: Eventually the backends will contain automatic cache lookup and this feature will be much less useful as it will occur automatically, on the backend.
 
 #### Deleting Files from the local Data Cache
 
-It is not recommended to alter the cache. The software expects the cache to be in a certain state, and radomly altering it can lead to unexpected effects.
+It is not recommended to alter the cache. The software expects the cache to be in a certain state, and radomly altering it can lead to unexpected behavior.
 
 Besides telling the `servicex` library to ignore the cache in the above ways, you can also delete files from the local cache.
 The local cache directory is split up into sub-directories. Deleting files from each of the directories:

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ In many cases a user will have multiple machines or analysis facilities. Being a
 - The local query cache is used first
 - If nothing is found there, then a search occurs for an analysis query cache
 - If nothing is found there, then the list of machine query cache directories is searched. And in there, they are searched in reverse date order (newst first).
+- If there is a list of machine query cache directories, this library will write out a machine file of any new queries it submits.
 
 _Note_: Eventually the backends will contain automatic cache lookup and this feature will be much less useful as it will occur automatically, on the backend.
 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,6 @@ The file can contain an `api_endpoint` as mentioned earlier. In addition the oth
 
 - `backend_types` - a list of yaml dictionaries that contains some defaults for the backends. By default only the `return_data` is there, which for `xaod` is `root` and `uproot` is `parquet`. There is also a `cms_run1_aod` which returns `root`. Allows `servicex` to convert to `pandas.DataFrame` or `awkward` if requested by the user.
 
-- `machine_analysis_cache` - a list of directories on the local machine to search for query `request-id`'s (see the cache section above). The directories are search in order.
-
 All strings are expanded using python's [os.path.expand](https://docs.python.org/3/library/os.path.html#os.path.expandvars) method - so `$NAME` and `${NAME}` will work to expand existing environment variables.
 
 ## Features

--- a/README.md
+++ b/README.md
@@ -142,6 +142,21 @@ with ds.ignore_cache():
 do_query(ds)  # Cache is not ignored
 ```
 
+#### Analysis And Machine Query Cache
+
+The `servicex` library can write out a local file which will map queries to backend `request-id`'s. This file can then be used on other machines to reference the same data in the backend. The advantage is that the backend does not need to re-run the query - the `servicex` library need only download it again. When a user uses multiple machines or shares analysis code with an analysis team, this is a much more efficient use of resources.
+
+- By default the library looks for a file `servicex_query_cache.json` in the current working directory, or a parent directory
+- To trigger the creation and updating of a cache file call the function `update_local_query_cache()`. If you like you can pass in a filename. By default it will use `servicex_query_cache.json` in the local directory. The file will be both used for look-ups and will be updated with all subsequent queries.
+
+In many cases a user will have multiple machines or analysis facilities. Being able to share this cache accross machines will have the same benifits. In the config file one can specify a directory. If this is then shared by dropbox, or OneDrive, or gDrive, or CERNBox, then the query cache files inside it can be picked up and used on other machines (or team members). See the config section below to specify a common directory.
+
+- The local query cache is used first
+- If nothing is found there, then a search occurs for an analysis query cache
+- If nothing is found there, then the list of machine query cache directories is searched. And in there, they are searched in reverse date order (newst first).
+
+_Note_: Eventually the backends will contain automatic cache lookup and this feature will be much less useful as it will occur automatically, on the backend.
+
 #### Deleting Files from the local Data Cache
 
 It is not recommended to alter the cache. The software expects the cache to be in a certain state, and radomly altering it can lead to unexpected effects.
@@ -171,7 +186,9 @@ The file can contain an `api_endpoint` as mentioned earlier. In addition the oth
   - Windows: `cache_path: "C:\\Users\\gordo\\Desktop\\cacheme"`
   - Linux: `cache_path: "/home/servicex-cache"`
 
-- `backend_types` - a list of yaml dictionaries that contains some defaults for the backends. By default only the `return_data` is there, which for `xaod` is `root` and `uproot` is `parquet`. Allows `servicex` to convert to `pandas.DataFrame` or `awkward` if requested by the user.
+- `backend_types` - a list of yaml dictionaries that contains some defaults for the backends. By default only the `return_data` is there, which for `xaod` is `root` and `uproot` is `parquet`. There is also a `cms_run1_aod` which returns `root`. Allows `servicex` to convert to `pandas.DataFrame` or `awkward` if requested by the user.
+
+- `machine_analysis_cache` - a list of directories on the local machine to search for query `request-id`'s (see the cache section above). The directories are search in order.
 
 All strings are expanded using python's [os.path.expand](https://docs.python.org/3/library/os.path.html#os.path.expandvars) method - so `$NAME` and `${NAME}` will work to expand existing environment variables.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The following lines will return a `pandas.DataFrame` containing all the jet pT's
     from servicex import ServiceXDataset
     query = "(call ResultTTree (call Select (call SelectMany (call EventDataset (list 'localds:bogus')) (lambda (list e) (call (attr e 'Jets') 'AntiKt4EMTopoJets'))) (lambda (list j) (/ (call (attr j 'pt')) 1000.0))) (list 'JetPt') 'analysis' 'junk.root')"
     dataset = "mc15_13TeV:mc15_13TeV.361106.PowhegPythia8EvtGen_AZNLOCTEQ6L1_Zee.merge.DAOD_STDM3.e3601_s2576_s2132_r6630_r6264_p2363_tid05630052_00"
-    ds = ServiceXDataset(dataset)
+    ds = ServiceXDataset(dataset, backend_name=`xaod`)
     r = ds.get_data_pandas_df(query)
     print(r)
 ```
@@ -86,6 +86,8 @@ If your query is badly formed or there is an other problem with the backend, an 
 If you'd like to be able to submit multiple queries and have them run on the `ServiceX` back end in parallel, it is best to use the `asyncio` interface, which has the identical signature, but is called `get_data_pandas_df_async`.
 
 For documentation of `get_data` and `get_data_async` see the `servicex.py` source file.
+
+The `backend_name` tells the library where to look in the `servicex.yaml` configuraiton file to find an end point (url and authentication information). See above for more information.
 
 ### How to specify the input data
 

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -12,4 +12,4 @@ from .utils import (  # NOQA
 )
 from .servicex_adaptor import ServiceXAdaptor  # NOQA
 from .minio_adaptor import MinioAdaptor  # NOQA
-from .cache import Cache, ignore_cache  # NOQA
+from .cache import Cache, ignore_cache, update_local_query_cache  # NOQA

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -51,6 +51,9 @@ def ignore_cache():
 _g_analysis_cache_location: Optional[Path] = None
 _g_analysis_cache_filename: str = 'servicex_query_cache.json'
 
+# List of queries we know to be bad from this run
+_g_bad_query_cache_ids: set[str] = set()
+
 
 def reset_local_query_cache():
     '''Used to reset the analysis cache location. Normally called only
@@ -60,6 +63,8 @@ def reset_local_query_cache():
     _g_analysis_cache_location = None
     global _g_analysis_cache_filename
     _g_analysis_cache_filename = 'servicex_query_cache.json'
+    global _g_bad_query_cache_ids
+    _g_bad_query_cache_ids = set()
 
 
 reset_local_query_cache()
@@ -169,7 +174,10 @@ class Cache:
 
         f = self._query_cache_file(json)
         if not f.exists():
-            return self._lookup_analysis_query_cache(_query_cache_hash(json))
+            hash = _query_cache_hash(json)
+            if hash in _g_bad_query_cache_ids:
+                return None
+            return self._lookup_analysis_query_cache(hash)
 
         with f.open('r') as i:
             request_id = i.readline().strip()
@@ -194,6 +202,17 @@ class Cache:
 
         self._write_analysis_query_cache(json, v)
 
+    def remove_query(self, json: Dict[str, Any]):
+        '''Remove the query from our local and analysis caches
+
+        Args:
+            json (Dict[str, Any]): The query to remove
+        '''
+        f = self._query_cache_file(json)
+        if f.exists():
+            f.unlink()
+        self._remove_from_analysis_cache(_query_cache_hash(json))
+
     def _write_analysis_query_cache(self, query_info: Dict[str, str], request_id: str):
         '''Write out a local analysis query hash-request-id assocaition.
 
@@ -214,6 +233,23 @@ class Cache:
 
         with q_file.open('w') as output:
             json.dump(analysis_cache, output)
+
+    def _remove_from_analysis_cache(self, query_hash: str):
+        '''Remove an item from the analysis cache if we are writing to it!
+
+        Args:
+            query_hash (str): The hash we will remove
+        '''
+        if _g_analysis_cache_location is None:
+            _g_bad_query_cache_ids.add(query_hash)
+            return
+
+        cache_contents, cache_file = self._find_analysis_cached_query(query_hash)
+        if cache_contents is not None:
+            del cache_contents[query_hash]
+            assert cache_file is not None
+            with cache_file.open('w') as output:
+                json.dump(cache_contents, output)
 
     def _lookup_analysis_query_cache(self, query_hash: str,
                                      filename: Optional[str] = None,
@@ -238,6 +274,25 @@ class Cache:
         Returns:
             (Optional[str]): The return hash of what we need to look up
         '''
+        cache_contents, _ = self._find_analysis_cached_query(query_hash)
+        if cache_contents is not None:
+            return cache_contents[query_hash]
+        return None
+
+    def _find_analysis_cached_query(self, query_hash: str,
+                                    filename: Optional[str] = None,
+                                    location: Optional[Path] = None) \
+            -> Tuple[Optional[Dict[str, str]], Optional[Path]]:
+        '''Returns the contents of an analysis cache file and the file that contains
+        a query hash
+
+        Args:
+            has (str): The hash of the query we are to find
+
+        Returns:
+            Tuple[Dict[str, str], Path]: The contents of the file and the path to the
+            analysis cache that contains the hash. `None` if the query was not found
+        '''
         # Get arguments setup
         c_filename = filename if filename is not None else _g_analysis_cache_filename
         c_location = location if location is not None \
@@ -250,12 +305,12 @@ class Cache:
             with cache_file.open('r') as input:
                 analysis_cache = json.load(input)
                 if query_hash in analysis_cache:
-                    return analysis_cache[query_hash]
+                    return (analysis_cache, cache_file)
 
         # Recurse one up.
         if len(c_location.parts) <= 1:
-            return None
-        return self._lookup_analysis_query_cache(query_hash, c_filename, c_location.parent)
+            return None, None
+        return self._find_analysis_cached_query(query_hash, c_filename, c_location.parent)
 
     def set_query_status(self, query_info: Dict[str, str]):
         '''Cache a query status (json dict)
@@ -293,11 +348,6 @@ class Cache:
             bool: True if present, false otherwise.
         """
         return self._query_status_cache_file(request_id).exists()
-
-    def remove_query(self, json: Dict[str, Any]):
-        f = self._query_cache_file(json)
-        if f.exists():
-            f.unlink()
 
     def set_files(self, id: str, files: List[Tuple[str, Path]]):
         """Cache the files for this request

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -225,12 +225,13 @@ class Cache:
         If `location` is specified, check that directory.
         In both cases, if the query hash isn't found, then move up one directory and try again.
 
-        `filename` is the name of the file we should be looking for. If `None` default to the global.
+        `filename` is the name of the file we should be looking for. If `None` default to the
+        global.
 
         Args:
             query_hash (str): The hash of the query we need to lookup.
             filename (Optional[str]): The name fo the file that contains the cache. If not
-            specified then defaults to the global. 
+            specified then defaults to the global.
             location (Optional[Path]): Directory to start searching in. If not specified then
             defaults to the global. If that isn't specified, defaults to the current directory.
 

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -122,7 +122,7 @@ class Cache:
     _in_memory_cache = {}
 
     @classmethod
-    def reset_cache(cls):
+    def reset_cache(cls):  # # pragma: no cover
         'Reset the internal cache, usually used for testing'
         cls._in_memory_cache = {}
 
@@ -231,6 +231,8 @@ class Cache:
 
         analysis_cache[_query_cache_hash(query_info)] = request_id
 
+        if not q_file.parent.exists():
+            q_file.parent.mkdir()
         with q_file.open('w') as output:
             json.dump(analysis_cache, output)
 

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Set, Tuple
 
 from .utils import ServiceXException, _query_cache_hash, sanitize_filename
 
@@ -52,7 +52,7 @@ _g_analysis_cache_location: Optional[Path] = None
 _g_analysis_cache_filename: str = 'servicex_query_cache.json'
 
 # List of queries we know to be bad from this run
-_g_bad_query_cache_ids: set[str] = set()
+_g_bad_query_cache_ids: Set[str] = set()
 
 
 def reset_local_query_cache():

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -162,7 +162,7 @@ class ServiceXDataset(ServiceXABC):
                                         end-point. If we do not have a `servicex_adaptor` then this
                                         will default to xaod, unless you have any endpoint listed
                                         in your servicex file. It will default to best match there,
-                                        in that case.
+                                        or fail if a name has been given.
             image                       Name of transformer image to use to transform the data. If
                                         left as default, `None`, then the default image for the
                                         ServiceX backend will be used.

--- a/servicex/servicex_config.py
+++ b/servicex/servicex_config.py
@@ -124,14 +124,9 @@ class ServiceXConfigAdaptor:
         log = logging.getLogger(__name__)
         for ep in endpoints:
             if not ep['type'].exists():
-                if backend_name is None:
-                    log.warning('No backend type requested, '
-                                f'using {ep["endpoint"].as_str_expanded()} - please be explicit '
-                                'in the ServiceXDataset constructor')
-                else:
-                    log.warning(f"No '{backend_name}' backend name found, "
-                                f'using {ep["endpoint"].as_str_expanded()} - please add to '
-                                'the configuration file (e.g. servicex.yaml)')
+                log.warning('No backend type requested, '
+                            f'using {ep["endpoint"].as_str_expanded()} - please be explicit '
+                            'in the ServiceXDataset constructor')
                 return extract_info(ep)
 
         # Nope - now we are going to have to just use the first one there.

--- a/servicex/servicex_config.py
+++ b/servicex/servicex_config.py
@@ -114,6 +114,11 @@ class ServiceXConfigAdaptor:
                         and not ep['name'].exists() \
                         and ep['type'].as_str_expanded() == backend_name:
                     return extract_info(ep)
+            seen_types = [str(ep['type'].as_str_expanded()) for ep in endpoints
+                          if ep['type'].exists()]
+            raise ServiceXException(f'Unable to find type {backend_name} '
+                                    'in servicex.yaml configuration file. Saw only types'
+                                    f': {", ".join(seen_types)}')
 
         # See if one is unlabeled.
         log = logging.getLogger(__name__)
@@ -128,15 +133,6 @@ class ServiceXConfigAdaptor:
                                 f'using {ep["endpoint"].as_str_expanded()} - please add to '
                                 'the configuration file (e.g. servicex.yaml)')
                 return extract_info(ep)
-
-        if backend_name is not None:
-            # They have a labeled backend, and all the end-points are labeled. So that means
-            # there really is not match. So throw!
-            seen_types = [str(ep['type'].as_str_expanded()) for ep in endpoints
-                          if ep['type'].exists()]
-            raise ServiceXException(f'Unable to find type {backend_name} '
-                                    'in .servicex configuration file. Saw only types'
-                                    f': {", ".join(seen_types)}')
 
         # Nope - now we are going to have to just use the first one there.
         for ep in endpoints:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -58,7 +58,7 @@ def test_analysis_cache_set_twice_same(tmp_path: Path):
 
 
 def test_query_hit_analysis_cache(tmp_path: Path):
-    'Make sure that we write something sensible to the analysis path'
+    'Make sure the analysis cache is updated'
     cache_loc_1 = tmp_path / 'cache1'
     cache_loc_2 = tmp_path / 'cache2'
 
@@ -72,7 +72,7 @@ def test_query_hit_analysis_cache(tmp_path: Path):
 
 
 def test_query_hit_analysis_cache_silent_read(tmp_path: Path):
-    'Make sure that we write something sensible to the analysis path'
+    'Make sure we read the analysis cache if it happens to be present'
     cache_loc_1 = tmp_path / 'cache1'
     cache_loc_2 = tmp_path / 'cache2'
 
@@ -88,7 +88,7 @@ def test_query_hit_analysis_cache_silent_read(tmp_path: Path):
 
 
 def test_query_hit_analysis_cache_not_triggered(tmp_path: Path):
-    'Make sure that we write something sensible to the analysis path'
+    'Make sure analysis cache is not written by default'
     cache_loc_1 = tmp_path / 'cache1'
     cache_loc_2 = tmp_path / 'cache2'
 
@@ -100,7 +100,7 @@ def test_query_hit_analysis_cache_not_triggered(tmp_path: Path):
 
 
 def test_query_hit_analysis_lookup_writes(tmp_path: Path):
-    'Make sure that we write something sensible to the analysis path'
+    'make sure analysis query cache is written to'
     cache_loc_1 = tmp_path / 'cache1'
     cache_loc_2 = tmp_path / 'cache2'
 
@@ -111,6 +111,47 @@ def test_query_hit_analysis_lookup_writes(tmp_path: Path):
 
     c2 = Cache(cache_loc_2)
     assert c2.lookup_query({'hi': 'there'}) == 'dude'
+
+
+def test_query_hit_analysis_cache_removed_query_noupdate(tmp_path: Path):
+    'Make sure to forget a query when we are not updating the analysis cache'
+    cache_loc_1 = tmp_path / 'cache1'
+    cache_loc_2 = tmp_path / 'cache2'
+    cache_loc_3 = tmp_path / 'cache3'
+
+    update_local_query_cache()
+
+    c1 = Cache(cache_loc_1)
+    c1.set_query({'hi': 'there'}, 'dude')
+
+    reset_local_query_cache()
+
+    c2 = Cache(cache_loc_2)
+    c2.remove_query({'hi': 'there'})
+    assert c2.lookup_query({'hi': 'there'}) is None
+
+    reset_local_query_cache()
+
+    # Make sure that the json file wasn't modified in this case!
+    c3 = Cache(cache_loc_3)
+    assert c3.lookup_query({'hi': 'there'}) == 'dude'
+
+
+def test_query_hit_analysis_cache_removed_query_update(tmp_path: Path):
+    'If we are updating the query cache, make sure to remove an item'
+    cache_loc_1 = tmp_path / 'cache1'
+    cache_loc_2 = tmp_path / 'cache2'
+
+    update_local_query_cache()
+
+    c1 = Cache(cache_loc_1)
+    c1.set_query({'hi': 'there'}, 'dude')
+    c1.remove_query({'hi': 'there'})
+
+    reset_local_query_cache()
+
+    c2 = Cache(cache_loc_2)
+    assert c2.lookup_query({'hi': 'there'}) is None
 
 
 def test_ic_query(tmp_path):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,21 +11,21 @@ from servicex import (Cache, ServiceXException, ignore_cache,
 @pytest.fixture()
 def reset_in_memory_cache():
     Cache.reset_cache()
-    cf = Path('./servicex_query_cache.json')
-    if cf.exists():
-        cf.unlink()
     yield
     Cache.reset_cache()
-    if cf.exists():
-        cf.unlink()
 
 
 @pytest.fixture(autouse=True)
 def analysis_query_cache_reset():
     'Want to make sure the local query cache is reset for everything!'
     reset_local_query_cache()
+    cf = Path('./servicex_query_cache.json')
+    if cf.exists():
+        cf.unlink()
     yield
     reset_local_query_cache()
+    if cf.exists():
+        cf.unlink()
 
 
 def test_create_cache(tmp_path):
@@ -96,7 +96,7 @@ def test_query_hit_analysis_cache_not_triggered(tmp_path: Path):
     c1.set_query({'hi': 'there'}, 'dude')
 
     c2 = Cache(cache_loc_2)
-    assert c2.lookup_query({'hi': 'there'}) == None
+    assert c2.lookup_query({'hi': 'there'}) is None
 
 
 def test_query_hit_analysis_lookup_writes(tmp_path: Path):

--- a/tests/test_servicex_config.py
+++ b/tests/test_servicex_config.py
@@ -221,14 +221,10 @@ def test_sx_adaptor_settings_backend_name_requested_with_unlabeled_type(caplog):
         }
     ]
     x = ServiceXConfigAdaptor(c)
-    endpoint, token = x.get_servicex_adaptor_config('xaod')
+    with pytest.raises(ServiceXException) as e:
+        _ = x.get_servicex_adaptor_config('xaod')
 
-    assert endpoint == 'http://my-left-foot.com:5000'
-    assert token == 'forkingshirtballs.thegoodplace.bortles'
-
-    assert caplog.record_tuples[0][2] == "No 'xaod' backend name found, " \
-                                         "using http://my-left-foot.com:5000 - please add to " \
-                                         "the configuration file (e.g. servicex.yaml)"
+    assert 'Unable to find' in str(e)
 
 
 def test_sx_adaptor_settings_backend_name_requested_after_labeled_type(caplog):


### PR DESCRIPTION
* If there is an analysis cache json file present, include it in the query cache resolution.
* Make it possible to write out an analysis cache automatically while running
* Remove bad queries automatically from an analysis cache
* Makes it possible to distribute the same data used by multiple poeple, easily.
* flake8 now runs initially in the CI, and then everything else runs
* Update documentation
* Make for a hard crash when we ask for a backend by name and we don't know about it. This is to help avoid accidentally marking analysis cache entries bad.

Fixes #172