### PR TITLE
Don't used cached results if there were any failures

### DIFF
--- a/servicex/app/cache.py
+++ b/servicex/app/cache.py
@@ -57,7 +57,7 @@ def list():
     table.add_column("Codegen")
     table.add_column("Transform ID")
     table.add_column("Run Date")
-    table.add_column("Files")
+    table.add_column("Files/Failed")
     table.add_column("Format")
     runs = cache.cached_queries()
     for r in runs:
@@ -66,7 +66,7 @@ def list():
             r.codegen,
             r.request_id,
             r.submit_time.astimezone().strftime("%a, %Y-%m-%d %H:%M"),
-            str(r.files),
+            f"{r.files}/{r.failed_files}",
             r.result_format
         )
     rich.print(table)

--- a/servicex/dataset.py
+++ b/servicex/dataset.py
@@ -207,6 +207,10 @@ class Dataset(ABC):
             if not self.ignore_cache \
             else None
 
+        # We won't use a cached record if there were any failures in that transform
+        if cached_record and cached_record.failed_files:
+            cached_record = None
+
         # And that we grabbed the resulting files in the way that the user requested
         # (Downloaded, or obtained pre-signed URLs)
         if cached_record:

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -156,4 +156,6 @@ class TransformedResults(BaseModel):
     file_list: List[str]
     signed_url_list: List[str]
     files: int
+    failed_files: int
+    status: str
     result_format: ResultFormat

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,5 +126,7 @@ def transformed_result() -> TransformedResults:
         file_list=["/tmp/1.root", "/tmp/2.root"],
         signed_url_list=[],
         files=2,
+        failed_files=0,
+        status="Completed",
         result_format=ResultFormat.root_file,
     )


### PR DESCRIPTION
# Problem
Even if there were failures in a previous transform we would just pull it out of cache and serve it up. 

# Approach

Keep track of the number of failed files in the cached record. Only return it to the user if it was flawless.

1. As part of this PR I realized that the tiny DB is not threadsafe so I added locks to the cache code.
2. Added reporting of failed files in the cache CLI report
3. There was a bug `servicex cache list` command where it would try to report on code generator records in the tiny db. Enhanced that query to only report transform records