### PR TITLE
Add optional constructor to change the result-destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,7 @@ Everything is based around the `ServiceXDataset` object. Below is the documentat
                  backend_name: Optional[str] = None,
                  image: str = 'sslhep/servicex_func_adl_xaod_transformer:v0.4',
                  max_workers: int = 20,
+                 result_destination = 'object-store',
                  servicex_adaptor: ServiceXAdaptor = None,
                  minio_adaptor: MinioAdaptor = None,
                  cache_adaptor: Optional[Cache] = None,
@@ -256,6 +257,9 @@ Everything is based around the `ServiceXDataset` object. Below is the documentat
           image                       Name of transformer image to use to transform the data
           max_workers                 Maximum number of transformers to run simultaneously on
                                       ServiceX.
+          result_destination          Where the transformers should write the results.
+                                      Defaults to object-store, but could be used to save
+                                      results to a posix volume                                      
           servicex_adaptor            Object to control communication with the servicex instance
                                       at a particular ip address with certain login credentials.
                                       Default comes from the `config_adaptor`.

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -143,6 +143,7 @@ class ServiceXDataset(ServiceXABC):
                  backend_name: Optional[str] = None,
                  image: str = None,
                  max_workers: int = 20,
+                 result_destination: str = 'object-store',
                  servicex_adaptor: ServiceXAdaptor = None,
                  minio_adaptor: Union[MinioAdaptor, MinioAdaptorFactory] = None,
                  cache_adaptor: Optional[Cache] = None,
@@ -168,6 +169,9 @@ class ServiceXDataset(ServiceXABC):
                                         ServiceX backend will be used.
             max_workers                 Maximum number of transformers to run simultaneously on
                                         ServiceX.
+            result_destination          Where the transformers should write the results.
+                                        Defaults to object-store, but could be used to save
+                                        results to a posix volume
             servicex_adaptor            Object to control communication with the servicex instance
                                         at a particular ip address with certian login credentials.
                                         Will be configured via the `config_adaptor` by default.
@@ -202,7 +206,7 @@ class ServiceXDataset(ServiceXABC):
             -  The full description of calling parameters is recorded in the local cache, including
                things like `image` name and tag.
         '''
-        ServiceXABC.__init__(self, dataset, image, max_workers,
+        ServiceXABC.__init__(self, dataset, image, max_workers, result_destination,
                              status_callback_factory,
                              )
 
@@ -835,7 +839,7 @@ class ServiceXDataset(ServiceXABC):
         # Items that must always be present
         json_query: Dict[str, Union[str, Iterable[str]]] = {
             "selection": selection_query,
-            "result-destination": "object-store",
+            "result-destination": self._result_destination,
             "result-format": 'parquet' if data_type == 'parquet' else "root-file",
             "chunk-size": '1000',
             "workers": str(self._max_workers)

--- a/servicex/servicexabc.py
+++ b/servicex/servicexabc.py
@@ -30,6 +30,7 @@ class ServiceXABC(ABC):
                  dataset: DatasetType,
                  image: Optional[str] = None,
                  max_workers: int = 20,
+                 result_destination: str = 'object-store',
                  status_callback_factory: Optional[StatusUpdateFactory] = _run_default_wrapper,
                  ):
         '''
@@ -44,6 +45,9 @@ class ServiceXABC(ABC):
                                         down.
             max_workers                 Maximum number of transformers to run simultaneously on
                                         ServiceX.
+            result_destination          Where the transformers should write the results.
+                                        Defaults to object-store, but could be used to save
+                                        results to a posix volume
             cache_path                  Path to the cache
             status_callback_factory     Factory to create a status notification callback for each
                                         query. One is created per query.
@@ -62,6 +66,7 @@ class ServiceXABC(ABC):
         self._dataset = dataset
         self._image = image
         self._max_workers = max_workers
+        self._result_destination = result_destination
 
         # We can't create the notifier until the actual query,
         # so only need to save the status update.


### PR DESCRIPTION
## Problem
It is not possible to specify the `result-destination` for ServiceX Submits. It always defaults to `object-store`

Solution to #215 

## Approach
Added a new argument to the ServiceX constructor. Use this in the invocation of ServiceX Transform