### PR TITLE
Added functions to get URLs sync from request + corresponding tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,11 +25,9 @@ jobs:
           pip install --no-cache-dir -e .[test]
           pip list
       - name: Lint with Flake8
-        if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
         run: |
           flake8 --exclude=tests/* --ignore=E501,W503
       - name: Check for vulnerable libraries
-        if: matrix.python-version == 3.7 && matrix.platform == 'ubuntu-latest'
         run: |
           pip install safety
           pip freeze | safety check

--- a/scripts/run_test.py
+++ b/scripts/run_test.py
@@ -4,11 +4,9 @@
 # An example endpoint (pass as arg to this script):
 #       http://localhost:5000
 import argparse
-from typing import Optional
 import asyncio
 
 from servicex import ServiceXDataset
-from servicex.servicex_adaptor import ServiceXAdaptor
 
 
 async def run_query(endpoint: str, dest: str) -> None:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -68,7 +68,7 @@ class StreamInfoBase:
     def file(self) -> str:
         """Returns the ServiceX filename
 
-        This filename is unique in the dataset, and will be the same accross different queries
+        This filename is unique in the dataset, and will be the same across different queries
         against the dataset. It can be used as a key to sort results.
 
         Notes:

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -471,9 +471,9 @@ class ServiceXDataset(ServiceXABC):
         selection_query: str,
         title: Optional[str] = None,
         as_signed_url: Optional[bool] = False,
-    ) -> list:
-        """Returns a list of each completed batch of work from ServiceX, taken from
-        the async iterator output of get_data_rootfiles_uri_stream.
+    ) -> List[StreamInfoUrl]:
+        """Returns a list of StreamInfoUrl entries containing a `url` for each output file
+        from the transform, taken from get_data_rootfiles_uri_stream.
         The data that comes back includes a `url` that can be accessed to download the
         data.
 
@@ -481,9 +481,9 @@ class ServiceXDataset(ServiceXABC):
             selection_query (str): The ServiceX Selection
             title (str): Optional title for transform request
             as_signed_url (bool): Return the uri as a presigned http url?
-        """        
+        """
         return [
-            f 
+            f
             async for f in self.get_data_rootfiles_uri_stream(
                 selection_query, title=title, as_signed_url=as_signed_url
             )
@@ -507,15 +507,14 @@ class ServiceXDataset(ServiceXABC):
             selection_query, "parquet", title, as_signed_url
         ):  # type: ignore
             yield f_info
-            
+
     async def get_data_parquet_uri_async(
         self,
         selection_query: str,
         title: Optional[str] = None,
         as_signed_url: Optional[bool] = False,
-    ) -> list:
-        """Returns a list of each of the files from the minio bucket,
-        as the files are added there.
+    ) -> List[StreamInfoUrl]:
+        """Returns a list of each of the files from the minio bucket.
 
         Args:
             selection_query (str): The ServiceX Selection
@@ -528,7 +527,7 @@ class ServiceXDataset(ServiceXABC):
                 selection_query, title, as_signed_url
             )
         ]
-        
+
     async def _file_return(
         self, selection_query: str, data_format: str, title: Optional[str]
     ):
@@ -1080,6 +1079,6 @@ class ServiceXDataset(ServiceXABC):
         return json_query
 
     # Define the synchronous versions of the async methods for easy of use
-    
+
     get_data_rootfiles_uri = make_sync(get_data_rootfiles_uri_async)
     get_data_parquet_uri = make_sync(get_data_parquet_uri_async)

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -557,6 +557,66 @@ async def test_good_run_single_ds_2file_awkward(mocker, good_awkward_file_data):
     await ds.get_data_awkward_async("(valid qastle string)")
     assert len(good_awkward_file_data.combine_awkward.call_args[0][0]) == 2
 
+@pytest.mark.asyncio
+async def test_async_root_files_from_minio(mocker):
+    "Get a root file pulling back minio info as it arrives"
+    mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset(
+        "localds://mc16_tev:13",
+        servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+        minio_adaptor=mock_minio_adaptor,  # type: ignore
+        cache_adaptor=mock_cache,
+        local_log=mock_logger,
+        data_convert_adaptor=data_adaptor,
+    )
+    lst = await ds.get_data_rootfiles_uri_async(
+            "(valid qastle string)", as_signed_url=True
+        )
+    
+    assert len(lst) == 1
+    r = lst[0]
+    assert isinstance(r, StreamInfoUrl)
+    assert r.bucket == "123-456"
+    assert r.file == "one_minio_entry"
+    assert r.url == "http://the.url.com"
+
+    assert mock_servicex_adaptor.query_json["result-format"] == "root-file"
+    assert mock_minio_adaptor.access_called_with == ("123-456", "one_minio_entry")
+
+def test_root_files_from_minio(mocker):
+    "Get a root file pulling back minio info as it arrives"
+    mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset(
+        "localds://mc16_tev:13",
+        servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+        minio_adaptor=mock_minio_adaptor,  # type: ignore
+        cache_adaptor=mock_cache,
+        local_log=mock_logger,
+        data_convert_adaptor=data_adaptor,
+    )
+    lst = ds.get_data_rootfiles_uri(
+            "(valid qastle string)", as_signed_url=True
+        )
+    
+    assert len(lst) == 1
+    r = lst[0]
+    assert isinstance(r, StreamInfoUrl)
+    assert r.bucket == "123-456"
+    assert r.file == "one_minio_entry"
+    assert r.url == "http://the.url.com"
+
+    assert mock_servicex_adaptor.query_json["result-format"] == "root-file"
+    assert mock_minio_adaptor.access_called_with == ("123-456", "one_minio_entry")
 
 @pytest.mark.asyncio
 async def test_stream_root_files_from_minio(mocker):
@@ -797,6 +857,54 @@ async def test_stream_parquet_files_from_minio(mocker):
 
     assert mock_servicex_adaptor.query_json["result-format"] == "parquet"
 
+@pytest.mark.asyncio
+async def test_async_parquet_files_from_minio(mocker):
+    "Get a parquet file pulling back minio info as it arrives"
+    mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset(
+        "localds://mc16_tev:13",
+        servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+        minio_adaptor=mock_minio_adaptor,  # type: ignore
+        cache_adaptor=mock_cache,
+        local_log=mock_logger,
+        data_convert_adaptor=data_adaptor,
+    )
+    lst = await ds.get_data_parquet_uri_async("(valid qastle string)")
+
+    assert len(lst) == 1
+    assert lst[0].bucket == "123-456"
+    assert lst[0].file == "one_minio_entry"
+
+    assert mock_servicex_adaptor.query_json["result-format"] == "parquet"
+
+def test_parquet_files_from_minio(mocker):
+    "Get a parquet file pulling back minio info as it arrives"
+    mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+
+    ds = fe.ServiceXDataset(
+        "localds://mc16_tev:13",
+        servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+        minio_adaptor=mock_minio_adaptor,  # type: ignore
+        cache_adaptor=mock_cache,
+        local_log=mock_logger,
+        data_convert_adaptor=data_adaptor,
+    )
+    lst = ds.get_data_parquet_uri("(valid qastle string)")
+
+    assert len(lst) == 1
+    assert lst[0].bucket == "123-456"
+    assert lst[0].file == "one_minio_entry"
+
+    assert mock_servicex_adaptor.query_json["result-format"] == "parquet"
 
 @pytest.mark.asyncio
 async def test_stream_parquet_files(mocker):

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -557,6 +557,7 @@ async def test_good_run_single_ds_2file_awkward(mocker, good_awkward_file_data):
     await ds.get_data_awkward_async("(valid qastle string)")
     assert len(good_awkward_file_data.combine_awkward.call_args[0][0]) == 2
 
+
 @pytest.mark.asyncio
 async def test_async_root_files_from_minio(mocker):
     "Get a root file pulling back minio info as it arrives"
@@ -575,9 +576,9 @@ async def test_async_root_files_from_minio(mocker):
         data_convert_adaptor=data_adaptor,
     )
     lst = await ds.get_data_rootfiles_uri_async(
-            "(valid qastle string)", as_signed_url=True
-        )
-    
+        "(valid qastle string)", as_signed_url=True
+    )
+
     assert len(lst) == 1
     r = lst[0]
     assert isinstance(r, StreamInfoUrl)
@@ -587,6 +588,7 @@ async def test_async_root_files_from_minio(mocker):
 
     assert mock_servicex_adaptor.query_json["result-format"] == "root-file"
     assert mock_minio_adaptor.access_called_with == ("123-456", "one_minio_entry")
+
 
 def test_root_files_from_minio(mocker):
     "Get a root file pulling back minio info as it arrives"
@@ -604,10 +606,8 @@ def test_root_files_from_minio(mocker):
         local_log=mock_logger,
         data_convert_adaptor=data_adaptor,
     )
-    lst = ds.get_data_rootfiles_uri(
-            "(valid qastle string)", as_signed_url=True
-        )
-    
+    lst = ds.get_data_rootfiles_uri("(valid qastle string)", as_signed_url=True)
+
     assert len(lst) == 1
     r = lst[0]
     assert isinstance(r, StreamInfoUrl)
@@ -617,6 +617,7 @@ def test_root_files_from_minio(mocker):
 
     assert mock_servicex_adaptor.query_json["result-format"] == "root-file"
     assert mock_minio_adaptor.access_called_with == ("123-456", "one_minio_entry")
+
 
 @pytest.mark.asyncio
 async def test_stream_root_files_from_minio(mocker):
@@ -857,6 +858,7 @@ async def test_stream_parquet_files_from_minio(mocker):
 
     assert mock_servicex_adaptor.query_json["result-format"] == "parquet"
 
+
 @pytest.mark.asyncio
 async def test_async_parquet_files_from_minio(mocker):
     "Get a parquet file pulling back minio info as it arrives"
@@ -882,6 +884,7 @@ async def test_async_parquet_files_from_minio(mocker):
 
     assert mock_servicex_adaptor.query_json["result-format"] == "parquet"
 
+
 def test_parquet_files_from_minio(mocker):
     "Get a parquet file pulling back minio info as it arrives"
     mock_cache = build_cache_mock(mocker, data_file_return="/foo/bar.root")
@@ -905,6 +908,7 @@ def test_parquet_files_from_minio(mocker):
     assert lst[0].file == "one_minio_entry"
 
     assert mock_servicex_adaptor.query_json["result-format"] == "parquet"
+
 
 @pytest.mark.asyncio
 async def test_stream_parquet_files(mocker):


### PR DESCRIPTION
* Implemented new functions to synchronously get all URLs from a request, for ROOT files and Parquet files. 
Functions are implemented as async to create the lists of URLs and then made sync after. Tests for each new function are also added.
* Fixed long-standing protection against `flake8` running during the initial stages (and got it back to passing flake8!!).