### PR TITLE
Cleanup servicex namespace

### DIFF
--- a/examples/Uproot_FuncADL_Dict.py
+++ b/examples/Uproot_FuncADL_Dict.py
@@ -1,8 +1,8 @@
-from servicex import FuncADL_Uproot, deliver
+from servicex import query as q, deliver
 
 
 def uproot_funcadl_dict():
-    query = FuncADL_Uproot().FromTree('reco'). \
+    query = q.FuncADL_Uproot().FromTree('reco'). \
         Select(lambda e: {'el_pt_NOSYS': e['el_pt_NOSYS']})  # type: ignore
 
     spec = {
@@ -18,5 +18,5 @@ def uproot_funcadl_dict():
     return deliver(spec)
 
 
-if __name__ == "main":
+if __name__ == "__main__":
     uproot_funcadl_dict()

--- a/examples/Uproot_PythonFunction_Dict.py
+++ b/examples/Uproot_PythonFunction_Dict.py
@@ -1,4 +1,4 @@
-from servicex import PythonFunction, deliver
+from servicex import query as q, deliver
 
 
 def uproot_pythonfunction_dict():
@@ -9,7 +9,7 @@ def uproot_pythonfunction_dict():
             br = o.arrays("el_pt_NOSYS")
         return br
 
-    query = PythonFunction().with_uproot_function(run_query)
+    query = q.PythonFunction().with_uproot_function(run_query)
 
     spec = {
         'General': {
@@ -24,5 +24,5 @@ def uproot_pythonfunction_dict():
     return deliver(spec)
 
 
-if __name__ == "main":
+if __name__ == "__main__":
     uproot_pythonfunction_dict()

--- a/examples/Uproot_UprootRaw_Dict.py
+++ b/examples/Uproot_UprootRaw_Dict.py
@@ -1,9 +1,9 @@
-from servicex import UprootRaw, deliver
+from servicex import query as q, deliver
 
 
 def uproot_uproot_raw_dict():
 
-    query = UprootRaw([{"treename": "reco", "filter_name": "el_pt_NOSYS"}])
+    query = q.UprootRaw([{"treename": "reco", "filter_name": "el_pt_NOSYS"}])
 
     spec = {
         'Sample': [{
@@ -15,5 +15,5 @@ def uproot_uproot_raw_dict():
     return deliver(spec)
 
 
-if __name__ == "main":
+if __name__ == "__main__":
     uproot_uproot_raw_dict()

--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -25,40 +25,17 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from servicex import dataset_group
-from servicex import models
-from servicex import servicex_client
-from servicex import dataset_identifier
 from servicex.databinder_models import Sample, General, ServiceXSpec
-from servicex.func_adl.func_adl_dataset import FuncADLQuery_Uproot as FuncADL_Uproot
-from servicex.uproot_raw.uproot_raw import UprootRawQuery as UprootRaw
-from servicex.python_dataset import PythonQuery as PythonFunction
-from servicex.servicex_client import ServiceXClient, deliver
-from .query_core import Query
+from servicex.servicex_client import deliver
 from .models import ResultFormat, ResultDestination
-from .dataset_group import DatasetGroup
-from .dataset_identifier import RucioDatasetIdentifier, FileListDataset
 import servicex.dataset as dataset
 import servicex.query as query
 
 __all__ = [
-    "ServiceXClient",
-    "Query",
-    "DatasetGroup",
     "ResultFormat",
     "ResultDestination",
-    "servicex_client",
-    "dataset_group",
-    "models",
-    "dataset_identifier",
-    "RucioDatasetIdentifier",
-    "FileListDataset",
-    "FuncADL_Uproot",
-    "UprootRaw",
-    "PythonFunction",
     "Sample",
     "General",
-    "DefinitionList",
     "ServiceXSpec",
     "deliver",
     "dataset",

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -2,7 +2,8 @@ import pytest
 from unittest.mock import patch
 from pydantic import ValidationError
 
-from servicex import ServiceXSpec, FileListDataset, RucioDatasetIdentifier, dataset
+from servicex import ServiceXSpec, dataset
+from servicex.dataset import FileList, Rucio
 
 
 def basic_spec(samples=None):
@@ -44,7 +45,7 @@ def test_single_root_file():
         )
     )
 
-    assert isinstance(spec.Sample[0].dataset_identifier, FileListDataset)
+    assert isinstance(spec.Sample[0].dataset_identifier, FileList)
     assert spec.Sample[0].dataset_identifier.files == [
         "root://eospublic.cern.ch//file1.root"
     ]
@@ -67,7 +68,7 @@ def test_list_of_root_files():
         )
     )
 
-    assert isinstance(spec.Sample[0].dataset_identifier, FileListDataset)
+    assert isinstance(spec.Sample[0].dataset_identifier, FileList)
     assert spec.Sample[0].dataset_identifier.files == [
         "root://eospublic.cern.ch//file1.root",
         "root://eospublic.cern.ch//file2.root",
@@ -87,7 +88,7 @@ def test_rucio_did():
         )
     )
 
-    assert isinstance(spec.Sample[0].dataset_identifier, RucioDatasetIdentifier)
+    assert isinstance(spec.Sample[0].dataset_identifier, Rucio)
     assert (
         spec.Sample[0].dataset_identifier.did
         == "rucio://user.ivukotic:user.ivukotic.single_top_tW__nominal"
@@ -108,7 +109,7 @@ def test_rucio_did_numfiles():
         )
     )
 
-    assert isinstance(spec.Sample[0].dataset_identifier, RucioDatasetIdentifier)
+    assert isinstance(spec.Sample[0].dataset_identifier, Rucio)
     assert (
         spec.Sample[0].dataset_identifier.did
         == "rucio://user.ivukotic:user.ivukotic.single_top_tW__nominal?files=10"
@@ -282,7 +283,7 @@ Sample:
 
 def test_funcadl_query(transformed_result, codegen_list):
     from servicex import deliver
-    from servicex import FuncADL_Uproot
+    from servicex.query import FuncADL_Uproot  # type: ignore
     spec = ServiceXSpec.model_validate({
         "Sample": [
             {
@@ -302,7 +303,7 @@ def test_funcadl_query(transformed_result, codegen_list):
 
 def test_query_with_codegen_override(transformed_result, codegen_list):
     from servicex import deliver
-    from servicex import FuncADL_Uproot
+    from servicex.query import FuncADL_Uproot  # type: ignore
     # first, with General override
     spec = ServiceXSpec.model_validate({
         "General": {
@@ -349,7 +350,7 @@ def test_query_with_codegen_override(transformed_result, codegen_list):
 
 
 def test_databinder_load_dict():
-    from servicex import FuncADL_Uproot
+    from servicex.query import FuncADL_Uproot  # type: ignore
     from servicex.servicex_client import _load_ServiceXSpec
     _load_ServiceXSpec({
         "Sample": [
@@ -364,7 +365,8 @@ def test_databinder_load_dict():
 
 
 def test_python_query(transformed_result, codegen_list):
-    from servicex import PythonFunction, deliver
+    from servicex import deliver
+    from servicex.query import PythonFunction  # type: ignore
 
     def run_query(input_filenames=None):
         print("Greetings from your query")
@@ -390,7 +392,7 @@ def test_python_query(transformed_result, codegen_list):
 
 def test_uproot_raw_query(transformed_result, codegen_list):
     from servicex import deliver
-    from servicex import UprootRaw
+    from servicex.query import UprootRaw  # type: ignore
     spec = ServiceXSpec.model_validate({
         "Sample": [
             {
@@ -444,4 +446,4 @@ def test_generic_query(codegen_list):
 
 def test_entrypoint_import():
     """ This will check that we have at least the Python transformer defined in servicex.query """
-    from servicex.query import PythonFunction  # noqa
+    from servicex.query import PythonFunction  # type: ignore # noqa: F401


### PR DESCRIPTION
Remove many things from the top-level `servicex` namespace. What remains:
```
__all__ = [
    "ResultFormat",
    "ResultDestination",
    "Sample",
    "General",
    "ServiceXSpec",
    "deliver",
    "dataset",
    "query"
]
```