### PR TITLE
Add as_signed_url property so url_streams can return s3 URIs by default

### DIFF
--- a/servicex/minio_adaptor.py
+++ b/servicex/minio_adaptor.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import asyncio
+import urllib.parse
 from concurrent.futures.thread import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, AsyncIterator, List, Optional, Dict, cast
@@ -86,6 +87,20 @@ class MinioAdaptor:
             str: A url good for some amount of time to access the bucket.
         """
         return self._client.presigned_get_object(request_id, object_name)
+
+    def get_s3_uri(self, request_id: str, object_name: str) -> str:
+        """Given a request ID and a file name in that request, return an S3 URI that can
+        be used by a correctly configured S3 client.
+
+        Args:
+        :param request_id: The request id guid (that is the bucket in minio)
+        :param object_name: The file (the object in the minio bucket)
+        :return:
+            A formatted S3 URI to that object
+        """
+        return urllib.parse.urlunsplit((
+            "s3", request_id, object_name, None, None)
+        )
 
     async def download_file(
         self, request_id: str, bucket_fname: str, output_file: Path

--- a/tests/test_minio_adaptor.py
+++ b/tests/test_minio_adaptor.py
@@ -175,6 +175,11 @@ def test_access_url(good_minio_client):
     good_minio_client[1].presigned_get_object.assert_called_with("123-456", "file1")
 
 
+def test_access_s3_uri():
+    mn = MinioAdaptor("localhost:9000")
+    assert mn.get_s3_uri("123-456", "file1") == "s3://123-456/file1"
+
+
 def test_list_objects(good_minio_client):
     ma = MinioAdaptor("localhost:9000")
 


### PR DESCRIPTION
# Problem
The latest version of _coffea_ `NanoEvents` can no longer read parquet files supplied via http.

Solution to #238 

# Approach
1. Changed the names of the get data url stream methods to be uri_stream to be more accurate
2. Added an optional parameter to the methods `as_signed_url` - by default this is False, but if you set it to True you can still get back the signed urls. Otherwise you get back s3 URIs

