### PR TITLE
Cache Clear fix on Temp files not deleting

### DIFF
--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -55,7 +55,7 @@ class Configuration(BaseModel):
         :param v:
         :return:
         """
-        #create a folder inside the tmp directory if not specified in cache_path
+        # create a folder inside the tmp directory if not specified in cache_path
         if not v:
             v = "/tmp/servicex_${USER}"
 

--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -55,8 +55,9 @@ class Configuration(BaseModel):
         :param v:
         :return:
         """
+        #create a folder inside the tmp directory if not specified in cache_path
         if not v:
-            v = "/tmp"
+            v = "/tmp/servicex_${USER}"
 
         s_path = os.path.expanduser(v)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -50,5 +50,14 @@ def test_config_read(tempdir):
 @patch('servicex.configuration.tempfile.gettempdir', return_value="./mytemp")
 def test_default_cache_path(tempdir):
 
+    # Windows style user name
+    os.environ['UserName'] = "p_higgs"
     c = Configuration.read(config_path="tests/example_config_no_cache_path.yaml")
-    assert c.cache_path == "mytemp"
+    assert c.cache_path == "mytemp/servicex_p_higgs"
+    del os.environ['UserName']
+
+    # Linux style user name
+    os.environ['USER'] = "p_higgs"
+    c = Configuration.read(config_path="tests/example_config_no_cache_path.yaml")
+    assert c.cache_path == "mytemp/servicex_p_higgs"
+    del os.environ['USER']


### PR DESCRIPTION
### On windows the cache is set to `/tmp` - which causes bad things when you do cache clear #304

### Problem:
When user does not give `cache_path` in `.servicex`, the default temp directory is used. Therefore when you try to clear the cache, some files are not deleted due to permission issue.

### Fix:
Rather than having `/tmp` as the default added `/tmp/servicex_$USER`. 
This ensures the local cache is set to this path and it is safely deleted when clearing cache

### Code changes:
In the configuration.py-> `expand_cache_path(cls, v)`, changed the default value of `v="/tmp"` to `v="/tmp/servicex_$USER"`

Added tests for this new changes in test_config.py

