### PR TITLE
Propagate the original MinIO exception in case of connection errors.

### DIFF
--- a/servicex/minio_adaptor.py
+++ b/servicex/minio_adaptor.py
@@ -74,7 +74,7 @@ class MinioAdaptor:
                 f"Unable to reach Minio at {e.pool.host}:{e.pool.port}{e.url}. "
                 f"Max retries exceeded."
             )
-            raise ServiceXException(msg)
+            raise ServiceXException(msg) from e
         except NoSuchBucket as e:
             raise ServiceXNoFilesInCache(
                 f'No files in cache for request "{request_id}"'


### PR DESCRIPTION

In my local environment, I am always seeing the following MinIO error while listing objects:

```
    raise ServiceXException(msg)
servicex.utils.ServiceXException: (ServiceXException(...), 'Unable to reach Minio at localhost:9000/2ca35b92-ddc0-4f73-bdd4-ccad718f1dfb?location=. Max retries exceeded.')
```

I confirmed that there was no connection reset happening. It turned out that the original MinIO exception was not being propagated in this case and that made debugging the problem very difficult. With the change in this PR, I now see this trace:

```
...
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:997)
...
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='localhost', port=9000): Max retries exceeded with url: /2ca35b92-ddc0-4f73-bdd4-ccad718f1dfb?location= (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:997)')))
...
    raise ServiceXException(msg) from e
servicex.utils.ServiceXException: (ServiceXException(...), 'Unable to reach Minio at localhost:9000/2ca35b92-ddc0-4f73-bdd4-ccad718f1dfb?location=. Max retries exceeded.')
```

It is now clear why the problem is happening.

