### PR TITLE
Short Filenames

### DIFF
--- a/servicex_client/minio_adapter.py
+++ b/servicex_client/minio_adapter.py
@@ -41,7 +41,9 @@ def _sanitize_filename(fname: str):
 
 
 class MinioAdapter:
-    MAX_PATH_LEN = 32
+    # This must be at least 40, the length of the `hash` we are using, or
+    # undefined things will happen.
+    MAX_PATH_LEN = 60
 
     def __init__(
         self,


### PR DESCRIPTION
* Fixed bug in short-filename logic
* The max filename should never be shorter than the hash length, or the result is undefiend.
* Changed filename length to be 60.