### PR TITLE
Fix backend default datatype resoluiton

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,31 +4,49 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Install Package",
-            "type": "shell",
-            "command": "${config:python.pythonPath}",
-            "args": ["-m", "pip", "install", "-e", "."],
-            "problemMatcher": []
-        },
-        {
-            "label": "Create Wheel",
-            "type": "shell",
-            "command": "${config:python.pythonPath}",
-            "args": ["-m", "pip", "wheel", "."],
-            "problemMatcher": []
-        },
-        {
-            "label": "Upload to pypi",
-            "type": "shell",
-            "command": "powershell",
-            "args": ["-Command", "& .vscode/push-to-pypi.ps1"],
-            "problemMatcher": []
-        },
-        {
             "label": "Run Code Coverage",
             "type": "shell",
             "command": ". .venv/scripts/activate.ps1 ; coverage-3.9.exe run -m pytest",
             "problemMatcher": []
-        }
+        },
+        {
+            // That the name of task
+            "label": "flake8-whole-project",
+            // We are going to execute shell command in this task
+            "type": "shell",
+            // Actual command to execute
+            "command": ". .venv/scripts/activate.ps1 ; flake8 servicex ; flake8 tests",
+            // How command output will be presented - in overall, we want it to be silent
+            "presentation": {
+              "echo": true,
+              "reveal": "never",
+              "focus": false,
+              "panel": "shared",
+              "showReuseMessage": false,
+              "clear": true,
+              "revealProblems": "never"
+            },
+            // Definition of problem matcher - which will translate problems reported in
+            // command line by flake8 to entries in PROBLEMS tab
+            "problemMatcher": {
+              // Name of owner which will handle found problems
+              "owner": "flake8",
+              // Name of problem matcher which will show next to problem in PROBLEMS tab
+              "source": "flake8-whole-project",
+              // How paths to files with found problems, should be interpreted by problem matcher
+              "fileLocation": ["relative", "${workspaceFolder}"],
+              "pattern": {
+                // Regular expression used to match found problems
+                // For details, see https://regex101.com/r/JXYDAE/1
+                "regexp": "^(.+):(\\d+):(\\d+): ((\\w)\\d+) (.+)$",
+                "file": 1,
+                "line": 2,
+                "column": 3,
+                "code": 4,
+                "severity": 5,
+                "message": 6
+              },
+            },
+        },
     ]
 }

--- a/servicex/servicex_config.py
+++ b/servicex/servicex_config.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Tuple, cast
+from typing import Dict, Optional, Tuple
 
 from confuse.core import ConfigView
 
@@ -44,20 +44,17 @@ class ServiceXConfigAdaptor:
             str: The backend datatype, like `root` or `parquet`.
         '''
         # Check to see if we know about the backend info
-        if backend_name is not None:
-            info = self.get_backend_info(backend_name, 'return_data')
-            if info is not None:
-                return info
+        r = self.get_backend_info(backend_name, 'return_data')
 
-        if self._settings['default_return_data'].exists():
-            return cast(str, self._settings['default_return_data'].as_str_expanded())
+        if r is None:
+            raise ServiceXException('A default default_return_data is missing from config files '
+                                    '- is servicex installed correctly?')
 
-        raise ServiceXException('A default default_return_data is missing from config files - is '
-                                'servicex installed correctly?')
+        return r
 
-    def get_backend_info(self, backend_name: str, key: str) -> Optional[str]:
-        '''Find an item in the backend info, searching first the backend settings and then
-           searching the defaults.
+    def get_backend_info(self, backend_name: Optional[str], key: str) -> Optional[str]:
+        '''Find an item in the backend info, searching first for the backend
+        name/type and then the defaults with a given type.
 
         Args:
             backend_name (str): Backend name
@@ -67,23 +64,103 @@ class ServiceXConfigAdaptor:
             Optional[str]: Return a string for the info we are after, or return None if we can't
                            find it.
         '''
+        config = self._get_backend_info(backend_name)
+        return config[key] if key in config else None
 
-        def find_in_list(c, key) -> Optional[str]:
-            if c.exists():
-                for ep in c:
-                    if ep['type'].exists():
-                        if ep['type'].as_str() == backend_name:
-                            if key in ep:
-                                return ep[key].as_str_expanded()
-            return None
+    def _get_backend_info(self, backend_name: Optional[str]) -> Dict[str, str]:
+        '''Returns all the info for a backend name/type.
 
-        a = find_in_list(self._settings['api_endpoints'], key)
-        a = find_in_list(self._settings['backend_types'], key) if a is None else a
-        return a
+        Search algoirthm is non-trivial:
+        1. If `backend_name` is not `None`:
+           1. Look at the `api_endpoints` for a `name` matching `backend_name`.
+           2. Look at the `api_endpoints` for a `type` matching `backend_name`,
+              complain that `name` wasn't present.
+           3. Fail if nothing matches
+        2. If `backend_name` is None:
+           1. Use the first end point in the list, and complain.
+
+        Given the above is done, then look at `backend_types` for a matching `type`,
+        and for any key found there not already present, add it, and return the dictionary.
+
+        Args:
+            backend_name (str): Name or type of the api end point we are going to look up.
+
+        Returns:
+            Dict[str, str]: Attributes for this backend's configuration
+        '''
+        # Find a list of all endpoints.
+        # It is an error if this is not specified somewhere.
+        endpoints = self.settings['api_endpoints']
+
+        # If we have a good name, look for exact match
+        config: Optional[Dict[str, str]] = None
+        log = logging.getLogger(__name__)
+        if backend_name is not None:
+            # Search the list of end points for a matching name
+            for ep in endpoints:
+                if ep['name'].exists() and ep['name'].as_str_expanded() == backend_name:
+                    config = {k: str(ep[k].as_str_expanded()) for k in ep.keys()}
+                    break
+            if config is None:
+                for ep in endpoints:
+                    if ep['type'].exists() \
+                            and ep['type'].as_str_expanded() == backend_name:
+                        config = {k: str(ep[k].as_str_expanded()) for k in ep.keys()}
+                        log.warning(f'Found backend type matching "{backend_name}". Matching by '
+                                    'type is depreciated. Please switch to using the "name" '
+                                    'keyword in your servicex.yaml file.')
+                        break
+            if config is None:
+                # They asked for something explicit, we couldn't find it, so we need to bomb.
+                # Given how annoying this is, build a useful error message.
+                seen_types = [str(ep['type'].as_str_expanded()) for ep in endpoints
+                              if ep['type'].exists()]
+                seen_names = [str(ep['name'].as_str_expanded()) for ep in endpoints
+                              if ep['name'].exists()]
+
+                raise ServiceXException(f'Unable to find name/type {backend_name} '
+                                        'in api_endpoints in servicex.yaml configuration file. Saw'
+                                        f' only names ({", ".join(seen_names)}) and types '
+                                        f'({", ".join(seen_types)})')
+
+        # Nope - now we are going to have to just use the first one there.
+        else:
+            for ep in endpoints:
+                log.warning('No backend name/type requested, '
+                            f'using {ep["endpoint"].as_str_expanded()} - please be explicit '
+                            'in the ServiceXDataset constructor')
+                config = {k: str(ep[k].as_str_expanded()) for k in ep.keys()}
+                break
+
+        if config is None:
+            # If we are here - then... it just isn't going to work!
+            raise ServiceXException('Not even a default set of configurations are here! Bad '
+                                    ' install of the servicex package!')
+
+        # Now, extract the type and see if we can figure out any defaults from the
+        # `backend_types` info.
+        type_lookup = config['type'] if 'type' in config else backend_name
+        if type_lookup is None:
+            return config
+
+        backend_defaults = self.settings['backend_types']
+        for bd in backend_defaults:
+            if bd['type'].as_str_expanded() == type_lookup:
+                for k in bd.keys():
+                    if k not in config:
+                        config[k] = str(bd[k].as_str_expanded())
+
+        # Finally, a default return type
+        if 'return_data' not in config:
+            if 'default_return_data' in self.settings.keys():
+                config['return_data'] = \
+                    str(self.settings['default_return_data'].as_str_expanded())
+
+        return config
 
     def get_servicex_adaptor_config(self, backend_name: Optional[str] = None) -> \
             Tuple[str, Optional[str]]:
-        '''Return the servicex (endpoint, username, email) from a given backend configuration.
+        '''Return the servicex (endpoint, token) from a given backend configuration.
 
         Args:
             backend_name (str): The backend name (like `xaod`) which we hopefully can find in the
@@ -93,49 +170,10 @@ class ServiceXConfigAdaptor:
             Tuple[str, str]: The tuple of info to create a `ServiceXAdaptor`: end point,
             token (optionally).
         '''
-        # Find a list of all endpoints.
-        # It is an error if this is not specified somewhere.
-        endpoints = self._settings['api_endpoints']
+        config = self._get_backend_info(backend_name)
 
-        def extract_info(ep) -> Tuple[str, Optional[str]]:
-            endpoint = ep['endpoint'].as_str_expanded()
-            token = ep['token'].as_str_expanded() if 'token' in ep else None
+        endpoint = config['endpoint']
+        token = config['token'] if 'token' in config else None
 
-            # We can default these to "None"
-            return (endpoint, token)  # type: ignore
-
-        # If we have a good name, look for exact match
-        if backend_name is not None:
-            for ep in endpoints:
-                if ep['name'].exists() and ep['name'].as_str_expanded() == backend_name:
-                    return extract_info(ep)
-            for ep in endpoints:
-                if ep['type'].exists() \
-                        and not ep['name'].exists() \
-                        and ep['type'].as_str_expanded() == backend_name:
-                    return extract_info(ep)
-            seen_types = [str(ep['type'].as_str_expanded()) for ep in endpoints
-                          if ep['type'].exists()]
-            raise ServiceXException(f'Unable to find type {backend_name} '
-                                    'in servicex.yaml configuration file. Saw only types'
-                                    f': {", ".join(seen_types)}')
-
-        # See if one is unlabeled.
-        log = logging.getLogger(__name__)
-        for ep in endpoints:
-            if not ep['type'].exists():
-                log.warning('No backend type requested, '
-                            f'using {ep["endpoint"].as_str_expanded()} - please be explicit '
-                            'in the ServiceXDataset constructor')
-                return extract_info(ep)
-
-        # Nope - now we are going to have to just use the first one there.
-        for ep in endpoints:
-            log.warning('No backend type requested, '
-                        f'using {ep["endpoint"].as_str_expanded()} - please be explicit '
-                        'in the ServiceXDataset constructor')
-            return extract_info(ep)
-
-        # If we are here - then... it just isn't going to work!
-        raise ServiceXException('Not even a default set of configurations are here! Bad install '
-                                ' of the servicex package!')
+        # We can default these to "None"
+        return (endpoint, token)  # type: ignore

--- a/tests/test_servicex_config.py
+++ b/tests/test_servicex_config.py
@@ -33,6 +33,18 @@ def test_returned_datatype_default():
     assert x.get_default_returned_datatype(None) == 'root'
 
 
+def test_returned_datatype_default_missing():
+    c = ConfigSettings('servicex', 'servicex')
+    c.clear()
+    c['api_endpoints'] = [{'endpoint': 'http://bork', 'type': 'forkit'}]
+    x = ServiceXConfigAdaptor(c)
+
+    with pytest.raises(ServiceXException) as e:
+        x.get_default_returned_datatype(None)
+
+    assert 'default_return_data' in str(e)
+
+
 def test_returned_datatype_from_default_dict():
     c = ConfigSettings('servicex', 'servicex')
     c.clear()

--- a/tests/test_servicex_config.py
+++ b/tests/test_servicex_config.py
@@ -28,6 +28,7 @@ def test_returned_datatype_default():
     c = ConfigSettings('servicex', 'servicex')
     c.clear()
     c['default_return_data'] = 'root'
+    c['api_endpoints'] = [{'endpoint': 'http://bork', 'type': 'forkit'}]
     x = ServiceXConfigAdaptor(c)
     assert x.get_default_returned_datatype(None) == 'root'
 
@@ -35,6 +36,7 @@ def test_returned_datatype_default():
 def test_returned_datatype_from_default_dict():
     c = ConfigSettings('servicex', 'servicex')
     c.clear()
+    c['api_endpoints'] = [{'endpoint': 'http://bork', 'type': 'forkit'}]
     c['backend_types'] = [{'type': 'forkit', 'return_data': 'spoon'}]
     x = ServiceXConfigAdaptor(c)
     assert x.get_default_returned_datatype('forkit') == 'spoon'
@@ -49,13 +51,6 @@ def test_returned_datatype_from_endpoint():
     assert x.get_default_returned_datatype('forkit') == 'spoons'
 
 
-def test_returned_datatype_no_type_endpoint():
-    c = ConfigSettings('servicex', 'servicex')
-    c.clear()
-    c['backend_types'] = [{'type': 'forkit', 'return_data': 'spoon'}]
-    c['api_endpoints'] = [{'endpoint': 'http://localhost:5000'}]
-    x = ServiceXConfigAdaptor(c)
-    assert x.get_default_returned_datatype('forkit') == 'spoon'
 
 
 def test_defalt_config_has_default_return_datatype():
@@ -92,7 +87,7 @@ def test_sx_adaptor_settings(caplog):
     assert endpoint == 'http://my-left-foot.com:5000'
     assert token == 'forkingshirtballs.thegoodplace.bortles'
 
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == 1  # Depreciation warning
 
 
 def test_sx_adaptor_settings_name(caplog):
@@ -156,10 +151,9 @@ def test_sx_adaptor_settings_name_worng(caplog):
         }
     ]
     x = ServiceXConfigAdaptor(c)
-    with pytest.raises(ServiceXException) as e:
-        x.get_servicex_adaptor_config('my-type')
+    endpoint, token = x.get_servicex_adaptor_config('my-type')
 
-    assert 'Unable to find type my-type' in str(e)
+    assert len(caplog.record_tuples) == 1  # Depreciation warning for using match by type
 
 
 def test_sx_adaptor_settings_no_backend_name_requested(caplog):
@@ -180,7 +174,7 @@ def test_sx_adaptor_settings_no_backend_name_requested(caplog):
     assert endpoint == 'http://my-left-foot.com:5000'
     assert token == 'forkingshirtballs.thegoodplace.bortles'
 
-    assert caplog.record_tuples[0][2] == "No backend type requested, " \
+    assert caplog.record_tuples[0][2] == "No backend name/type requested, " \
                                          "using http://my-left-foot.com:5000 - please be " \
                                          "explicit " \
                                          "in the ServiceXDataset constructor"
@@ -203,7 +197,7 @@ def test_sx_adaptor_settings_no_backend_name_requested_or_listed(caplog):
     assert endpoint == 'http://my-left-foot.com:5000'
     assert token == 'forkingshirtballs.thegoodplace.bortles'
 
-    assert caplog.record_tuples[0][2] == "No backend type requested, " \
+    assert caplog.record_tuples[0][2] == "No backend name/type requested, " \
                                          "using http://my-left-foot.com:5000 - please be " \
                                          "explicit " \
                                          "in the ServiceXDataset constructor"
@@ -249,10 +243,10 @@ def test_sx_adaptor_settings_backend_name_requested_after_labeled_type(caplog):
     assert endpoint == 'http://my-left-foot.com:5001'
     assert token == 'forkingshirtballs.thegoodplace.bortles1'
 
-    assert len(caplog.record_tuples) == 0
+    assert len(caplog.record_tuples) == 1  # Depreciation warning for using type
 
 
-def test_sx_adaptor_settings_backend_name_unlabeled_type():
+def test_sx_adaptor_settings_backend_name_use_first():
     'Request None for a backend name'
     from confuse import Configuration
     c = Configuration('bogus', 'bogus')
@@ -271,8 +265,8 @@ def test_sx_adaptor_settings_backend_name_unlabeled_type():
     x = ServiceXConfigAdaptor(c)
     endpoint, token = x.get_servicex_adaptor_config()
 
-    assert endpoint == 'http://my-left-foot.com:5001'
-    assert token == 'forkingshirtballs.thegoodplace.bortles1'
+    assert endpoint == 'http://my-left-foot.com:5000'
+    assert token == 'forkingshirtballs.thegoodplace.bortles'
 
 
 def test_sx_adaptor_settings_wrong_type():
@@ -291,7 +285,7 @@ def test_sx_adaptor_settings_wrong_type():
     with pytest.raises(ServiceXException) as e:
         x.get_servicex_adaptor_config('your-type')
 
-    assert 'Unable to find type' in str(e.value)
+    assert 'Unable to find name/type' in str(e.value)
     assert 'my-type' in str(e.value)
 
 

--- a/tests/test_servicex_config.py
+++ b/tests/test_servicex_config.py
@@ -51,8 +51,6 @@ def test_returned_datatype_from_endpoint():
     assert x.get_default_returned_datatype('forkit') == 'spoons'
 
 
-
-
 def test_defalt_config_has_default_return_datatype():
     'Test default settings - default_returned_datatype'
     c = ConfigSettings('servicex', 'servicex')


### PR DESCRIPTION
* Bug fix: was not fetching the return datatype correctly. But was introduced in one of the previous updates for this version.

Revamped the whole default attributes per end point resolution into a single much more coherrent method. All the logic is now in one place!