### PR TITLE
Removing Mac Builds while feature is broken in GitHub actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest, macOS-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8, 3.9]
     runs-on: ${{ matrix.platform }}
 


### PR DESCRIPTION
MacBuilds are failing with an error:
```
Run actions/setup-python@v1
Error: Version 3.6 with arch x64 not found
```

Seems like a temporary glitch with GHA, but I need to get a build out....