### PR TITLE
Ignore workflow property in transform request object

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -111,7 +111,6 @@ class TransformStatus(BaseModel):
     image: str
     result_destination: ResultDestination = Field(alias="result-destination")
     result_format: ResultFormat = Field(alias="result-format")
-    workflow_name: str = Field(alias="workflow-name")
     generated_code_cm: str = Field(alias="generated-code-cm")
     status: Status
     app_version: str = Field(alias="app-version")


### PR DESCRIPTION
The `workflow` property of the transform request is no longer used. This PR removes it from the model so that we can work with versions of ServiceX that no longer include it in the response.