### PR TITLE
Process Transform Title and Log URL

### DIFF
--- a/servicex/app/transforms.py
+++ b/servicex/app/transforms.py
@@ -71,7 +71,7 @@ def list(
     for t in transforms:
         if not complete or complete and t.status == Status.complete:
             table.add_row(
-                t.request_id, "Not implemented", t.status, str(t.files_completed)
+                t.request_id, t.title, t.status, str(t.files_completed)
             )
 
     rich.print(table)

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -159,3 +159,4 @@ class TransformedResults(BaseModel):
     signed_url_list: List[str]
     files: int
     result_format: ResultFormat
+    log_url: Optional[str]

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -107,6 +107,7 @@ class TransformStatus(BaseModel):
     """
     request_id: str
     did: str
+    title: Optional[str]
     selection: str
     tree_name: Optional[str] = Field(alias="tree-name")
     image: str
@@ -125,6 +126,7 @@ class TransformStatus(BaseModel):
     minio_secured: Optional[bool] = Field(alias="minio-secured")
     minio_access_key: Optional[str] = Field(alias="minio-access-key")
     minio_secret_key: Optional[str] = Field(alias="minio-secret-key")
+    log_url: Optional[str] = Field(alias="log-url")
 
     @validator("finish_time", pre=True)
     def parse_finish_time(cls, v):

--- a/servicex/query.py
+++ b/servicex/query.py
@@ -223,7 +223,7 @@ class Query(ABC):
         # If we get here with a cached record, then we know that the transform
         # has been run, but we just didn't get the files from object store in the way
         # requested by user
-        transform_bar_title = "Transform"
+        transform_bar_title = f"{sx_request.title}: Transform"
         if not cached_record:
             transform_progress = expandable_progress.add_task(
                 transform_bar_title, start=False, total=None

--- a/servicex/query.py
+++ b/servicex/query.py
@@ -236,6 +236,7 @@ class Query(ABC):
         minio_progress_bar_title = (
             "Download" if not signed_urls_only else "Signing URLS"
         )
+        minio_progress_bar_title = minio_progress_bar_title.rjust(len(transform_bar_title))
 
         download_progress = expandable_progress.add_task(
             minio_progress_bar_title, start=False, total=None

--- a/servicex/query.py
+++ b/servicex/query.py
@@ -338,7 +338,7 @@ class Query(ABC):
         # Is this the first time we've polled status? We now know the request ID.
         # Update the display and set our download directory.
         if not self.current_status:
-            rich.print(f"[bold]ServiceX Transform {s.request_id}[/bold]")
+            rich.print(f"[bold]ServiceX Transform {s.title}: {s.request_id}[/bold]")
             self.download_path = self.cache.cache_path_for_transform(s)
 
         self.current_status = s

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -64,7 +64,8 @@ class QueryCache:
             file_list=file_list,
             signed_url_list=signed_urls,
             files=completed_status.files,
-            result_format=transform.result_format
+            result_format=transform.result_format,
+            log_url=completed_status.log_url
         )
         self.db.insert(json.loads(record.json()))
         return record

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -122,5 +122,6 @@ class ServiceXAdapter:
                 raise AuthorizationError(f"Not authorized to access serviceX at {self.url}")
             if r.status_code == 404:
                 raise ValueError(f"Transform ID {request_id} not found")
+
             status = TransformStatus(**r.json())
             return status

--- a/tests/test_servicex_app_transforms.py
+++ b/tests/test_servicex_app_transforms.py
@@ -1,0 +1,60 @@
+from servicex.app.transforms import LogLevel, TimeFrame
+from servicex.app.transforms import add_query, select_time, create_kibana_link_parameters
+
+
+def test_add_query():
+    key = "abc"
+    value = "123-345-567"
+    query = "(query:(match_phrase:(abc:'123-345-567')))"
+    assert add_query(key, value) == query
+
+    key = "requestId"
+    value = "d2ede739-9779-4075-95b1-0c7fae1de408"
+    query = "(query:(match_phrase:(requestId:'d2ede739-9779-4075-95b1-0c7fae1de408')))"
+    assert add_query(key, value) == query
+
+
+def test_select_time():
+    time_frame = TimeFrame.week
+    time_filter = "time:(from:now%2Fw,to:now%2Fw)"
+    assert time_filter == select_time(time_frame)
+
+    time_frame = "month"
+    time_filter = "time:(from:now-30d%2Fd,to:now)"
+    assert time_filter == select_time(time_frame)
+
+    time_frame = "daY"
+    time_filter = "time:(from:now%2Fd,to:now%2Fd)"
+    assert time_filter == select_time(time_frame)
+
+
+def test_create_kibana_link_parameters():
+    initial_log_url = "https://atlas-kibana.mwt2.org:5601/s/servicex/app"\
+                      "/dashboards?auth_provider_hint=anonymous1#/view/"\
+                      "2d2b3b40-f34e-11ed-a6d8-9f6a16cd6d78?embed=true&_g=()"\
+                      "&show-time-filter=true&hide-filter-bar=true"
+    transform_id = "d2ede739-9779-4075-95b1-0c7fae1de408"
+    log_level = LogLevel.error
+    time_frame = TimeFrame.day
+    final_url = "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?"\
+                "auth_provider_hint=anonymous1#/view/2d2b3b40-f34e-11ed-a6d8-9f6a16cd6d78?"\
+                "embed=true&_g=(time:(from:now%2Fd,to:now%2Fd))"\
+                "&_a=(filters:!((query:(match_phrase:"\
+                "(requestId:'d2ede739-9779-4075-95b1-0c7fae1de408'))),"\
+                "(query:(match_phrase:(level:'error')))))&show-time-filter=true"\
+                "&hide-filter-bar=true"
+    assert create_kibana_link_parameters(initial_log_url, transform_id,
+                                         log_level, time_frame) == final_url
+
+    transform_id = "93713b34-2f0b-4d53-8412-8afa98626516"
+    log_level = LogLevel.info
+    time_frame = TimeFrame.month
+    final_url = "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?"\
+                "auth_provider_hint=anonymous1#/view/2d2b3b40-f34e-11ed-a6d8-9f6a16cd6d78?"\
+                "embed=true&_g=(time:(from:now-30d%2Fd,to:now))"\
+                "&_a=(filters:!((query:(match_phrase:"\
+                "(requestId:'93713b34-2f0b-4d53-8412-8afa98626516'))),"\
+                "(query:(match_phrase:(level:'info')))))&show-time-filter=true"\
+                "&hide-filter-bar=true"
+    assert create_kibana_link_parameters(initial_log_url, transform_id,
+                                         log_level, time_frame) == final_url


### PR DESCRIPTION
# Problem
The users would like to know the title of transforms and not just the request ID. They would also like to be able to view the logs for a transform without having to navigate the dashboard

# Approach
REST server nows sends the title over as well as the basic Logs url. Client will now parse this and use it in various places