### PR TITLE
Add timeout to transform status

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -118,7 +118,8 @@ class ServiceXAdapter:
         async with httpx.AsyncClient() as client:
             headers = await self._get_authorization(client)
             r = await client.get(url=f"{self.url}/servicex/transformation/{request_id}",
-                                 headers=headers)
+                                 headers=headers,
+                                 timeout=10)
             if r.status_code == 401:
                 raise AuthorizationError(f"Not authorized to access serviceX at {self.url}")
             if r.status_code == 404:


### PR DESCRIPTION
When ServiceX gets busy, sometimes it takes a little longer than 5 seconds (5.1 seconds in testing) to respond to a status transfer. This change will make sure we don't fail when that happens.

Fixes #373.
