### PR TITLE
Remove pandas restrictions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", "3.11"]
+        python-version: [3.8, 3.9, "3.10", "3.11", "3.12"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
     "python.analysis.logLevel": "Information",
-    "python.analysis.memory.keepLibraryAst": true,
-    "python.linting.flake8Enabled": true,
     "cSpell.words": [
         "accesskey",
         "aenter",
@@ -109,13 +107,8 @@
         "tests",
         "-s"
     ],
-    "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "editor.formatOnSave": true,
-    "python.formatting.provider": "black",
     "restructuredtext.preview.docutils.disabled": true,
-    "python.linting.flake8Args": [
-        "--config=.flake8"
-    ],
 }

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     maintainer_email="gwatts@uw.edu",
     url="https://github.com/ssl-hep/ServiceX_frontend",
     license="TBD",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     test_suite="tests",
     install_requires=[
         "idna==2.10",  # Required to thread version needle with requests library
@@ -93,11 +93,11 @@ setup(
         "Topic :: Software Development",
         "Topic :: Utilities",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
     package_data={
         "servicex": ["config_default.yaml"],

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     test_suite="tests",
     install_requires=[
         "idna==2.10",  # Required to thread version needle with requests library
-        "pandas~=1.0",
+        "pandas>1.5",
         "uproot>=4.0.1",
         "backoff>=2.0",
         "aiohttp~=3.6",


### PR DESCRIPTION
* Remove the upper bound on the `pandas` installation.
* Remove 3.7 testing and support (`pandas` is no longer around for that release!).

## Minor

* Fix up some config options we for vscode that are depreciated.

Fixes #357