### PR TITLE
Use logging library for status updates

### DIFF
--- a/examples/bigger_uproot.py
+++ b/examples/bigger_uproot.py
@@ -29,6 +29,11 @@
 from servicex import ServiceXSpec, General, Sample
 from servicex.func_adl.func_adl_dataset import FuncADLQuery
 from servicex.servicex_client import deliver
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("servicex")
+logger.setLevel(logging.DEBUG)
 
 query = FuncADLQuery().Select(lambda e: {'el_pt': e['el_pt']})
 

--- a/examples/databinder.py
+++ b/examples/databinder.py
@@ -31,9 +31,14 @@ import yaml
 
 from servicex import ServiceXSpec
 from servicex.servicex_client import deliver
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("servicex")
+logger.setLevel(logging.DEBUG)
 
 if len(sys.argv) != 2:
-    print("Usage: python databinder.py <config_file>")
+    logger.fatal("Usage: python databinder.py <config_file>")
     sys.exit(1)
 
 try:

--- a/examples/single_file_uproot.py
+++ b/examples/single_file_uproot.py
@@ -34,6 +34,13 @@ from servicex import ServiceXSpec, General, Sample
 from servicex.func_adl.func_adl_dataset import FuncADLQuery
 from servicex.servicex_client import deliver
 
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("servicex")
+logger.setLevel(logging.DEBUG)
+
+
 query = FuncADLQuery().Select(lambda e: {'lep_pt': e['lep_pt']}). \
     Where(lambda e: e['lep_pt'] > 1000)
 

--- a/servicex/query.py
+++ b/servicex/query.py
@@ -43,7 +43,6 @@ except ModuleNotFoundError:
 
 from servicex.types import DID
 
-import rich
 from rich.progress import Progress, TaskID
 
 from servicex.configuration import Configuration

--- a/servicex/query.py
+++ b/servicex/query.py
@@ -31,6 +31,7 @@ import abc
 import asyncio
 from abc import ABC
 from asyncio import Task, CancelledError
+import logging
 from typing import List, Optional, Union
 from servicex.expandable_progress import ExpandableProgress
 
@@ -43,9 +44,7 @@ except ModuleNotFoundError:
 from servicex.types import DID
 
 import rich
-from rich.progress import (
-    Progress,
-    TaskID)
+from rich.progress import Progress, TaskID
 
 from servicex.configuration import Configuration
 from servicex.minio_adapter import MinioAdapter
@@ -157,9 +156,10 @@ class Query(ABC):
         return self
 
     async def submit_and_download(
-        self, signed_urls_only: bool,
-            expandable_progress: ExpandableProgress,
-            dataset_group: Optional[bool] = False,
+        self,
+        signed_urls_only: bool,
+        expandable_progress: ExpandableProgress,
+        dataset_group: Optional[bool] = False,
     ) -> Optional[TransformedResults]:
         """
         Submit the transform request to ServiceX. Poll the transform status to see when
@@ -186,27 +186,31 @@ class Query(ABC):
             :return:
             """
             if task.exception():
-                rich.print("ServiceX Exception", task.exception())
+                logging.getLogger(__name__).error(
+                    "ServiceX Exception", exc_info=task.exception()
+                )
                 if download_files_task:
                     download_files_task.cancel("Transform failed")
                 raise task.exception()
 
             if self.current_status.files_failed:
-                rich.print(
-                    f"[bold red]Transforms completed with failures[/bold red] "
+                logging.getLogger(__name__).warning(
+                    f"Transforms completed with failures "
                     f"{self.current_status.files_failed} files failed out of "
                     f"{self.current_status.files}"
                 )
             else:
-                rich.print("Transforms completed successfully")
+                logging.getLogger(__name__).info("Transforms completed successfully")
 
         sx_request = self.transform_request
 
         # Let's see if this is in the cache already, but respect the user's wishes
         # to ignore the cache
-        cached_record = self.cache.get_transform_by_hash(sx_request.compute_hash()) \
-            if not self.ignore_cache \
+        cached_record = (
+            self.cache.get_transform_by_hash(sx_request.compute_hash())
+            if not self.ignore_cache
             else None
+        )
 
         # And that we grabbed the resulting files in the way that the user requested
         # (Downloaded, or obtained pre-signed URLs)
@@ -217,7 +221,7 @@ class Query(ABC):
                 or not signed_urls_only
                 and cached_record.file_list
             ):
-                rich.print("Returning results from cache")
+                logging.getLogger(__name__).info("Returning results from cache")
                 return cached_record
 
         # If we get here with a cached record, then we know that the transform
@@ -225,9 +229,13 @@ class Query(ABC):
         # requested by user
         transform_bar_title = f"{sx_request.title}: Transform"
         if not cached_record:
-            transform_progress = expandable_progress.add_task(
-                transform_bar_title, start=False, total=None
-            ) if expandable_progress else None
+            transform_progress = (
+                expandable_progress.add_task(
+                    transform_bar_title, start=False, total=None
+                )
+                if expandable_progress
+                else None
+            )
         else:
             self.request_id = cached_record.request_id
             transform_progress = None
@@ -236,19 +244,28 @@ class Query(ABC):
         minio_progress_bar_title = (
             "Download" if not signed_urls_only else "Signing URLS"
         )
-        minio_progress_bar_title = minio_progress_bar_title.rjust(len(transform_bar_title))
+        minio_progress_bar_title = minio_progress_bar_title.rjust(
+            len(transform_bar_title)
+        )
 
-        download_progress = expandable_progress.add_task(
-            minio_progress_bar_title, start=False, total=None
-        ) if expandable_progress else None
+        download_progress = (
+            expandable_progress.add_task(
+                minio_progress_bar_title, start=False, total=None
+            )
+            if expandable_progress
+            else None
+        )
 
         if not cached_record:
             self.request_id = await self.servicex.submit_transform(sx_request)
 
             monitor_task = loop.create_task(
                 self.transform_status_listener(
-                    expandable_progress, transform_progress, transform_bar_title,
-                    download_progress, minio_progress_bar_title
+                    expandable_progress,
+                    transform_progress,
+                    transform_bar_title,
+                    download_progress,
+                    minio_progress_bar_title,
                 )
             )
             monitor_task.add_done_callback(transform_complete)
@@ -289,11 +306,17 @@ class Query(ABC):
 
             return transform_report
         except CancelledError:
-            rich.print("Aborted file downloads due to transform failure")
+            logging.getLogger(__name__).warning(
+                "Aborted file downloads due to transform failure"
+            )
 
     async def transform_status_listener(
-        self, progress: ExpandableProgress, progress_task: TaskID,
-        progress_bar_title: str, download_task: TaskID, download_bar_title: str
+        self,
+        progress: ExpandableProgress,
+        progress_task: TaskID,
+        progress_bar_title: str,
+        download_task: TaskID,
+        download_bar_title: str,
     ):
         """
         Poll ServiceX for the status of a transform. Update progress bars and keep track
@@ -314,16 +337,21 @@ class Query(ABC):
             if not final_count and self.current_status.files:
                 final_count = self.current_status.files
                 if progress:
-                    progress.update(progress_task, progress_bar_title, total=final_count)
+                    progress.update(
+                        progress_task, progress_bar_title, total=final_count
+                    )
                     progress.start_task(task_id=progress_task, task_type="Transform")
 
-                    progress.update(download_task, download_bar_title, total=final_count)
+                    progress.update(
+                        download_task, download_bar_title, total=final_count
+                    )
                     progress.start_task(task_id=download_task, task_type="Download")
 
             if progress:
                 progress.update(
-                    progress_task, progress_bar_title,
-                    completed=self.current_status.files_completed
+                    progress_task,
+                    progress_bar_title,
+                    completed=self.current_status.files_completed,
                 )
 
             if self.current_status.status == Status.complete:
@@ -339,7 +367,9 @@ class Query(ABC):
         # Is this the first time we've polled status? We now know the request ID.
         # Update the display and set our download directory.
         if not self.current_status:
-            rich.print(f"[bold]ServiceX Transform {s.title}: {s.request_id}[/bold]")
+            logging.getLogger(__name__).info(
+                f"ServiceX Transform {s.title}: {s.request_id}"
+            )
             self.download_path = self.cache.cache_path_for_transform(s)
 
         self.current_status = s
@@ -434,25 +464,29 @@ class Query(ABC):
         await asyncio.gather(*download_tasks)
         return result_uris
 
-    async def as_files_async(self,
-                             display_progress: bool = True,
-                             provided_progress: Optional[ProgressIndicators] = None
-                             ) -> TransformedResults:
+    async def as_files_async(
+        self,
+        display_progress: bool = True,
+        provided_progress: Optional[ProgressIndicators] = None,
+    ) -> TransformedResults:
         r"""
         Submit the transform and request all the resulting files to be downloaded
         :return: TransformResult instance with the list of complete paths to the downloaded files
         """
         with ExpandableProgress(display_progress, provided_progress) as progress:
-            return await self.submit_and_download(signed_urls_only=False,
-                                                  expandable_progress=progress)
+            return await self.submit_and_download(
+                signed_urls_only=False, expandable_progress=progress
+            )
 
     as_files = make_sync(as_files_async)
 
     try:
-        async def as_pandas_async(self,
-                                  display_progress: bool = True,
-                                  provided_progress: Optional[ProgressIndicators] = None) \
-                -> pd.DataFrame:
+
+        async def as_pandas_async(
+            self,
+            display_progress: bool = True,
+            provided_progress: Optional[ProgressIndicators] = None,
+        ) -> pd.DataFrame:
             r"""
             Return a pandas dataframe containing the results. This only works if you've
             installed pandas extra
@@ -460,9 +494,9 @@ class Query(ABC):
             :return: Pandas Dataframe
             """
             self.result_format = ResultFormat.parquet
-            transformed_result = await self.as_files_async(display_progress=display_progress,
-                                                           provided_progress=provided_progress
-                                                           )
+            transformed_result = await self.as_files_async(
+                display_progress=display_progress, provided_progress=provided_progress
+            )
             dataframes = pd.concat(
                 [pd.read_parquet(p) for p in transformed_result.file_list]
             )
@@ -472,24 +506,31 @@ class Query(ABC):
     except NameError:
         pass
 
-    async def as_signed_urls_async(self, display_progress: bool = True,
-                                   provided_progress: Optional[ProgressIndicators] = None,
-                                   dataset_group: bool = False) \
-            -> TransformedResults:
+    async def as_signed_urls_async(
+        self,
+        display_progress: bool = True,
+        provided_progress: Optional[ProgressIndicators] = None,
+        dataset_group: bool = False,
+    ) -> TransformedResults:
         r"""
         Presign URLs for each of the transformed files
 
         :return: TransformedResults object with the presigned_urls list populated
         """
         if dataset_group:
-            return await self.submit_and_download(signed_urls_only=True,
-                                                  expandable_progress=provided_progress,
-                                                  dataset_group=dataset_group)
+            return await self.submit_and_download(
+                signed_urls_only=True,
+                expandable_progress=provided_progress,
+                dataset_group=dataset_group,
+            )
 
-        with ExpandableProgress(display_progress=display_progress,
-                                provided_progress=provided_progress) as progress:
-            return await self.submit_and_download(signed_urls_only=True,
-                                                  expandable_progress=progress,
-                                                  dataset_group=dataset_group)
+        with ExpandableProgress(
+            display_progress=display_progress, provided_progress=provided_progress
+        ) as progress:
+            return await self.submit_and_download(
+                signed_urls_only=True,
+                expandable_progress=progress,
+                dataset_group=dataset_group,
+            )
 
     as_signed_urls = make_sync(as_signed_urls_async)

--- a/servicex/query.py
+++ b/servicex/query.py
@@ -60,6 +60,7 @@ from servicex.servicex_adapter import ServiceXAdapter
 from make_it_sync import make_sync
 
 ProgressIndicators = Union[Progress, ExpandableProgress]
+logger = logging.getLogger(__name__)
 
 
 class Query(ABC):
@@ -185,7 +186,7 @@ class Query(ABC):
             :return:
             """
             if task.exception():
-                logging.getLogger(__name__).error(
+                logger.error(
                     "ServiceX Exception", exc_info=task.exception()
                 )
                 if download_files_task:
@@ -193,13 +194,13 @@ class Query(ABC):
                 raise task.exception()
 
             if self.current_status.files_failed:
-                logging.getLogger(__name__).warning(
+                logger.warning(
                     f"Transforms completed with failures "
                     f"{self.current_status.files_failed} files failed out of "
                     f"{self.current_status.files}"
                 )
             else:
-                logging.getLogger(__name__).info("Transforms completed successfully")
+                logger.info("Transforms completed successfully")
 
         sx_request = self.transform_request
 
@@ -220,7 +221,7 @@ class Query(ABC):
                 or not signed_urls_only
                 and cached_record.file_list
             ):
-                logging.getLogger(__name__).info("Returning results from cache")
+                logger.info("Returning results from cache")
                 return cached_record
 
         # If we get here with a cached record, then we know that the transform
@@ -305,7 +306,7 @@ class Query(ABC):
 
             return transform_report
         except CancelledError:
-            logging.getLogger(__name__).warning(
+            logger.warning(
                 "Aborted file downloads due to transform failure"
             )
 
@@ -366,7 +367,7 @@ class Query(ABC):
         # Is this the first time we've polled status? We now know the request ID.
         # Update the display and set our download directory.
         if not self.current_status:
-            logging.getLogger(__name__).info(
+            logger.info(
                 f"ServiceX Transform {s.title}: {s.request_id}"
             )
             self.download_path = self.cache.cache_path_for_transform(s)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -58,14 +58,19 @@ def deliver(config: ServiceXSpec):
     for sample in config.Sample:
         if sample.Query:
             if type(sample.Query) is str:
-                qastle_query = qastle.python_ast_to_text_ast(ast.parse(sample.Query)) # NOQA E501
+                qastle_query = qastle.python_ast_to_text_ast(
+                    ast.parse(sample.Query)
+                )  # NOQA E501
                 sample.Query = FuncADLQuery()
 
                 sample.Query.set_provided_qastle(qastle_query)
 
-            query = sx.func_adl_dataset(sample.dataset_identifier, sample.Name,
-                                        get_codegen(sample, config.General),
-                                        config.General.OutputFormat)
+            query = sx.func_adl_dataset(
+                sample.dataset_identifier,
+                sample.Name,
+                get_codegen(sample, config.General),
+                config.General.OutputFormat,
+            )
             query._q_ast = sample.Query._q_ast
             query._item_type = sample.Query._item_type
             if sample.Tree:
@@ -86,9 +91,12 @@ def deliver(config: ServiceXSpec):
                 except SyntaxError as e:
                     raise SyntaxError(f"Syntax error in {sample.Name}: {e}")
 
-            dataset = sx.python_dataset(sample.dataset_identifier, sample.Name,
-                                        get_codegen(sample, config.General),
-                                        config.General.OutputFormat)
+            dataset = sx.python_dataset(
+                sample.dataset_identifier,
+                sample.Name,
+                get_codegen(sample, config.General),
+                config.General.OutputFormat,
+            )
             dataset.python_function = sample.Function
             dataset.ignore_cache = sample.IgnoreLocalCache
             datasets.append(dataset)
@@ -173,7 +181,7 @@ class ServiceXClient:
         if backend:
             cached_backends = self.query_cache.get_codegen_by_backend(backend)
         if cached_backends:
-            rich.print("Returning code generators from cache")
+            logging.getLogger(__name__).info("Returning code generators from cache")
             return cached_backends["codegens"]
         else:
             code_generators = self.servicex.get_code_generators()
@@ -187,7 +195,7 @@ class ServiceXClient:
         codegen: str = "uproot",
         result_format: Optional[ResultFormat] = None,
         item_type: Type[T] = Any,
-        ignore_cache: bool = False
+        ignore_cache: bool = False,
     ) -> FuncADLQuery[T]:
         r"""
         Generate a dataset that can use func_adl query language
@@ -217,7 +225,7 @@ class ServiceXClient:
             query_cache=self.query_cache,
             result_format=result_format,
             item_type=item_type,
-            ignore_cache=ignore_cache
+            ignore_cache=ignore_cache,
         )
 
     def python_dataset(
@@ -226,7 +234,7 @@ class ServiceXClient:
         title: str = "ServiceX Client",
         codegen: str = "uproot",
         result_format: Optional[ResultFormat] = None,
-        ignore_cache: bool = False
+        ignore_cache: bool = False,
     ) -> PythonQuery:
         r"""
         Generate a dataset that can use accept a python function for the  query
@@ -256,5 +264,5 @@ class ServiceXClient:
             config=self.config,
             query_cache=self.query_cache,
             result_format=result_format,
-            ignore_cache=ignore_cache
+            ignore_cache=ignore_cache,
         )

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -43,6 +43,7 @@ from make_it_sync import make_sync
 from servicex.databinder_models import ServiceXSpec, General, Sample
 
 T = TypeVar("T")
+logger = logging.getLogger(__name__)
 
 
 def deliver(config: ServiceXSpec):
@@ -180,7 +181,7 @@ class ServiceXClient:
         if backend:
             cached_backends = self.query_cache.get_codegen_by_backend(backend)
         if cached_backends:
-            logging.getLogger(__name__).info("Returning code generators from cache")
+            logger.info("Returning code generators from cache")
             return cached_backends["codegens"]
         else:
             code_generators = self.servicex.get_code_generators()

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -25,6 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import logging
 from typing import Optional, List, TypeVar, Any, Type
 
 from servicex.configuration import Configuration
@@ -40,8 +41,6 @@ import qastle
 
 from make_it_sync import make_sync
 from servicex.databinder_models import ServiceXSpec, General, Sample
-
-import rich
 
 T = TypeVar("T")
 


### PR DESCRIPTION
This PR will exchange some of the `rich.print` calls that happen as the library runs and route them through `logging.info` and `logging.warning` and `logging.error`.

* Less inline output while library is running
* Allows user of library to control how much output is printed
* Brings it into line for the "correct" way to use library, according to python.