### PR TITLE
Do not request `parquet` when we want `root-file`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -101,4 +101,7 @@
     "editor.formatOnSave": true,
     "python.formatting.provider": "black",
     "restructuredtext.preview.docutils.disabled": true,
+    "python.linting.flake8Args": [
+        "--config=.flake8"
+    ],
 }


### PR DESCRIPTION
Bug fixes:

* Make sure to be consistent about passing `root-file` and not `root-files`
* Limit the result format types allowed to `root-file` and `parquet`. There is a global var in `servicex.py` that contains the legal list that can be updated when testing new formats.
* Change where `flake8` in `vscode` gets its info from

Fixes #253