### PR TITLE
feat: Add nox support

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,12 @@
 [flake8]
 max-line-length = 99
-ignore = W503
-exclude = .git,__pycache__,.nox,build,dist
+extend-ignore = E501,W503
+exclude =
+    # common excludes
+    .git,
+    __pycache__,
+    .nox,
+    build,
+    dist,
+    # project decided excludes
+    tests

--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,4 @@
 [flake8]
 max-line-length = 99
 ignore = W503
+exclude = .git,__pycache__,.nox,build,dist

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
           python -m pip list
       - name: Lint with Flake8
         run: |
-          flake8 --exclude=tests/* --ignore=E501,W503
+          flake8
       - name: Check for vulnerable libraries
         run: |
           python -m pip install safety

--- a/README.md
+++ b/README.md
@@ -344,10 +344,11 @@ For any changes please feel free to submit pull requests! We are using the `gitl
 
 To do development please setup your environment with the following steps:
 
-1. A python 3.7 development environment
+1. A Python `3.7+` development environment
 2. Fork/Pull down this package, XX
 3. `python -m pip install -e .[test]`
-4. Run the tests to make sure everything is good: `pytest`.
+4. `python -m pip install nox`
+5. Run the tests with `nox` to make sure everything is good: `nox --session tests`.
 
 Then add tests as you develop. When you are done, submit a pull request with any required changes to the documentation and the online tests will run.
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,78 @@
+import shutil
+from pathlib import Path
+
+import nox
+
+ALL_PYTHONS = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+
+nox.options.sessions = ["lint", "tests"]
+
+
+DIR = Path(__file__).parent.resolve()
+
+
+@nox.session(reuse_venv=True)
+def lint(session):
+    """
+    Lint with flake8.
+    """
+    session.install("--upgrade", "flake8")
+    session.run("flake8", "--exclude=tests/*", "--ignore=E501,W503", *session.posargs)
+
+
+@nox.session(python=ALL_PYTHONS, reuse_venv=True)
+def tests(session):
+    """
+    Run the unit tests under coverage.
+    Specify a particular Python version with --python option.
+
+    Example:
+
+        $ nox --session tests --python 3.11
+    """
+    session.install("--upgrade", "--editable", ".[test]")
+    session.install("--upgrade", "pytest")
+    session.run(
+        "pytest",
+        "--ignore=setup.py",
+        "--cov=servicex",
+        "--cov-report=term-missing",
+        "--cov-config=.coveragerc",
+        "--cov-report=xml",
+        *session.posargs,
+    )
+
+
+@nox.session(reuse_venv=True)
+def coverage(session):
+    """
+    Generate coverage report
+    """
+    session.install("--upgrade", "pip")
+    session.install("--upgrade", "coverage[toml]")
+
+    session.run("coverage", "report")
+    session.run("coverage", "xml")
+    htmlcov_path = DIR / "htmlcov"
+    if htmlcov_path.exists():
+        session.log(f"rm -r {htmlcov_path}")
+        shutil.rmtree(htmlcov_path)
+    session.run("coverage", "html")
+
+
+@nox.session
+def build(session):
+    """
+    Build a sdist and wheel.
+    """
+
+    # cleanup previous build and dist dirs
+    build_path = DIR.joinpath("build")
+    if build_path.exists():
+        shutil.rmtree(build_path)
+    dist_path = DIR.joinpath("dist")
+    if dist_path.exists():
+        shutil.rmtree(dist_path)
+
+    session.install("build")
+    session.run("python", "-m", "build")

--- a/noxfile.py
+++ b/noxfile.py
@@ -17,7 +17,7 @@ def lint(session):
     Lint with flake8.
     """
     session.install("--upgrade", "flake8")
-    session.run("flake8", "--exclude=tests/*", "--ignore=E501,W503", *session.posargs)
+    session.run("flake8", *session.posargs)
 
 
 @nox.session(python=ALL_PYTHONS, reuse_venv=True)


### PR DESCRIPTION
Adopt the use of `nox` as a workflow runner and add a `noxfile.py` to provide `nox` "sessions" that allow for OS agnostic execution of scripted workflows. `nox` comes to me from introduction by @henryiii and I view it as much nicer replacement to `Makefile` driven tasks that makes it super simple to get people onboarded into a developer environment with just a `python -m pip install nox` and then to run the tests it is as easy as `nox -s tests`.

The reason I'm adding it here now is to make it very easy to build the docs across OSes when the docs workflow is added next (which will add `nox -s docs`).

* Update `.flake8` config.
   - Use 'extend-ignore' option to compliment command line ignores.
   - Use 'exclude' pattern to get most common files and tests.