### PR TITLE
Match the root file result format in the generated json to the expected value in the service

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -46,7 +46,7 @@ class ResultFormat(str, Enum):
     Specify the file format for the generated output
     """
     parquet = "parquet"
-    root = "root"
+    root = "root-file"
 
 
 class Status(str, Enum):

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -43,6 +43,16 @@ def servicex():
     return ServiceXAdapter("https://servicex.org")
 
 
+def test_result_formats():
+    """
+    This test is just to make sure the enum string representations match the values
+    expected by the service. Compare this to the json parser in
+    servicex.resources.transformation.submit.SubmitTransformationRequest.make_api
+    """
+    assert ResultFormat.parquet == "parquet"
+    assert ResultFormat.root == "root-file"
+
+
 @pytest.mark.asyncio
 @patch('servicex.servicex_adapter.httpx.AsyncClient.get')
 async def test_get_transforms(get, servicex, transform_status_response):


### PR DESCRIPTION

For consistency sake, the enum was changed to root, however this is not what the server expects. To fix this we keep the enum key root, but make the string representation root-file. Added a unit test to verify this along with a pointer to the statement in the ServiceX client which sets up the valid values for this field