### PR TITLE
Use "guard list" for `deliver()`

### DIFF
--- a/servicex/dataset_group.py
+++ b/servicex/dataset_group.py
@@ -66,25 +66,27 @@ class DatasetGroup:
         self,
         display_progress: bool = True,
         provided_progress: Optional[Progress] = None,
-    ) -> List[TransformedResults]:
+        return_exceptions: bool = False,
+    ) -> List[Union[TransformedResults, BaseException]]:
         with ExpandableProgress(display_progress, provided_progress) as progress:
             self.tasks = [
                 d.as_signed_urls_async(provided_progress=progress)
                 for d in self.datasets
             ]
-            return await asyncio.gather(*self.tasks)
+            return await asyncio.gather(*self.tasks, return_exceptions=return_exceptions)
 
     as_signed_urls = make_sync(as_signed_urls_async)
 
     async def as_files_async(self,
                              display_progress: bool = True,
-                             provided_progress: Optional[Progress] = None
-                             ) -> List[TransformedResults]:
+                             provided_progress: Optional[Progress] = None,
+                             return_exceptions: bool = False,
+                             ) -> List[Union[TransformedResults, BaseException]]:
         with ExpandableProgress(display_progress, provided_progress) as progress:
             self.tasks = [
                 d.as_files_async(provided_progress=progress)
                 for d in self.datasets
             ]
-            return await asyncio.gather(*self.tasks)
+            return await asyncio.gather(*self.tasks, return_exceptions=return_exceptions)
 
     as_files = make_sync(as_files_async)

--- a/servicex/dataset_group.py
+++ b/servicex/dataset_group.py
@@ -26,7 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import asyncio
-from typing import List, Optional
+from typing import List, Optional, Union
 from rich.progress import Progress
 
 from servicex.query_core import Query

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -151,7 +151,7 @@ def _build_datasets(config, config_path, servicex_name):
 
 
 def _output_handler(config: ServiceXSpec, requests: List[Query],
-                    results: List[TransformedResults]):
+                    results: List[Union[TransformedResults, Exception]]):
     matched_results = zip(requests, results)
     if config.General.Delivery == General.DeliveryEnum.SignedURLs:
         out_dict = {obj[0].title: GuardList(obj[1].signed_url_list
@@ -195,6 +195,7 @@ def deliver(
 
     elif config.General.Delivery == General.DeliveryEnum.LocalCache:
         results = group.as_files(return_exceptions=return_exceptions)
+        print(results)
         return _output_handler(config, datasets, results)
 
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -54,8 +54,9 @@ logger = logging.getLogger(__name__)
 
 class GuardList(Sequence):
     def __init__(self, data: Union[Sequence, Exception]):
+        import copy
         super().__init__()
-        self._data = data
+        self._data = copy.copy(data)
 
     def valid(self) -> bool:
         return not isinstance(self._data, Exception)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -26,7 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import logging
-from typing import Optional, List, TypeVar, Any, Type, Mapping, Union
+from typing import Optional, List, TypeVar, Any, Type, Mapping, Union, cast
 from pathlib import Path
 
 from servicex.configuration import Configuration
@@ -46,9 +46,41 @@ from servicex.dataset_group import DatasetGroup
 
 from make_it_sync import make_sync
 from servicex.databinder_models import ServiceXSpec, General, Sample
+from collections.abc import Sequence
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
+
+
+class GuardList(Sequence[T]):
+    def __init__(self, data: Union[Sequence[T], Exception]):
+        super().__init__()
+        self._data = data
+
+    def valid(self) -> bool:
+        return not isinstance(self._data, Exception)
+
+    def __getitem__(self, index) -> T:
+        if not self.valid():
+            data = cast(Exception, self._data)
+            raise data
+        else:
+            data = cast(Sequence[T], self._data)
+            return data[index]
+
+    def __len__(self):
+        if not self.valid():
+            data = cast(Exception, self._data)
+            raise data
+        else:
+            data = cast(Sequence, self._data)
+            return len(data)
+
+    def __repr__(self):
+        if self.valid():
+            return repr(self._data)
+        else:
+            return f'Invalid GuardList: {repr(self._data)}'
 
 
 def _load_ServiceXSpec(
@@ -156,11 +188,19 @@ def _build_datasets(config, config_path, servicex_name):
     return datasets
 
 
-def _output_handler(config: ServiceXSpec, results: List[TransformedResults]):
+def _output_handler(config: ServiceXSpec, requests: List[Query],
+                    results: List[TransformedResults]):
+    matched_results = zip(requests, results)
     if config.General.Delivery == General.DeliveryEnum.SignedURLs:
-        out_dict = {obj.title: obj.signed_url_list for obj in results}
+        out_dict = {obj[0].title: GuardList(obj[1].signed_url_list
+                                            if not isinstance(obj[1], Exception)
+                                            else obj[1])
+                    for obj in matched_results}
     elif config.General.Delivery == General.DeliveryEnum.LocalCache:
-        out_dict = {obj.title: obj.file_list for obj in results}
+        out_dict = {obj[0].title: GuardList(obj[1].file_list
+                                            if not isinstance(obj[1], Exception)
+                                            else obj[1])
+                    for obj in matched_results}
 
     if config.General.OutputDirectory:
         import yaml as yl
@@ -178,7 +218,8 @@ def _output_handler(config: ServiceXSpec, results: List[TransformedResults]):
 def deliver(
     config: Union[ServiceXSpec, Mapping[str, Any], str, Path],
     config_path: Optional[str] = None,
-    servicex_name: Optional[str] = None
+    servicex_name: Optional[str] = None,
+    return_exceptions: bool = True
 ):
     config = _load_ServiceXSpec(config)
 
@@ -187,12 +228,12 @@ def deliver(
     group = DatasetGroup(datasets)
 
     if config.General.Delivery == General.DeliveryEnum.SignedURLs:
-        results = group.as_signed_urls()
-        return _output_handler(config, results)
+        results = group.as_signed_urls(return_exceptions=return_exceptions)
+        return _output_handler(config, datasets, results)
 
     elif config.General.Delivery == General.DeliveryEnum.LocalCache:
-        results = group.as_files()
-        return _output_handler(config, results)
+        results = group.as_files(return_exceptions=return_exceptions)
+        return _output_handler(config, datasets, results)
 
 
 class ServiceXClient:

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -26,7 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import logging
-from typing import Optional, List, TypeVar, Any, Type, Mapping, Union, cast
+from typing import Optional, List, TypeVar, Any, Mapping, Union, cast
 from pathlib import Path
 
 from servicex.configuration import Configuration

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -52,23 +52,23 @@ T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
 
-class GuardList(Sequence[T]):
-    def __init__(self, data: Union[Sequence[T], Exception]):
+class GuardList(Sequence):
+    def __init__(self, data: Union[Sequence, Exception]):
         super().__init__()
         self._data = data
 
     def valid(self) -> bool:
         return not isinstance(self._data, Exception)
 
-    def __getitem__(self, index) -> T:
+    def __getitem__(self, index) -> Any:
         if not self.valid():
             data = cast(Exception, self._data)
             raise data
         else:
-            data = cast(Sequence[T], self._data)
+            data = cast(Sequence, self._data)
             return data[index]
 
-    def __len__(self):
+    def __len__(self) -> int:
         if not self.valid():
             data = cast(Exception, self._data)
             raise data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,6 +175,22 @@ def transformed_result(dummy_parquet_file) -> TransformedResults:
 
 
 @fixture
+def transformed_result_signed_url() -> TransformedResults:
+    return TransformedResults(
+        hash="123-4455",
+        title="Test",
+        codegen="uproot",
+        request_id="123-45-6789",
+        submit_time=datetime.now(),
+        data_dir="/foo/bar",
+        file_list=[],
+        signed_url_list=['https://dummy.junk.io/1.parquet', 'https://dummy.junk.io/2.parquet'],
+        files=2,
+        result_format=ResultFormat.root,
+    )
+
+
+@fixture
 def dummy_parquet_file():
     data = {'column1': [1, 2, 3, 4],
             'column2': ['A', 'B', 'C', 'D']}

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from pydantic import ValidationError
 
 from servicex import ServiceXSpec, FileListDataset, RucioDatasetIdentifier, dataset
+from servicex.query_core import ServiceXException
 
 
 def basic_spec(samples=None):
@@ -178,6 +179,29 @@ def test_submit_mapping(transformed_result, codegen_list):
          patch('servicex.servicex_client.ServiceXClient.get_code_generators',
                return_value=codegen_list):
         deliver(spec, config_path='tests/example_config.yaml')
+
+
+def test_submit_mapping_failure(transformed_result, codegen_list):
+    from servicex import deliver
+    spec = {
+        "Sample": [
+            {
+                "Name": "sampleA",
+                "RucioDID": "user.ivukotic:user.ivukotic.single_top_tW__nominal",
+                "Query": "[{'treename': 'nominal'}]",
+                "Codegen": "uproot-raw"
+            }
+        ]
+    }
+    with patch('servicex.dataset_group.DatasetGroup.as_files',
+               return_value=[ServiceXException("dummy")]), \
+         patch('servicex.servicex_client.ServiceXClient.get_code_generators',
+               return_value=codegen_list):
+        results = deliver(spec, config_path='tests/example_config.yaml')
+        assert len(results) == 1
+        with pytest.raises(ServiceXException):  # should expect an exception to be thrown on access
+            for _ in results['sampleA']:
+                pass
 
 
 def test_yaml(tmp_path):

--- a/tests/test_dataset_group.py
+++ b/tests/test_dataset_group.py
@@ -61,6 +61,23 @@ async def test_as_signed_urls(mocker, transformed_result):
 
 
 @pytest.mark.asyncio
+async def test_as_files(mocker, transformed_result):
+    ds1 = mocker.Mock()
+    ds1.as_files_async = AsyncMock(return_value=transformed_result)
+
+    ds2 = mocker.Mock()
+    ds2.as_files_async = AsyncMock(return_value=transformed_result.model_copy(
+        update={"request_id": "98-765-432"}))
+
+    group = DatasetGroup([ds1, ds2])
+    results = await group.as_files_async()
+
+    assert len(results) == 2
+    assert results[0].request_id == "123-45-6789"
+    assert results[1].request_id == "98-765-432"
+
+
+@pytest.mark.asyncio
 async def test_failure(mocker, transformed_result):
     ds1 = mocker.Mock()
     ds1.as_signed_urls_async = AsyncMock(return_value=transformed_result)

--- a/tests/test_guardlist.py
+++ b/tests/test_guardlist.py
@@ -1,0 +1,14 @@
+from servicex.servicex_client import GuardList
+import pytest
+
+
+def test_guardlist():
+    gl1 = GuardList([1])
+    assert str(gl1) == '[1]'
+    assert gl1[0] == 1
+    gl2 = GuardList(ValueError())
+    assert str(gl2) == 'Invalid GuardList: ValueError()'
+    with pytest.raises(ValueError):
+        gl2[0]
+    with pytest.raises(ValueError):
+        len(gl2)

--- a/tests/test_output_handler.py
+++ b/tests/test_output_handler.py
@@ -17,5 +17,5 @@ def test_output_directory(tmp_path):
     }
     config = ServiceXSpec(**config)
 
-    _output_handler(config, [])
+    _output_handler(config, [], [])
     assert Path(tmp_path, "servicex_fileset.yaml").exists()


### PR DESCRIPTION
By default, let `deliver()` return all requests made, even if some of them throw exceptions. Each return list is wrapped in a `GuardList` which will reraise any exception if the user attempts to access the corresponding result, and whose validity can be checked with `.valid()`.