### PR TITLE
Don't add failed results to cache

### DIFF
--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -49,12 +49,11 @@ class QueryCache:
     def close(self):
         self.db.close()
 
-    def cache_transform(self, transform: TransformRequest,
-                        completed_status: TransformStatus, data_dir: str,
-                        file_list: List[str],
-                        signed_urls) -> TransformedResults:
-
-        record = TransformedResults(
+    def transformed_results(self, transform: TransformRequest,
+                            completed_status: TransformStatus, data_dir: str,
+                            file_list: List[str],
+                            signed_urls) -> TransformedResults:
+        return TransformedResults(
             hash=transform.compute_hash(),
             title=transform.title,
             codegen=transform.codegen,
@@ -67,8 +66,9 @@ class QueryCache:
             result_format=transform.result_format,
             log_url=completed_status.log_url
         )
+
+    def cache_transform(self, record: TransformedResults):
         self.db.insert(json.loads(record.model_dump_json()))
-        return record
 
     def update_record(self, record: TransformedResults):
         transforms = Query()

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -68,11 +68,13 @@ def test_cache_transform(transform_request, completed_status):
         config = Configuration(cache_path=temp_dir, api_endpoints=[])  # type: ignore
         cache = QueryCache(config)
         cache.cache_transform(
-            transform=transform_request,
-            completed_status=completed_status,
-            data_dir="/foo/bar",
-            file_list=file_uris,
-            signed_urls=[],
+            cache.transformed_results(
+                transform=transform_request,
+                completed_status=completed_status,
+                data_dir="/foo/bar",
+                file_list=file_uris,
+                signed_urls=[],
+            )
         )
 
         test = cache.get_transform_by_hash(transform_request.compute_hash())
@@ -92,11 +94,13 @@ def test_cache_transform(transform_request, completed_status):
 
         # make a duplicate record
         cache.cache_transform(
-            transform=transform_request,
-            completed_status=completed_status,
-            data_dir="/foo/baz",
-            file_list=file_uris,
-            signed_urls=[],
+            cache.transformed_results(
+                transform=transform_request,
+                completed_status=completed_status,
+                data_dir="/foo/baz",
+                file_list=file_uris,
+                signed_urls=[],
+            )
         )
 
         with pytest.raises(CacheException):
@@ -130,21 +134,25 @@ def test_record_delete(transform_request, completed_status):
         config = Configuration(cache_path=temp_dir, api_endpoints=[])  # type: ignore
         cache = QueryCache(config)
         cache.cache_transform(
-            transform=transform_request,
-            completed_status=completed_status,
-            data_dir="/foo/bar",
-            file_list=file_uris,
-            signed_urls=[],
+            cache.transformed_results(
+                transform=transform_request,
+                completed_status=completed_status,
+                data_dir="/foo/bar",
+                file_list=file_uris,
+                signed_urls=[],
+            )
         )
 
         cache.cache_transform(
-            transform=transform_request,
-            completed_status=completed_status.model_copy(
-                update={"request_id": "02c64494-4529-49a7-a4a6-95661ea3936e"}
-            ),
-            data_dir="/foo/baz",
-            file_list=file_uris,
-            signed_urls=[],
+            cache.transformed_results(
+                transform=transform_request,
+                completed_status=completed_status.model_copy(
+                    update={"request_id": "02c64494-4529-49a7-a4a6-95661ea3936e"}
+                ),
+                data_dir="/foo/baz",
+                file_list=file_uris,
+                signed_urls=[],
+            )
         )
 
         assert len(cache.cached_queries()) == 2
@@ -213,11 +221,13 @@ def test_add_both_codegen_and_transform_to_cache(transform_request, completed_st
         config = Configuration(cache_path=temp_dir, api_endpoints=[])  # type: ignore
         cache = QueryCache(config)
         cache.cache_transform(
-            transform=transform_request,
-            completed_status=completed_status,
-            data_dir="/foo/bar",
-            file_list=file_uris,
-            signed_urls=[],
+            cache.transformed_results(
+                transform=transform_request,
+                completed_status=completed_status,
+                data_dir="/foo/bar",
+                file_list=file_uris,
+                signed_urls=[],
+            )
         )
 
         cache.update_codegen_by_backend('backend_1', ['codegen_1'])

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -287,7 +287,7 @@ async def test_use_of_cache(mocker):
             config=config,
         )
         datasource.result_format = ResultFormat.parquet
-        upd = mocker.patch.object(cache, 'update_record')
+        upd = mocker.patch.object(cache, 'update_record', side_effect=cache.update_record)
         with ExpandableProgress(display_progress=False) as progress:
             result1 = await datasource.submit_and_download(signed_urls_only=True,
                                                            expandable_progress=progress)


### PR DESCRIPTION
A miniature variant of #318 : if there are any failures, don't store in the cache at all (as opposed to noting the failure in the cache). Also doesn't include the locking features of #318.
