### PR TITLE
Fix default progress bar for SignedURL 

### DIFF
--- a/servicex/dataset_group.py
+++ b/servicex/dataset_group.py
@@ -67,10 +67,9 @@ class DatasetGroup:
         display_progress: bool = True,
         provided_progress: Optional[Progress] = None,
     ) -> List[TransformedResults]:
-        with ExpandableProgress(display_progress, provided_progress,
-                                overall_progress=True) as progress:
+        with ExpandableProgress(display_progress, provided_progress) as progress:
             self.tasks = [
-                d.as_signed_urls_async(provided_progress=progress, dataset_group=True)
+                d.as_signed_urls_async(provided_progress=progress)
                 for d in self.datasets
             ]
             return await asyncio.gather(*self.tasks)


### PR DESCRIPTION
The default progress bar is set to `overall_progress` when `Delivery` is set to `SignedURLs`. Fix default to show progress bar for each sample.