### PR TITLE
build: Remove nest-asyncio from core dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade '.[pandas,test]'
+          python -m pip install --upgrade '.[databinder,pandas,test]'
           python -m pip list
 
       - name: Test with pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ dependencies = [
     "PyYAML>=6.0",
     "types-PyYAML>=6.0",
     "rich>=13.0.0",  # databinder
-    "nest-asyncio>=1.5.7",  # databinder # FIXME: nest-asyncio deprecated
     "aiofile",  # compatible versions controlled through miniopy-async
     "make-it-sync",  # compatible versions controlled through func_adl
 ]
@@ -61,6 +60,10 @@ Homepage = "https://github.com/ssl-hep/ServiceX_frontend"
 "Source Code" = "https://github.com/ssl-hep/ServiceX_frontend"
 
 [project.optional-dependencies]
+
+databinder = [
+    "nest-asyncio>=1.5.7",  # databinder # FIXME: nest-asyncio deprecated
+]
 pandas = [
     "pandas>=2.0.2",
     "pyarrow>=12.0.0",
@@ -81,7 +84,7 @@ docs = [
     "furo>=2023.5.20",
 ]
 develop = [
-    "servicex[pandas,test,docs]",
+    "servicex[databinder,pandas,test,docs]",
 ]
 
 [tool.hatch.build.targets.sdist]


### PR DESCRIPTION
* As the databinder module is deprecated and scheduled for removal (c.f. https://github.com/ssl-hep/ServiceX_frontend/issues/355#issuecomment-2030460171), remove nest-asyncio from the required core dependencies.
* Add a 'databinder' extra that includes the nest-asyncio dependency, as the databinder module still exists and should be kept functional until it is removed or revised. (c.f. https://github.com/ssl-hep/ServiceX_frontend/issues/355#issuecomment-2032035624)

Amends PR https://github.com/ssl-hep/ServiceX_frontend/pull/349.