### PR TITLE
Further clean up of error messages

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -112,8 +112,10 @@ class ServiceXAdapter:
                     f"Not authorized to access serviceX at {self.url}")
             elif r.status_code == 400:
                 raise ValueError(f"Invalid transform request: {r.json()['message']}")
-            elif r.status_code >= 400:
-                raise ValueError(f"Error in transformation submission: {r}")
+            elif r.status_code > 400:
+                error_message = r.json().get('message', str(r))
+                raise RuntimeError("ServiceX WebAPI Error during transformation "
+                                   f"submission: {r.status_code} - {error_message}")
         return r.json()['request_id']
 
     async def get_transform_status(self, request_id: str) -> TransformStatus:


### PR DESCRIPTION
PR #378 was working but not tuned up before the submission. This PR:

* Improves error logic (it wasn't wrong before, just two options for a branch)
* Improves the error message further.

Error message now looks like the following:
```
  File "/venv/lib/python3.9/site-packages/servicex/dataset_group.py", line 76, in as_signed_urls_async
    return await asyncio.gather(*self.tasks)
  File "/venv/lib/python3.9/site-packages/servicex/query.py", line 521, in as_signed_urls_async
    return await self.submit_and_download(
  File "/venv/lib/python3.9/site-packages/servicex/query.py", line 260, in submit_and_download
    self.request_id = await self.servicex.submit_transform(sx_request)
  File "/venv/lib/python3.9/site-packages/servicex/servicex_adapter.py", line 120, in submit_transform
    raise RuntimeError("ServiceX WebAPI Error during transformation "
RuntimeError: ServiceX WebAPI Error during transformation submission: 504 - <Response [504 Gateway Time-out]>
```