### PR TITLE
Safe Downloaded Filenames

### DIFF
--- a/servicex_client/minio_adapter.py
+++ b/servicex_client/minio_adapter.py
@@ -35,6 +35,11 @@ from miniopy_async import Minio
 from servicex_client.models import ResultFile, TransformStatus
 
 
+def _sanitize_filename(fname: str):
+    "No matter the string given, make it an acceptable filename on all platforms"
+    return fname.replace("*", "_").replace(";", "_").replace(":", "_")
+
+
 class MinioAdapter:
     MAX_PATH_LEN = 32
 
@@ -80,7 +85,9 @@ class MinioAdapter:
         path = Path(
             os.path.join(
                 local_dir,
-                self.hash_path(object_name) if shorten_filename else object_name,
+                _sanitize_filename(
+                    self.hash_path(object_name) if shorten_filename else object_name,
+                ),
             )
         )
 

--- a/tests/test_minio_adapter.py
+++ b/tests/test_minio_adapter.py
@@ -74,6 +74,16 @@ async def test_download_file(minio_adapter):
 
 
 @pytest.mark.asyncio
+async def test_download_bad_filename(minio_adapter):
+    minio_adapter.minio.fget_object = AsyncMock(return_value="t::est.txt")
+    result = await minio_adapter.download_file("t::est.txt", local_dir="/tmp/foo")
+    assert str(result).endswith("t__est.txt")
+    minio_adapter.minio.fget_object.assert_called_with(
+        bucket_name="bucket", file_path="/tmp/foo/t__est.txt", object_name="t::est.txt"
+    )
+
+
+@pytest.mark.asyncio
 async def test_get_signed_url(minio_adapter):
     minio_adapter.minio.get_presigned_url = AsyncMock(
         return_value="https://pre-signed.me"


### PR DESCRIPTION
Make sure that filenames for files coming back from minio have ":", "*", etc., removed so they are safe on any OS