### PR TITLE
Remove max range for pyarrow package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name="servicex",
           'make_it_sync==1.0.0',
           'google-auth==1.17',
           'confuse==1.3.0',
-          'pyarrow>=1.0, <4.0'
+          'pyarrow>=1.0'
       ],
       extras_require={
           'test': [


### PR DESCRIPTION
Providing the same max range for pyarrow as coffea does,it fixes https://github.com/iris-hep/analysis-grand-challenge/issues/11

cc: @gordonwatts 