### PR TITLE
Drop python 3.6 from test matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, "3.10"]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
# Problem
GitHub Actions has dropped the VM for python 3.6 - tests are failing

# Approach
Removed 3.6 from the test matrix