### PR TITLE
Handle unknown status code being returned in submission

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -111,6 +111,8 @@ class ServiceXAdapter:
                     f"Not authorized to access serviceX at {self.url}")
             elif r.status_code == 400:
                 raise ValueError(f"Invalid transform request: {r.json()['message']}")
+            elif r.status_code >= 400:
+                raise ValueError(f"Error in transformation submission: {r.json()['message']}")
         return r.json()['request_id']
 
     async def get_transform_status(self, request_id: str) -> TransformStatus:


### PR DESCRIPTION
Be more informative if e.g. status 500 is returned from ServiceX