### PR TITLE
ci: Use uv for all pip installs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,8 @@ jobs:
 
       - name: Lint with Flake8
         run: |
-          python -m pip install --upgrade flake8
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade flake8
           flake8
 
   test:
@@ -45,9 +46,10 @@ jobs:
 
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade '.[databinder,pandas,test]'
-          python -m pip list
+          python -m pip install --upgrade uv
+          uv pip install --system --upgrade pip setuptools wheel
+          uv pip install --system --upgrade '.[databinder,pandas,test]'
+          uv pip list --system
 
       - name: Test with pytest
         run: |

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -24,9 +24,10 @@ jobs:
 
     - name: Install python-build and twine
       run: |
-        python -m pip install --upgrade pip
-        python -m pip install build twine
-        python -m pip list
+        python -m pip install --upgrade uv
+        uv pip install --system --upgrade pip
+        uv pip install --system build twine
+        uv pip list --system
 
     - name: Set env
       run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -82,9 +83,10 @@ jobs:
 
     - name: Install Python dependencies
       run: |
-        python -m pip install --upgrade pip setuptools wheel
-        python -m pip install --upgrade '.[docs]'
-        python -m pip list
+        python -m pip install --upgrade uv
+        uv pip install --system --upgrade pip setuptools wheel
+        uv pip install --system --upgrade '.[docs]'
+        uv pip list --system
 
     - name: Build documentation
       run: |


### PR DESCRIPTION
* Use 'uv pip' for all calls to 'pip install' in GitHub Actions workflows.
   - c.f. https://github.com/astral-sh/uv/
   - In the case of the serviceX client, this is just a few seconds saved, but that adds up over every CI run.
* The '--system' call is required as uv requires a virtual environment to be activated without it, and GitHub Actions does not provide a default virtual environment.