### PR TITLE
Bump version number to avoid conflicts in testing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "servicex"
-version = "2.0.0-alpha.1"
+version = "3.0.0-alpha.1"
 description = ""
 authors = [
     "Ben Galewsky <bengal1@illinois.edu>",


### PR DESCRIPTION
* Some packages are already requiring a version >= 2.6, which causes conflicts with this pacakge when installed in editable mode