### PR TITLE
Agc fixes

### DIFF
--- a/examples/xAODDataset.py
+++ b/examples/xAODDataset.py
@@ -47,9 +47,8 @@ good_ele = ds.Select(
     lambda e: {
         "run": e.EventInfo("EventInfo").runNumber(),
         "event": e.EventInfo("EventInfo").eventNumber(),
-        "good_ele": e.Electrons("Electrons").
-        Where(lambda e: (e.pt() / 1000 > 25.0) and (abs(e.eta()) < 2.5)
-              ),
+        "good_ele": e.Electrons("Electrons")
+                     .Where(lambda e: (e.pt() / 1000 > 25.0) and (abs(e.eta()) < 2.5)),
     }
 )
 

--- a/servicex/dataset_group.py
+++ b/servicex/dataset_group.py
@@ -60,6 +60,7 @@ class DatasetGroup:
         """
         for dataset in self.datasets:
             dataset.set_result_format(result_format)
+        return self
 
     async def as_signed_urls_async(
         self,

--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -72,7 +72,7 @@ class FileListDataset:
 
         :param files: Either a list of URIs or a single URI string
         """
-        if type(files) == str:
+        if type(files) is str:
             self.files = [files]
         else:
             self.files = files

--- a/servicex/func_adl/func_adl_dataset.py
+++ b/servicex/func_adl/func_adl_dataset.py
@@ -81,6 +81,7 @@ class FuncADLDataset(Dataset, EventDataset[T]):
         query_cache: QueryCache = None,
         result_format: Optional[ResultFormat] = None,
         item_type: Type = Any,
+        ignore_cache: bool = False,
     ):
         Dataset.__init__(
             self,
@@ -91,6 +92,7 @@ class FuncADLDataset(Dataset, EventDataset[T]):
             config=config,
             query_cache=query_cache,
             result_format=result_format,
+            ignore_cache=ignore_cache,
         )
         EventDataset.__init__(self, item_type=item_type)
         self.provided_qastle = None
@@ -111,7 +113,7 @@ class FuncADLDataset(Dataset, EventDataset[T]):
         memo[id(self)] = obj
 
         for attr, value in vars(self).items():
-            if type(value) == QueryCache:
+            if type(value) is QueryCache:
                 setattr(obj, attr, value)
             else:
                 setattr(obj, attr, copy.deepcopy(value, memo))

--- a/servicex/func_adl/func_adl_dataset_group.py
+++ b/servicex/func_adl/func_adl_dataset_group.py
@@ -32,7 +32,7 @@ from typing import Union, Callable, Iterable
 import ast
 from servicex import DatasetGroup
 
-from func_adl_dataset import T
+from servicex.func_adl.func_adl_dataset import T
 
 
 class FuncADLDatasetGroup(DatasetGroup):

--- a/servicex/python_dataset.py
+++ b/servicex/python_dataset.py
@@ -45,7 +45,8 @@ class PythonDataset(Dataset):
                  codegen: str = None,
                  config: Configuration = None,
                  query_cache: QueryCache = None,
-                 result_format: typing.Optional[ResultFormat] = None
+                 result_format: typing.Optional[ResultFormat] = None,
+                 ignore_cache: bool = False
                  ):
         super().__init__(dataset_identifier=dataset_identifier,
                          title=title,
@@ -53,7 +54,8 @@ class PythonDataset(Dataset):
                          sx_adapter=sx_adapter,
                          config=config,
                          query_cache=query_cache,
-                         result_format=result_format)
+                         result_format=result_format,
+                         ignore_cache=ignore_cache)
 
         self.python_function = None
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -125,6 +125,7 @@ class ServiceXClient:
         codegen: str = "uproot",
         result_format: Optional[ResultFormat] = None,
         item_type: Type[T] = Any,
+        ignore_cache: bool = False
     ) -> FuncADLDataset[T]:
         r"""
         Generate a dataset that can use func_adl query language
@@ -135,6 +136,8 @@ class ServiceXClient:
         :param codegen: Name of the code generator to use with this transform
         :param result_format:  Do you want Paqrquet or Root? This can be set later with
                                the set_result_format method
+        :param item_type: The type of the items that will be returned from the query
+        :param ignore_cache: Ignore the query cache and always run the query
         :return: A func_adl dataset ready to accept query statements.
         """
         if codegen not in self.code_generators:
@@ -152,6 +155,7 @@ class ServiceXClient:
             query_cache=self.query_cache,
             result_format=result_format,
             item_type=item_type,
+            ignore_cache=ignore_cache
         )
 
     def python_dataset(
@@ -160,6 +164,7 @@ class ServiceXClient:
         title: str = "ServiceX Client",
         codegen: str = "uproot",
         result_format: Optional[ResultFormat] = None,
+        ignore_cache: bool = False
     ) -> PythonDataset:
         r"""
         Generate a dataset that can use accept a python function for the  query
@@ -170,6 +175,7 @@ class ServiceXClient:
         :param codegen: Name of the code generator to use with this transform
         :param result_format:  Do you want Paqrquet or Root? This can be set later with
                                the set_result_format method
+        :param ignore_cache: Ignore the query cache and always run the query
         :return: A func_adl dataset ready to accept a python function statements.
 
         """
@@ -188,4 +194,5 @@ class ServiceXClient:
             config=self.config,
             query_cache=self.query_cache,
             result_format=result_format,
+            ignore_cache=ignore_cache
         )


### PR DESCRIPTION
As I was testing out the ServiceX client 3.0 with the Analysis grand Challenge notebook, I uncovered a few minor issues.

1.  DatasetGroup didn't return self in set_result_format so this couldn't be used in a pipeline
2. The import statement for types in func_adl_dataset didn't use the correct module name
3. Added ignore_cache option