### PR TITLE
ci: Use trusted publishers for publishing to PyPI

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -7,6 +7,10 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # Mandatory for publishing with a trusted publisher
+    # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    permissions:
+      id-token: write
 
     steps:
     - uses: actions/checkout@v4
@@ -59,7 +63,6 @@ jobs:
       if: github.repository == 'ssl-hep/ServiceX_frontend'
       uses: pypa/gh-action-pypi-publish@v1.8.14
       with:
-        password: ${{ secrets.pypi_password_servicex }}
         print-hash: true
 
   build-docs:


### PR DESCRIPTION
* Use the OpenID Connect (OIDC) standard to publish to PyPI using PyPI's "Trusted Publisher" implementation to publish without using API tokens stored as GitHub Actions secrets.
   - c.f. https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
   - c.f. https://docs.pypi.org/trusted-publishers/

For a full example (with lots of discussion) c.f. https://github.com/scikit-hep/pyhf/pull/2183

For a concise summary, c.f. the [Scientific Python Developer Guide section on this](https://learn.scientific-python.org/development/guides/gha-wheels/#publishing).

## What is required of a maintainer for this to work

1. Login to PyPI
2. Follow the [Adding a trusted publisher to an existing PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) instructions.