### PR TITLE
Update changes for release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
   pull_request:
   # Run daily at 0:01 UTC
   schedule:
-    - cron: "1 0 * * *"
+    - cron: "1 0 * * 0"
   workflow_dispatch:
 
 jobs:
@@ -39,7 +39,7 @@ jobs:
 
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest]
+        platform: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
     runs-on: ${{ matrix.platform }}
 

--- a/servicex/config_default.yaml
+++ b/servicex/config_default.yaml
@@ -9,6 +9,9 @@ api_endpoints:
   - endpoint: http://localhost:5000
     name: default
     type: cms_run1_aod
+  - endpoint: http://localhost:5000
+    name: default
+    type: uproot
 
 # This is the path of the cache. The "/tmp" will be translated, platform appropriate, and
 # the env variable USER will be replaced.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
         "qastle>=0.10",
         "make_it_sync>= 1.0.0",
         "google-auth",
-        "confuse==1.3.0",
+        "confuse",
         "pyarrow>=1.0",
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
         "minio~=5.0",
         "tqdm~=4.0",
         "qastle>=0.10",
-        "make_it_sync==1.0.0",
+        "make_it_sync>= 1.0.0",
         "google-auth",
         "confuse==1.3.0",
         "pyarrow>=1.0",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "aiohttp~=3.6",
         "minio~=5.0",
         "tqdm~=4.0",
-        "qastle>=0.10, <1.0",
+        "qastle>=0.10",
         "make_it_sync==1.0.0",
         "google-auth",
         "confuse==1.3.0",
@@ -82,6 +82,7 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
     package_data={
         "servicex": ["config_default.yaml"],


### PR DESCRIPTION
* Update `setup`'s restrictions to remove upper limits on things like `quastle`.
* Make sure there is a default `uproot`-backend definition in the default fall-back `servicex.yaml` file.
* Relax the `make_async` package restriction
* Relax the `confuse` yaml parser definition
* Add mac-os testing in (not sure why it wasn't there!)
* And have it run its periodic checks once per week, not once per day.

Working towards a 2.6.2 release.