### PR TITLE
Fix disappearing sample title

### DIFF
--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -402,7 +402,6 @@ class Query(ABC):
                         progress_task,
                         progress_bar_title,
                         completed=self.current_status.files_completed,
-                        description="Files completed",
                         bar=bar)
                     return
                 elif self.current_status.status == Status.canceled:


### PR DESCRIPTION
This PR fixes disappearing sample title after transformation is completed. It's clear enough from the change of transformation progress bar and completed file counter.

Previously:
<img width="714" alt="files_completed_only" src="https://github.com/user-attachments/assets/db4f30d4-7254-49ac-8832-83372cac9497">

and with Fix:
<img width="712" alt="with_fix" src="https://github.com/user-attachments/assets/c7858858-df48-4b47-86e1-1b60908f9011">
