### PR TITLE
Deal with empty and bad dataset names

### DIFF
--- a/servicex/servicex_adaptor.py
+++ b/servicex/servicex_adaptor.py
@@ -210,6 +210,18 @@ class ServiceXAdaptor:
                     f"Transform status for {request_id}" ' is marked "Fatal".'
                 )
 
+            if (
+                "status" in info
+                and info["status"] == "Complete"
+                and info["files-remaining"] is None
+                and info["files-processed"] == 0
+            ):
+                raise ServiceXFatalTransformException(
+                    f"Transform status for {request_id}"
+                    ' is marked "Complete" but no files were processed. Either the dataset '
+                    "is empty, or the dataset name is invalid."
+                )
+
             files_remaining = self._get_transform_stat(info, "files-remaining")
             files_failed = self._get_transform_stat(info, "files-skipped")
             files_processed = self._get_transform_stat(info, "files-processed")


### PR DESCRIPTION
ServiceX no longer returns a *Fatal* error when it is asked to look up a bad dataset name or a dataset name that has zero files.

* Detect a completed transform with no files

Fixes #313
Fixes #312