### PR TITLE
Obey default data return formats

### DIFF
--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -106,7 +106,7 @@ class StreamInfoUrl(StreamInfoBase):
 
     @property
     def bucket(self) -> str:
-        """Returns the buck name - unique and constant accross transformations.
+        """Returns the buck name - unique and constant across transformations.
         Can be used to order the results
 
         Returns:
@@ -166,7 +166,7 @@ class StreamInfoData(StreamInfoBase):
 
 class ServiceXDataset(ServiceXABC):
     """
-    Used to access an instance of ServiceX at an end point on the internet. Support convieration
+    Used to access an instance of ServiceX at an end point on the internet. Support conversion
     by configuration object `config_adaptor` or by creating the adaptors defined in the `__init__`
     function.
     """
@@ -210,7 +210,7 @@ class ServiceXDataset(ServiceXABC):
                                         Defaults to object-store, but could be used to save
                                         results to a posix volume
             servicex_adaptor            Object to control communication with the servicex instance
-                                        at a particular ip address with certian login credentials.
+                                        at a particular ip address with certain login credentials.
                                         Will be configured via the `config_adaptor` by default.
             minio_adaptor               Object to control communication with the minio servicex
                                         instance.
@@ -347,7 +347,7 @@ class ServiceXDataset(ServiceXABC):
         access the data.
 
         Args:
-            selection_query (str): The `qastle` query for the data to retreive.
+            selection_query (str): The `qastle` query for the data to retrieve.
 
         Yields:
             AsyncIterator[StreamInfoPath]: As ServiceX completes the data, and it is downloaded
@@ -375,7 +375,7 @@ class ServiceXDataset(ServiceXABC):
         access the data.
 
         Args:
-            selection_query (str): The `qastle` query for the data to retreive.
+            selection_query (str): The `qastle` query for the data to retrieve.
 
         Yields:
             AsyncIterator[StreamInfoPath]: As ServiceX completes the data, and it is downloaded
@@ -417,7 +417,7 @@ class ServiceXDataset(ServiceXABC):
         as a separate `awkward` array. The data is returned in a `StreamInfoData` object.
 
         Args:
-            selection_query (str): The `qastle` query for the data to retreive.
+            selection_query (str): The `qastle` query for the data to retrieve.
 
         Yields:
             AsyncIterator[StreamInfoData]: As ServiceX completes the data, and it is downloaded
@@ -437,7 +437,7 @@ class ServiceXDataset(ServiceXABC):
         as a separate `pandas.DataFrame` array. The data is returned in a `StreamInfoData` object.
 
         Args:
-            selection_query (str): The `qastle` query for the data to retreive.
+            selection_query (str): The `qastle` query for the data to retrieve.
 
         Yields:
             AsyncIterator[StreamInfoData]: As ServiceX completes the data, and it is downloaded
@@ -539,7 +539,7 @@ class ServiceXDataset(ServiceXABC):
         Given a query, return the list of files, in a unique order, that hold
         the data for the query.
 
-        For certian types of exceptions, the queries will be repeated. For example,
+        For certain types of exceptions, the queries will be repeated. For example,
         if `ServiceX` indicates that it was restarted in the middle of the query, then
         the query will be re-submitted.
 
@@ -670,7 +670,7 @@ class ServiceXDataset(ServiceXABC):
         """Given a query, return the data, in a unique order, that hold
         the data for the query.
 
-        For certian types of exceptions, the queries will be repeated. For example,
+        For certain types of exceptions, the queries will be repeated. For example,
         if `ServiceX` indicates that it was restarted in the middle of the query, then
         the query will be re-submitted.
 
@@ -710,7 +710,7 @@ class ServiceXDataset(ServiceXABC):
         """Given a query, return the data, in the order it arrives back
         converted as appropriate.
 
-        For certian types of exceptions, the queries will be repeated. For example,
+        For certain types of exceptions, the queries will be repeated. For example,
         if `ServiceX` indicates that it was restarted in the middle of the query, then
         the query will be re-submitted.
 
@@ -741,7 +741,7 @@ class ServiceXDataset(ServiceXABC):
         that contain the results of the query. This is an async generator, and files
         are returned as they arrive.
 
-        For certian types of exceptions, the queries will be repeated. For example,
+        For certain types of exceptions, the queries will be repeated. For example,
         if `ServiceX` indicates that it was restarted in the middle of the query, then
         the query will be re-submitted.
 
@@ -779,7 +779,7 @@ class ServiceXDataset(ServiceXABC):
         Return a list of files from servicex as they have been downloaded to this machine. The
         return type is an awaitable that will yield the path to the file.
 
-        For certian types of `ServiceX` failures we will automatically attempt a few retries:
+        For certain types of `ServiceX` failures we will automatically attempt a few retries:
 
             - When `ServiceX` forgets the query. This sometimes happens when a user submits a
               query, and then disconnects from the network, `ServiceX` is restarted, and then the
@@ -815,7 +815,7 @@ class ServiceXDataset(ServiceXABC):
                 self._cache.lookup_query_status(request_id)
             )
 
-            # Look up the cache, and then fetch an iterator going thorugh the results
+            # Look up the cache, and then fetch an iterator going through the results
             # from either servicex or the cache, depending.
             try:
                 cached_files = self._cache.lookup_files(request_id)

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -393,9 +393,13 @@ class ServiceXDataset(ServiceXABC):
     async def get_data_pandas_df_async(
         self, selection_query: str, title: Optional[str] = None
     ):
+        data_format = self._return_types[0]
         return self._converter.combine_pandas(
             await self._data_return(
-                selection_query, lambda f: self._converter.convert_to_pandas(f), title
+                selection_query,
+                lambda f: self._converter.convert_to_pandas(f),
+                title,
+                data_format=data_format,
             )
         )
 

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -404,9 +404,13 @@ class ServiceXDataset(ServiceXABC):
     async def get_data_awkward_async(
         self, selection_query: str, title: Optional[str] = None
     ):
+        data_format = self._return_types[0]
         return self._converter.combine_awkward(
             await self._data_return(
-                selection_query, lambda f: self._converter.convert_to_awkward(f), title
+                selection_query,
+                lambda f: self._converter.convert_to_awkward(f),
+                title,
+                data_format=data_format,
             )
         )
 
@@ -1052,7 +1056,7 @@ class ServiceXDataset(ServiceXABC):
         json_query: Dict[str, Union[str, Iterable[str]]] = {
             "selection": selection_query,
             "result-destination": self._result_destination,
-            "result-format": "parquet" if data_format == "parquet" else "root-file",
+            "result-format": data_format,
             "chunk-size": "1000",
             "workers": str(self._max_workers),
         }

--- a/servicex/servicexabc.py
+++ b/servicex/servicexabc.py
@@ -119,7 +119,7 @@ class ServiceXABC(ABC):
     ) -> pd.DataFrame:
         """
         Fetch query data from ServiceX matching `selection_query` and return it as
-        a pandas dataframe. The data is uniquely ordered (the same query will always
+        a pandas DataFrame. The data is uniquely ordered (the same query will always
         return the same order).
 
         Arguments:
@@ -127,7 +127,7 @@ class ServiceXABC(ABC):
             title               Title reported to the ServiceX backend for status reporting
 
         Returns:
-            df                  The pandas dataframe
+            df                  The pandas DataFrame
 
         Exceptions:
             xxx                 If the data is not the correct shape (e.g. a flat,

--- a/servicex/utils.py
+++ b/servicex/utils.py
@@ -350,7 +350,7 @@ class _default_wrapper_mgr:
     def _update_bar(
         self, bar: Optional[tqdm], total: Optional[int], num: int, failed: int
     ):
-        assert bar is not None, "Internal error - bar was not initalized"
+        assert bar is not None, "Internal error - bar was not initialized"
         if total is not None:
             if bar.total != total:
                 # There is a bug in the tqm library if running in a notebook
@@ -417,7 +417,7 @@ def clean_linq(q: str) -> str:
 
     Arguments
 
-        q           Strign containing the qastle code`
+        q           String containing the qastle code`
 
     Returns
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,9 +48,9 @@ class MockServiceXAdaptor:
         self,
         mocker: MockFixture,
         request_id: str,
-        mock_transform_status: Mock = None,
-        mock_query: Mock = None,
-        mock_transform_query_status: Mock = None,
+        mock_transform_status: Optional[Mock] = None,
+        mock_query: Optional[Mock] = None,
+        mock_transform_query_status: Optional[Mock] = None,
     ):
         self.request_id = request_id
         self._endpoint = "http://localhost:5000"
@@ -139,11 +139,11 @@ __g_inmem_value = None
 
 def build_cache_mock(
     mocker,
-    query_cache_return: str = None,
+    query_cache_return: Optional[str] = None,
     files: Optional[List[Tuple[str, Path]]] = None,
     in_memory: Any = None,
     make_in_memory_work: bool = False,
-    data_file_return: str = None,
+    data_file_return: Optional[str] = None,
     query_status_lookup_return: Optional[Dict[str, str]] = None,
 ) -> Cache:
     c = mocker.MagicMock(spec=Cache)

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -84,7 +84,7 @@ def test_default_ctor_no_type(mocker):
 
 
 def test_default_ctor_cache(mocker):
-    "Test that the decfault config is passed the right value"
+    "Test that the default config is passed the right value"
 
     config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
     config.settings = Configuration("servicex", "servicex")
@@ -103,7 +103,7 @@ def test_default_ctor_cache(mocker):
 
 
 def test_default_ctor_cache_no(mocker):
-    "Test that the decfault config is passed the right value"
+    "Test that the default config is passed the right value"
 
     config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
     config.settings = Configuration("servicex", "servicex")
@@ -1905,7 +1905,7 @@ async def test_download_cached_awkward(mocker, good_awkward_file_data):
 
 @pytest.mark.asyncio
 async def test_simultaneous_query_not_requeued(mocker, good_awkward_file_data):
-    "Run two at once - they should not both generate queires as they are identical"
+    "Run two at once - they should not both generate queries as they are identical"
 
     async def do_query():
         mock_cache = build_cache_mock(mocker, make_in_memory_work=True)

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -26,6 +26,10 @@ from servicex.utils import ServiceXNoFilesInCache, log_adaptor
 
 from .conftest import MockMinioAdaptor, MockServiceXAdaptor, build_cache_mock  # NOQA
 
+# To enable later tests when we want something no one is going
+# to specify anywhere in their code.
+fe.servicex.g_allowed_formats.append("parquet-ftw")
+
 
 def clean_fname(fname: str):
     "No matter the string given, make it an acceptable filename"
@@ -493,6 +497,8 @@ async def test_good_run_single_ds_1file_awkward(mocker, good_awkward_file_data):
     mock_logger = mocker.MagicMock(spec=log_adaptor)
     mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
     mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.get_default_returned_datatype.return_value = "root-file"
 
     ds = fe.ServiceXDataset(
         "localds://mc16_tev:13",
@@ -501,6 +507,7 @@ async def test_good_run_single_ds_1file_awkward(mocker, good_awkward_file_data):
         cache_adaptor=mock_cache,
         data_convert_adaptor=good_awkward_file_data,
         local_log=mock_logger,
+        config_adaptor=config,
     )
     r = await ds.get_data_awkward_async("(valid qastle string)")
     assert isinstance(r, dict)
@@ -511,6 +518,31 @@ async def test_good_run_single_ds_1file_awkward(mocker, good_awkward_file_data):
     good_awkward_file_data.combine_awkward.assert_called_once()
     good_awkward_file_data.convert_to_awkward.assert_called_once()
     assert len(good_awkward_file_data.combine_awkward.call_args[0][0]) == 1
+
+
+@pytest.mark.asyncio
+async def test_awkward_uses_default_return_type(mocker, good_awkward_file_data):
+    "Make sure the awkward request against an xaod backend asks for a root file"
+    mock_cache = build_cache_mock(mocker)
+    mock_logger = mocker.MagicMock(spec=log_adaptor)
+    mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
+    mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.get_default_returned_datatype.return_value = "parquet-ftw"
+
+    ds = fe.ServiceXDataset(
+        "localds://mc16_tev:13",
+        backend_name="uproot",
+        servicex_adaptor=mock_servicex_adaptor,  # type: ignore
+        minio_adaptor=mock_minio_adaptor,  # type: ignore
+        cache_adaptor=mock_cache,
+        data_convert_adaptor=good_awkward_file_data,
+        local_log=mock_logger,
+        config_adaptor=config,
+    )
+    await ds.get_data_awkward_async("(valid qastle string)")
+
+    assert mock_servicex_adaptor.query_json["result-format"] == "parquet-ftw"
 
 
 @pytest.mark.asyncio
@@ -545,6 +577,8 @@ async def test_good_run_single_ds_2file_awkward(mocker, good_awkward_file_data):
     mock_minio_adaptor = MockMinioAdaptor(
         mocker, files=["one_minio_entry", "two_minio_entry"]
     )
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.get_default_returned_datatype.return_value = "root-file"
 
     ds = fe.ServiceXDataset(
         "localds://mc16_tev:13",
@@ -553,6 +587,7 @@ async def test_good_run_single_ds_2file_awkward(mocker, good_awkward_file_data):
         cache_adaptor=mock_cache,
         data_convert_adaptor=good_awkward_file_data,
         local_log=mock_logger,
+        config_adaptor=config,
     )
     await ds.get_data_awkward_async("(valid qastle string)")
     assert len(good_awkward_file_data.combine_awkward.call_args[0][0]) == 2
@@ -1009,6 +1044,8 @@ async def test_status_exception(mocker):
     )
     mock_minio_adaptor = MockMinioAdaptor(mocker, files=[])
     data_adaptor = mocker.MagicMock(spec=DataConverterAdaptor)
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.get_default_returned_datatype.return_value = "parquet-ftw"
 
     ds = fe.ServiceXDataset(
         "localds://mc16_tev:13",
@@ -1017,6 +1054,7 @@ async def test_status_exception(mocker):
         cache_adaptor=mock_cache,
         data_convert_adaptor=data_adaptor,
         local_log=mock_logger,
+        config_adaptor=config,
     )
     with pytest.raises(fe.ServiceXException) as e:
         await ds.get_data_awkward_async("(valid qastle string)")
@@ -1417,6 +1455,8 @@ async def test_cache_awkward_root_confusion(mocker, good_awkward_file_data, tmp_
     mock_logger = mocker.MagicMock(spec=log_adaptor)
     mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
     mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+    config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+    config.get_default_returned_datatype.return_value = "parquet-ftw"
 
     # Use the real cache here - we need to return the value we stash.
     c = tmp_path / "cache"
@@ -1432,6 +1472,7 @@ async def test_cache_awkward_root_confusion(mocker, good_awkward_file_data, tmp_
         cache_adaptor=cache,
         data_convert_adaptor=good_awkward_file_data,
         local_log=mock_logger,
+        config_adaptor=config,
     )
     q_string = "(valid qastle string)"
     r1 = await ds.get_data_rootfiles_async(q_string)
@@ -1840,6 +1881,9 @@ async def test_simultaneous_query_not_requeued(mocker, good_awkward_file_data):
         mock_logger = mocker.MagicMock(spec=log_adaptor)
         mock_servicex_adaptor = MockServiceXAdaptor(mocker, "123-456")
         mock_minio_adaptor = MockMinioAdaptor(mocker, files=["one_minio_entry"])
+        config = mocker.MagicMock(spec=ServiceXConfigAdaptor)
+        config.get_default_returned_datatype.return_value = "parquet-ftw"
+
         ds = fe.ServiceXDataset(
             "localds://dude-is-funny",
             servicex_adaptor=mock_servicex_adaptor,  # type: ignore
@@ -1847,6 +1891,7 @@ async def test_simultaneous_query_not_requeued(mocker, good_awkward_file_data):
             data_convert_adaptor=good_awkward_file_data,
             cache_adaptor=mock_cache,
             local_log=mock_logger,
+            config_adaptor=config,
         )
         return await ds.get_data_awkward_async("(valid qastle string")
 


### PR DESCRIPTION
* Fix #259 - get_awkward now properly requests parquet files from an uproot background, and root files from a xaod backend.
* get_pandas does the same things
* Spell checker was run on multiple source files and spelling updated.
* A global variable in `servicex.py` limits you to what data formats you can request. It is now possible to alter that global variable if you want to add a new format without having to `hack` the package.