### PR TITLE
General.ServiceX as an optional field

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -96,7 +96,7 @@ class General(BaseModel):
         LocalCache = "LocalCache"
         SignedURLs = "SignedURLs"
 
-    ServiceX: str = Field(..., alias="ServiceX")
+    ServiceX: str = Field(default=None)
     Codegen: Optional[str] = None
     OutputFormat: ResultFormat = (
         Field(default=ResultFormat.root, pattern="^(parquet|root-file)$")
@@ -110,8 +110,11 @@ class General(BaseModel):
     OutFilesetName: str = 'servicex_fileset'
 
 
+_General = General
+
+
 class ServiceXSpec(BaseModel):
-    General: General
+    General: _General = General()
     Sample: List[Sample]
     Definition: Optional[List] = None
 

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -109,6 +109,8 @@ class General(BaseModel):
     OutFilesetName: str = 'servicex_fileset'
 
 
+# TODO: ServiceXSpec class has a field name General and it clashes with the class name General
+# when it is called General() to initialize default values for General class
 _General = General
 
 

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -96,7 +96,6 @@ class General(BaseModel):
         LocalCache = "LocalCache"
         SignedURLs = "SignedURLs"
 
-    ServiceX: str = Field(default=None)
     Codegen: Optional[str] = None
     OutputFormat: ResultFormat = (
         Field(default=ResultFormat.root, pattern="^(parquet|root-file)$")

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -141,7 +141,11 @@ class ServiceXClient:
         self.endpoints = self.config.endpoint_dict()
 
         if not url and not backend:
-            backend = self.config.default_endpoint
+            if self.config.default_endpoint:
+                backend = self.config.default_endpoint
+            else:
+                # Take the first endpoint from servicex.yaml if default_endpoint is not set
+                backend = self.config.api_endpoints[0].name
 
         if bool(url) == bool(backend):
             raise ValueError("Only specify backend or url... not both")

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -45,7 +45,11 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-def deliver(config: Union[ServiceXSpec, Mapping[str, Any]], config_path: Optional[str] = None):
+def deliver(
+    config: Union[ServiceXSpec, Mapping[str, Any]],
+    config_path: Optional[str] = None,
+    servicex_name: Optional[str] = None
+):
     if isinstance(config, Mapping):
         config = ServiceXSpec(**config)
 
@@ -59,7 +63,7 @@ def deliver(config: Union[ServiceXSpec, Mapping[str, Any]], config_path: Optiona
         elif isinstance(_sample.Query, Query):
             return _sample.Query.codegen
 
-    sx = ServiceXClient(backend=config.General.ServiceX, config_path=config_path)
+    sx = ServiceXClient(backend=servicex_name, config_path=config_path)
     datasets = []
     for sample in config.Sample:
         if sample.Query:

--- a/tests/example_config_default_endpoint.yaml
+++ b/tests/example_config_default_endpoint.yaml
@@ -1,0 +1,19 @@
+# Default settings for servicex. This will point you to a developer end-point, that
+# you've setup on your own machine (usually using k8's port-forward command):
+
+api_endpoints:
+  - endpoint: http://localhost:5000
+    name: localhost
+
+  - endpoint: https://servicex-release-testing-4.servicex.ssl-hep.org
+    name: testing4
+    token: notreallyatoken
+
+  - endpoint: https://servicex.af.uchicago.edu
+    name: servicex-uc-af
+    token: notreallyatoken
+
+# This is the path of the cache. The "/tmp" will be translated, platform appropriate, and
+# the env variable USER will be replaced.
+cache_path: /tmp/servicex_${USER}
+default_endpoint: servicex-uc-af

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -8,7 +8,6 @@ from servicex import ServiceXSpec, FileListDataset, RucioDatasetIdentifier
 def basic_spec(samples=None):
     return {
         "General": {
-            "ServiceX": "servicex",
             "Codegen": "python",
         },
         "Sample": samples
@@ -19,7 +18,6 @@ def basic_spec(samples=None):
 def test_load_config():
     config = {
         "General": {
-            "ServiceX": "servicex",
             "Codegen": "python",
             "Delivery": "LocalCache",
         },
@@ -156,7 +154,6 @@ def test_submit_mapping(transformed_result, codegen_list):
     from servicex import deliver
     spec = {
         "General": {
-            "ServiceX": "servicex-uc-af",
             "Codegen": "uproot-raw",
         },
         "Sample": [
@@ -181,7 +178,6 @@ def test_yaml(tmp_path):
     with open(path := (tmp_path / "python.yaml"), "w") as f:
         f.write("""
 General:
-  ServiceX: "servicex-uc-af"
   OutputFormat: root-file
   Delivery: LocalCache
 
@@ -206,7 +202,6 @@ Sample:
     with open(path := (tmp_path / "python.yaml"), "w") as f:
         f.write("""
 General:
-  ServiceX: "servicex-uc-af"
   OutputFormat: root-file
   Delivery: LocalCache
 
@@ -228,7 +223,6 @@ def test_yaml_include(tmp_path):
     with open(tmp_path / "definitions.yaml", "w") as f1, \
          open(path2 := (tmp_path / "parent.yaml"), "w") as f2:
         f1.write("""
-- &DEF_facility servicex-uc-af
 - &DEF_query !Python |
         def run_query(input_filenames=None):
             return []
@@ -238,7 +232,6 @@ Definitions:
     !include definitions.yaml
 
 General:
-  ServiceX: *DEF_facility
   OutputFormat: root-file
   Delivery: LocalCache
 
@@ -255,10 +248,7 @@ Sample:
 def test_funcadl_query(transformed_result, codegen_list):
     from servicex import deliver
     from servicex.func_adl.func_adl_dataset import FuncADLQuery_Uproot
-    spec = ServiceXSpec.model_validate({
-        "General": {
-            "ServiceX": "servicex-uc-af",
-        },
+    spec = ServiceXSpec.model_validate({        
         "Sample": [
             {
                 "Name": "sampleA",
@@ -280,8 +270,7 @@ def test_query_with_codegen_override(transformed_result, codegen_list):
     from servicex.func_adl.func_adl_dataset import FuncADLQuery_Uproot
     # first, with General override
     spec = ServiceXSpec.model_validate({
-        "General": {
-            "ServiceX": "servicex-uc-af",
+        "General": {            
             "Codegen": "does-not-exist"
         },
         "Sample": [
@@ -303,10 +292,7 @@ def test_query_with_codegen_override(transformed_result, codegen_list):
         assert excinfo.value.args[0].startswith('does-not-exist')
 
     # second, with sample-level override
-    spec = ServiceXSpec.model_validate({
-        "General": {
-            "ServiceX": "servicex-uc-af"
-        },
+    spec = ServiceXSpec.model_validate({        
         "Sample": [
             {
                 "Name": "sampleA",
@@ -331,9 +317,6 @@ def test_databinder_load_dict():
     from servicex.func_adl.func_adl_dataset import FuncADLQuery_Uproot
     from servicex.databinder.databinder_configuration import load_databinder_config
     load_databinder_config({
-        "General": {
-            "ServiceX": "servicex-uc-af",
-        },
         "Sample": [
             {
                 "Name": "sampleA",
@@ -352,10 +335,7 @@ def run_query(input_filenames=None):
     print("Greetings from your query")
     return []
 """
-    spec = ServiceXSpec.model_validate({
-        "General": {
-            "ServiceX": "servicex-uc-af",
-        },
+    spec = ServiceXSpec.model_validate({        
         "Sample": [
             {
                 "Name": "sampleA",
@@ -374,10 +354,7 @@ def run_query(input_filenames=None):
 def test_uproot_raw_query(transformed_result, codegen_list):
     from servicex import deliver
     from servicex.uproot_raw.uproot_raw import UprootRawQuery
-    spec = ServiceXSpec.model_validate({
-        "General": {
-            "ServiceX": "servicex-uc-af",
-        },
+    spec = ServiceXSpec.model_validate({        
         "Sample": [
             {
                 "Name": "sampleA",
@@ -396,10 +373,7 @@ def test_uproot_raw_query(transformed_result, codegen_list):
 def test_fail_with_tree_on_non_funcadl_query():
     from servicex.uproot_raw.uproot_raw import UprootRawQuery
     with pytest.raises(ValueError):
-        ServiceXSpec.model_validate({
-            "General": {
-                "ServiceX": "servicex-uc-af",
-            },
+        ServiceXSpec.model_validate({            
             "Sample": [
                 {
                     "Name": "sampleA",
@@ -415,7 +389,6 @@ def test_generic_query(codegen_list):
     from servicex.servicex_client import ServiceXClient
     spec = ServiceXSpec.model_validate({
         "General": {
-            "ServiceX": "servicex-uc-af",
             "Codegen": "uproot-raw",
         },
         "Sample": [
@@ -428,7 +401,7 @@ def test_generic_query(codegen_list):
     })
     with patch('servicex.servicex_client.ServiceXClient.get_code_generators',
                return_value=codegen_list):
-        sx = ServiceXClient(backend=spec.General.ServiceX, config_path='tests/example_config.yaml')
+        sx = ServiceXClient(config_path='tests/example_config.yaml')
         query = sx.generic_query(dataset_identifier=spec.Sample[0].RucioDID,
                                  codegen=spec.General.Codegen, query=spec.Sample[0].Query)
         assert query.generate_selection_string() == "[{'treename': 'nominal'}]"

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -248,7 +248,7 @@ Sample:
 def test_funcadl_query(transformed_result, codegen_list):
     from servicex import deliver
     from servicex.func_adl.func_adl_dataset import FuncADLQuery_Uproot
-    spec = ServiceXSpec.model_validate({        
+    spec = ServiceXSpec.model_validate({
         "Sample": [
             {
                 "Name": "sampleA",
@@ -270,7 +270,7 @@ def test_query_with_codegen_override(transformed_result, codegen_list):
     from servicex.func_adl.func_adl_dataset import FuncADLQuery_Uproot
     # first, with General override
     spec = ServiceXSpec.model_validate({
-        "General": {            
+        "General": {
             "Codegen": "does-not-exist"
         },
         "Sample": [
@@ -292,7 +292,7 @@ def test_query_with_codegen_override(transformed_result, codegen_list):
         assert excinfo.value.args[0].startswith('does-not-exist')
 
     # second, with sample-level override
-    spec = ServiceXSpec.model_validate({        
+    spec = ServiceXSpec.model_validate({
         "Sample": [
             {
                 "Name": "sampleA",
@@ -335,7 +335,7 @@ def run_query(input_filenames=None):
     print("Greetings from your query")
     return []
 """
-    spec = ServiceXSpec.model_validate({        
+    spec = ServiceXSpec.model_validate({
         "Sample": [
             {
                 "Name": "sampleA",
@@ -354,7 +354,7 @@ def run_query(input_filenames=None):
 def test_uproot_raw_query(transformed_result, codegen_list):
     from servicex import deliver
     from servicex.uproot_raw.uproot_raw import UprootRawQuery
-    spec = ServiceXSpec.model_validate({        
+    spec = ServiceXSpec.model_validate({
         "Sample": [
             {
                 "Name": "sampleA",
@@ -373,7 +373,7 @@ def test_uproot_raw_query(transformed_result, codegen_list):
 def test_fail_with_tree_on_non_funcadl_query():
     from servicex.uproot_raw.uproot_raw import UprootRawQuery
     with pytest.raises(ValueError):
-        ServiceXSpec.model_validate({            
+        ServiceXSpec.model_validate({
             "Sample": [
                 {
                     "Name": "sampleA",

--- a/tests/test_default_endpoint.py
+++ b/tests/test_default_endpoint.py
@@ -1,0 +1,17 @@
+from unittest.mock import patch
+
+from servicex.servicex_client import ServiceXClient
+
+
+def test_default_endpoint(codegen_list):
+    with patch('servicex.servicex_client.ServiceXClient.get_code_generators',
+               return_value=codegen_list):
+        sx = ServiceXClient(config_path="tests/example_config.yaml")
+        assert sx.servicex.url == "http://localhost:5000"
+
+
+def test_first_endpoint(codegen_list):
+    with patch('servicex.servicex_client.ServiceXClient.get_code_generators',
+               return_value=codegen_list):
+        sx = ServiceXClient(config_path="tests/example_config_default_endpoint.yaml")
+        assert sx.servicex.url == "https://servicex.af.uchicago.edu"


### PR DESCRIPTION
- `General.ServiceX` as an optional field to further minimize boilerplate
- Now `General` block can be omitted from `ServiceXSpec` and only `Sample` block is required
- Default `General.ServiceX` value is taken from the `default_endpoint` if present in the `servicex.yaml`. Otherwise the first endpoint is taken. (Assuming normal users have one endpoint)