### PR TITLE
Safeguard against VMS version numbers in tree names returned by `uproot`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,7 @@
         "AOD's",
         "asyncio",
         "atlasxaod",
+        "autopep",
         "awks",
         "AZNLOCTEQ",
         "backend's",
@@ -50,6 +51,7 @@
         "miniouser",
         "mino",
         "myfile",
+        "mypy",
         "nargs",
         "ncols",
         "ndarray",
@@ -65,6 +67,10 @@
         "protomolecule",
         "ptetaphi",
         "pyarrow",
+        "pycodestyle",
+        "pydocstyle",
+        "Pylance",
+        "pylint",
         "pypa",
         "pypi",
         "pytest",
@@ -95,7 +101,8 @@
         "unittests",
         "URL's",
         "xaod",
-        "xrootd"
+        "xrootd",
+        "yapf"
     ],
     "python.analysis.typeCheckingMode": "basic",
     "python.testing.pytestArgs": [

--- a/servicex/config_default.yaml
+++ b/servicex/config_default.yaml
@@ -31,7 +31,7 @@ default_return_data: parquet
 backend_types:
   - type: xaod
     return_data: root-file
-    codegen: atlasxaod
+    codegen: atlasr21
   - type: uproot
     return_data: parquet
     codegen: uproot

--- a/servicex/data_conversions.py
+++ b/servicex/data_conversions.py
@@ -154,6 +154,10 @@ class DataConverterAdaptor:
 
             with uproot.open(file) as f_in:  # type: ignore
                 tree_name = f_in.keys()[0]
+                # If `tree_name` ends with a ";NN", (where NN is a number
+                # left over from VMS file versioning!), remove everything from the
+                # ';' on
+                tree_name = tree_name.split(";")[0]
 
             if hasattr(uproot, "lazy"):
                 return uproot.lazy(f"{file}:{tree_name}")  # type: ignore

--- a/servicex/servicex.py
+++ b/servicex/servicex.py
@@ -198,7 +198,7 @@ class ServiceXDataset(ServiceXABC):
         Arguments
 
             dataset                     Name of a dataset from which queries will be selected.
-            backend_name                The type of backend. Used only if we need to find an
+            backend_name                The name of backend. Used only if we need to find an
                                         end-point. If we do not have a `servicex_adaptor` then this
                                         will default to xaod, unless you have any endpoint listed
                                         in your servicex file. It will default to best match there,

--- a/servicex/servicex_config.py
+++ b/servicex/servicex_config.py
@@ -44,6 +44,7 @@ class ServiceXConfigAdaptor:
 
         Args:
             backend_name (Optional[str]): The backend type string (`xaod`, `uproot`, etc)
+            backend_name (Optional[str]): Override the backend type
 
         Returns:
             str: The backend datatype, like `root` or `parquet`.
@@ -171,6 +172,7 @@ class ServiceXConfigAdaptor:
 
         # Now, extract the type and see if we can figure out any defaults from the
         # `backend_types` info. Skip this if we have a type we are passed in.
+        override_backend_info = backend_type is not None
         type_lookup = (
             backend_type
             if backend_type is not None
@@ -185,7 +187,7 @@ class ServiceXConfigAdaptor:
         for bd in backend_defaults:
             if bd["type"].as_str_expanded() == type_lookup:
                 for k in bd.keys():
-                    if k not in config:
+                    if override_backend_info or (k not in config):
                         config[k] = str(bd[k].as_str_expanded())
 
         # Finally, a default return type

--- a/tests/test_servicex.py
+++ b/tests/test_servicex.py
@@ -1387,7 +1387,7 @@ async def test_codegen_default_by_backend(mocker, good_awkward_file_data):
     await ds.get_data_rootfiles_async("(valid qastle string)")
 
     called = mock_servicex_adaptor.query_json
-    assert called["codegen"] == "atlasxaod"
+    assert called["codegen"] == "atlasr21"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* New version of uproot/awkward returns the version number for tree keys - but can't handle them in an `uproot.open`. Strip off the version number if it is there.
    * Classic example of VMS living on!
* Revise default configuration for backend name to reflect how ServiceX is usually configured, moving from `atlasxaod` to `atlasr21`.

Fixes #326