### PR TITLE
Accept both .servicex and servicex.yaml config files

### DIFF
--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -70,7 +70,9 @@ class Configuration(BaseModel):
             return Configuration(**yaml_config)
         else:
             path_extra = f"in {config_path}" if config_path else ""
-            raise NameError("Can't find .servicex or servicex.yaml config file " + path_extra)
+            raise NameError(
+                "Can't find .servicex or servicex.yaml config file " + path_extra
+            )
 
     @classmethod
     def _add_from_path(cls, path: Optional[Path] = None, walk_up_tree: bool = False):
@@ -80,18 +82,18 @@ class Configuration(BaseModel):
             name = path.name
             dir = path.parent.resolve()
         else:
-            name = ".servicex" 
+            name = ".servicex"
             alt_name = "servicex.yaml"
             dir = Path(os.getcwd())
 
         while True:
-            f = dir / name # user-defined path or .servicex
+            f = dir / name  # user-defined path or .servicex
             if f.exists():
                 with open(f) as config_file:
                     config = yaml.safe_load(config_file)
                     break
 
-            f = dir / alt_name # if neither option above, find servicex.yaml
+            f = dir / alt_name  # if neither option above, find servicex.yaml
             if f.exists():
                 with open(f) as config_file:
                     config = yaml.safe_load(config_file)
@@ -99,11 +101,10 @@ class Configuration(BaseModel):
 
             if not walk_up_tree:
                 break
-            
+
             if dir == dir.parent:
                 break
-            
+
             dir = dir.parent
-            
+
         return config
-    

--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -55,7 +55,7 @@ class Configuration(BaseModel):
     @classmethod
     def read(cls, config_path: Optional[str] = None):
         r"""
-        Read configuration from .servicex file.
+        Read configuration from .servicex or servicex.yaml file.
         :param config_path: If provided, use this as the path to the .servicex file.
                             Otherwise, search, starting from the current working directory
                             and look in enclosing directories
@@ -106,3 +106,4 @@ class Configuration(BaseModel):
             dir = dir.parent
             
         return config
+    

--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -54,14 +54,6 @@ class Configuration(BaseModel):
 
     @classmethod
     def read(cls, config_path: Optional[str] = None):
-        r"""
-        Read configuration from .servicex file.
-
-        :param config_path: If provided, use this as the path to the .servicex file.
-                            Otherwise, search, starting from the current working directory
-                            and look in enclosing directories
-        :return: Populated configuration object
-        """
         if config_path:
             yaml_config = cls._add_from_path(Path(config_path), walk_up_tree=False)
         else:
@@ -71,7 +63,7 @@ class Configuration(BaseModel):
             return Configuration(**yaml_config)
         else:
             path_extra = f"in {config_path}" if config_path else ""
-            raise NameError("Can't find .servicex config file " + path_extra)
+            raise NameError("Can't find .servicex or servicex.yaml config file " + path_extra)
 
     @classmethod
     def _add_from_path(cls, path: Optional[Path] = None, walk_up_tree: bool = False):
@@ -81,18 +73,29 @@ class Configuration(BaseModel):
             name = path.name
             dir = path.parent.resolve()
         else:
-            name = ".servicex"
+            name = ".servicex" 
+            alt_name = "servicex.yaml"
             dir = Path(os.getcwd())
 
         while True:
-            f = dir / name
+            f = dir / name # user-defined path or .servicex
             if f.exists():
                 with open(f) as config_file:
                     config = yaml.safe_load(config_file)
                     break
+
+            f = dir / alt_name # if neither option above, find servicex.yaml
+            if f.exists():
+                with open(f) as config_file:
+                    config = yaml.safe_load(config_file)
+                    break
+
             if not walk_up_tree:
                 break
+            
             if dir == dir.parent:
                 break
+            
             dir = dir.parent
+            
         return config

--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -54,6 +54,13 @@ class Configuration(BaseModel):
 
     @classmethod
     def read(cls, config_path: Optional[str] = None):
+        r"""
+        Read configuration from .servicex file.
+        :param config_path: If provided, use this as the path to the .servicex file.
+                            Otherwise, search, starting from the current working directory
+                            and look in enclosing directories
+        :return: Populated configuration object
+        """
         if config_path:
             yaml_config = cls._add_from_path(Path(config_path), walk_up_tree=False)
         else:


### PR DESCRIPTION
Small changes to configuration.py to search for both .servicex and servicex.yaml config files, while also accepting a user-defined config file path.