### PR TITLE
Change name of root-file result format

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -45,8 +45,8 @@ class ResultFormat(str, Enum):
     r"""
     Specify the file format for the generated output
     """
-    parquet = ("parquet",)
-    root_file = "root-file"
+    parquet = "parquet"
+    root = "root"
 
 
 class Status(str, Enum):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -126,5 +126,5 @@ def transformed_result() -> TransformedResults:
         file_list=["/tmp/1.root", "/tmp/2.root"],
         signed_url_list=[],
         files=2,
-        result_format=ResultFormat.root_file,
+        result_format=ResultFormat.root,
     )

--- a/tests/test_datest_group.py
+++ b/tests/test_datest_group.py
@@ -37,9 +37,9 @@ def test_set_result_format(mocker):
     ds1 = mocker.Mock()
     ds2 = mocker.Mock()
     group = DatasetGroup([ds1, ds2])
-    group.set_result_format(ResultFormat.root_file)
-    ds1.set_result_format.assert_called_once_with(ResultFormat.root_file)
-    ds2.set_result_format.assert_called_once_with(ResultFormat.root_file)
+    group.set_result_format(ResultFormat.root)
+    ds1.set_result_format.assert_called_once_with(ResultFormat.root)
+    ds2.set_result_format.assert_called_once_with(ResultFormat.root)
 
 
 @pytest.mark.asyncio

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -58,7 +58,7 @@ def test_hash(transform_request):
 
     # Changing result_format does
     request2 = request1.copy()
-    request2.result_format = ResultFormat.root_file
+    request2.result_format = ResultFormat.root
     assert request1.compute_hash() != request2.compute_hash()
 
 


### PR DESCRIPTION
# Problem
The `ResultFormat` for root is named differently from the one for parquet

Fixes #320 

# Approach
Changed the type to be just plain `root`