### PR TITLE
None value check for Definition key 

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -151,7 +151,7 @@ class ServiceXSpec(BaseModel):
                         raise ValueError(f"Definition {value} not found")
             return value
 
-        if 'Definition' in values:
+        if 'Definition' in values and values['Definition'] is not None:
             defs = values['Definition'].dict()
         else:
             defs = {}


### PR DESCRIPTION
### Problem:
In the `ServiceXSpec` model in `databinder_models.py`, the function `replace_definition` has a check to see if the `Definition` key exists in the `values` dictionary. However, running the bigger_uproot.py I noticed that key had a value None and this was not checked and was throwing an AttributeError.

### Fix:
Added another condition to check for None value for the key `Definition`.

