### PR TITLE
Allow timeout for transform submission

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -102,5 +102,5 @@
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
-    "editor.formatOnSave": true,
+    "editor.formatOnSave": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -98,8 +98,7 @@
     ],
     "python.analysis.typeCheckingMode": "basic",
     "python.testing.pytestArgs": [
-        "tests",
-        "-s"
+        "tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,5 @@
 {
     "python.analysis.logLevel": "Information",
-    "python.analysis.memory.keepLibraryAst": true,
-    "python.linting.flake8Enabled": true,
     "cSpell.words": [
         "accesskey",
         "aenter",
@@ -103,13 +101,7 @@
         "tests",
         "-s"
     ],
-    "python.pythonPath": ".venv\\Scripts\\python.exe",
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,
     "editor.formatOnSave": true,
-    "python.formatting.provider": "black",
-    "restructuredtext.preview.docutils.disabled": true,
-    "python.linting.flake8Args": [
-        "--config=.flake8"
-    ],
 }

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -106,7 +106,7 @@ class ServiceXAdapter:
                                   headers=headers,
                                   json=transform_request.dict(by_alias=True,
                                                               exclude_none=True),
-                                  timeout=20)
+                                  timeout=60)
             if r.status_code == 401:
                 raise AuthorizationError(
                     f"Not authorized to access serviceX at {self.url}")

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -105,7 +105,8 @@ class ServiceXAdapter:
             r = await client.post(url=f"{self.url}/servicex/transformation",
                                   headers=headers,
                                   json=transform_request.dict(by_alias=True,
-                                                              exclude_none=True))
+                                                              exclude_none=True),
+                                  timeout=20)
             if r.status_code == 401:
                 raise AuthorizationError(
                     f"Not authorized to access serviceX at {self.url}")


### PR DESCRIPTION
The default transform submission timeout is 5 seconds. In cases where ServiceX has a very large cached filelist (say 65K!) it can take more than 5 seconds for it to reply.

This change makes the client more robust against that sitaution.

## Minor

* Update old vscode settings