### PR TITLE
Protect against negative files remaining

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -98,4 +98,5 @@
     "python.testing.pytestEnabled": true,
     "editor.formatOnSave": true,
     "python.formatting.provider": "black",
+    "restructuredtext.preview.docutils.disabled": true,
 }

--- a/servicex/cache.py
+++ b/servicex/cache.py
@@ -1,6 +1,7 @@
-import os
 import hashlib
 import json
+import logging
+import os
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
@@ -207,6 +208,7 @@ class Cache:
 
         with f.open("r") as i:
             request_id = i.readline().strip()
+            logging.getLogger(__name__).debug(f"Found query '{request_id}' in cache")
 
         self._write_analysis_query_cache(json, request_id)
 

--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -214,6 +214,11 @@ class ServiceXAdaptor:
             files_failed = self._get_transform_stat(info, "files-skipped")
             files_processed = self._get_transform_stat(info, "files-processed")
 
+            if files_remaining is not None and int(files_remaining) < 0:
+                raise ServiceXFatalTransformException(
+                    f"Transform {request_id} returned negative files remaining. Bug in ServiceX?"
+                )
+
             assert files_processed is not None
 
             return files_remaining, files_processed, files_failed


### PR DESCRIPTION
Protect against a possible servicex bug:

* files-remaining is negative
* transform is marked as successful