### PR TITLE
Multiple xrootdfiles

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run -m pytest --cov=./ --cov-report=xml
+          coverage run -m pytest tests --cov=./ --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3.1.4

--- a/examples/config_databinder_func_adl.yaml
+++ b/examples/config_databinder_func_adl.yaml
@@ -6,7 +6,7 @@ General:
 
 Sample:
   - Name: ggH
-    XRootdFile: DEF_ggH_input
+    XRootDdFiles: DEF_ggH_input
     NFiles: 5
     Query: DEF_ttH_nominal_query
 

--- a/examples/config_databinder_func_adl.yaml
+++ b/examples/config_databinder_func_adl.yaml
@@ -6,7 +6,7 @@ General:
 
 Sample:
   - Name: ggH
-    XRootDdFiles: DEF_ggH_input
+    XRootDFiles: DEF_ggH_input
     NFiles: 5
     Query: DEF_ttH_nominal_query
 

--- a/examples/config_databinder_python.yaml
+++ b/examples/config_databinder_python.yaml
@@ -17,7 +17,7 @@ Sample:
     Function: DEF_function1
 
   - Name: ggH
-    XRootdFiles: DEF_ggH_input
+    XRootDFiles: DEF_ggH_input
     Function: DEF_function2
 
 Definition:

--- a/examples/config_databinder_python.yaml
+++ b/examples/config_databinder_python.yaml
@@ -17,7 +17,7 @@ Sample:
     Function: DEF_function1
 
   - Name: ggH
-    XRootdFile: DEF_ggH_input
+    XRootdFiles: DEF_ggH_input
     Function: DEF_function2
 
 Definition:

--- a/examples/python_codegen.py
+++ b/examples/python_codegen.py
@@ -50,7 +50,7 @@ spec = ServiceXSpec(
     Sample=[
         Sample(
             Name="Python Codegen",
-            XRootdFile="root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-01-22/4lep/MC/mc_345060.ggH125_ZZ4lep.4lep.root",
+            XRootDFiles="root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets/2020-01-22/4lep/MC/mc_345060.ggH125_ZZ4lep.4lep.root",
             Function=run_query
         )
     ]

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -37,7 +37,7 @@ class Sample(BaseModel):
     Name: str
     Codegen: Optional[str]
     RucioDID: Optional[str]
-    XRootdFile: Optional[Union[str, AnyUrl]]
+    XRootDFiles: Optional[Union[str, list[str]]]
     NFiles: Optional[int] = Field(default=None)
     Function: Optional[Union[str, Callable]] = Field(default=None)
     Query: Optional[Union[str, func_adl_dataset.Query]] = Field(default=None)
@@ -51,8 +51,8 @@ class Sample(BaseModel):
     def dataset_identifier(self):
         if self.RucioDID:
             return RucioDatasetIdentifier(self.RucioDID, num_files=self.NFiles or 0)
-        elif self.XRootdFile:
-            return FileListDataset(self.XRootdFile)
+        elif self.XRootDFiles:
+            return FileListDataset(self.XRootDFiles)
 
     @root_validator
     def validate_did_xor_file(cls, values):
@@ -61,10 +61,10 @@ class Sample(BaseModel):
         :param values:
         :return:
         """
-        if values['XRootdFile'] and values['RucioDID']:
-            raise ValueError("Only specify one of XRootdFile or RucioDID, not both.")
-        if not values['XRootdFile'] and not values['RucioDID']:
-            raise ValueError("Must specify one of XRootdFile or RucioDID.")
+        if values['XRootDFiles'] and values['RucioDID']:
+            raise ValueError("Only specify one of XRootDFiles or RucioDID, not both.")
+        if not values['XRootDFiles'] and not values['RucioDID']:
+            raise ValueError("Must specify one of XRootDFiles or RucioDID.")
         return values
 
     @root_validator
@@ -92,7 +92,9 @@ class General(BaseModel):
 
     ServiceX: str = Field(..., alias="ServiceX")
     Codegen: str
-    OutputFormat: Union[OutputFormatEnum, constr(regex='^(parquet|root-file)$')]  # NOQA F722
+    OutputFormat: Union[OutputFormatEnum,
+        constr(regex='^(parquet|root-file)$')] = Field(default=OutputFormatEnum.root)  # NOQA F722
+
     Delivery: Union[DeliveryEnum, constr(regex='^(LocalCache|SignedURLs)$')] # NOQA F722
 
 

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -37,7 +37,7 @@ class Sample(BaseModel):
     Name: str
     Codegen: Optional[str]
     RucioDID: Optional[str]
-    XRootDFiles: Optional[Union[str, list[str]]]
+    XRootDFiles: Optional[Union[str, List[str]]]
     NFiles: Optional[int] = Field(default=None)
     Function: Optional[Union[str, Callable]] = Field(default=None)
     Query: Optional[Union[str, func_adl_dataset.Query]] = Field(default=None)

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from enum import Enum
 from typing import Union, Optional, Callable, List
-from pydantic import BaseModel, Field, AnyUrl, root_validator, constr, validator
+from pydantic import BaseModel, Field, root_validator, constr, validator
 
 from servicex.dataset_identifier import RucioDatasetIdentifier, FileListDataset
 from servicex.func_adl import func_adl_dataset
@@ -95,7 +95,7 @@ class General(BaseModel):
     OutputFormat: Union[OutputFormatEnum,
         constr(regex='^(parquet|root-file)$')] = Field(default=OutputFormatEnum.root)  # NOQA F722
 
-    Delivery: Union[DeliveryEnum, constr(regex='^(LocalCache|SignedURLs)$')] # NOQA F722
+    Delivery: Union[DeliveryEnum, constr(regex='^(LocalCache|SignedURLs)$')] = Field(default=DeliveryEnum.LocalCache) # NOQA F722
 
 
 class Definition(BaseModel):


### PR DESCRIPTION
# Problem
The Pydantic 3.0 client doesn't accept multiple root file paths. It only supports a single root file. 

# Approach
Changed the name of the property from `XRootdFile` to `XRootDFiles` and allow it to be a string or a list of strings. Note that the case changed on this too.

Need to start testing more of this functionality out, so I updated test_databinder as a start