### PR TITLE
In Memory Cache - Include Datatype

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,34 +5,34 @@ on:
   pull_request:
   # Run daily at 0:01 UTC
   schedule:
-  - cron:  '1 0 * * *'
+    - cron: "1 0 * * *"
 
 jobs:
   flake8:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python
-      uses: actions/setup-python@v1
-      with:
-        python-version: 3.8
-    - name: Install dependencies
-      env:
-        servicex_version: 1.0a1
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        pip install --no-cache-dir -e .[test]
-        pip list
-    - name: Lint with Flake8
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      run: |
-        flake8 --exclude=tests/* --ignore=E501,W503
-    - name: Check for vulnerable libraries
-      if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      run: |
-        pip install safety
-        pip freeze | safety check
+      - uses: actions/checkout@master
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        env:
+          servicex_version: 1.0a1
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --no-cache-dir -e .[test]
+          pip list
+      - name: Lint with Flake8
+        if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+        run: |
+          flake8 --exclude=tests/* --ignore=E501,W503
+      - name: Check for vulnerable libraries
+        if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+        run: |
+          pip install safety
+          pip freeze | safety check
 
   test:
     needs:
@@ -45,25 +45,29 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-    - uses: actions/checkout@master
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      env:
-        servicex_version: 1.0a1
-      run: |
-        python -m pip install --upgrade pip setuptools wheel
-        pip install --no-cache-dir -e .[test]
-        pip list
-    - name: Test with pytest
-      run: |
-        python -m pytest
-    - name: Report coverage with Codecov
-      if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
-      uses: codecov/codecov-action@v1
-      with:
-        token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml # optional
-        flags: unittests # optional
+      - uses: actions/checkout@master
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        env:
+          servicex_version: 1.0a1
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          pip install --no-cache-dir -e .[test]
+          pip list
+      - name: Test with pytest
+        run: |
+          python -m pytest
+      - name: Code coverage with pytest
+        if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+        run: |
+          python -m pytest --ignore=setup.py --cov=servicex --cov-report=term-missing --cov-config=.coveragerc --cov-report xml
+      - name: Report coverage with Codecov
+        if: github.event_name == 'push' && matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          file: ./coverage.xml # optional
+          flags: unittests # optional

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-addopts = --ignore=setup.py --cov=servicex --cov-report=term-missing --cov-config=.coveragerc --cov-report xml
+; addopts = --ignore=setup.py --cov=servicex --cov-report=term-missing --cov-config=.coveragerc --cov-report xml
 junit_family=xunit1

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,4 @@
 [pytest]
 ; addopts = --ignore=setup.py --cov=servicex --cov-report=term-missing --cov-config=.coveragerc --cov-report xml
 junit_family=xunit1
+asyncio_mode = auto

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -621,8 +621,6 @@ class ServiceXDataset(ServiceXABC):
             )
         }
 
-        # Convert them to the proper format
-
         # Finally, we need them in the proper order so we append them
         # all together
         ordered_data = [all_data[k] for k in sorted(all_data.keys())]

--- a/servicex/servicex_utils.py
+++ b/servicex/servicex_utils.py
@@ -31,7 +31,7 @@ def _wrap_in_memory_sx_cache(fn):
         assert isinstance(selection_query, str)
 
         # Is it in the local cache?
-        h = _string_hash([sx._dataset, clean_linq(selection_query)])
+        h = _string_hash([sx._dataset, fn.__name__, clean_linq(selection_query)])
         logger = logging.getLogger(__name__)
         if h in _in_progress_items:
             logger.debug(f"{h} - waiting for processing")


### PR DESCRIPTION
* Currently in-memory cache was using only a hash calculated from the query and the dataset. That missed the fact that the same query can render awkward arrays and root files. This fixes that!
* Rationalize how we are running `pytest`
* Minor text clean up

Fixes #42