### PR TITLE
Local Test Harness for the codegenerator and science image

### DIFF
--- a/local_test_harness/.env
+++ b/local_test_harness/.env
@@ -3,3 +3,4 @@ LOG_LEVEL=DEBUG
 SCIENCE=sslhep/servicex_func_adl_uproot_transformer:uproot5
 CODEGEN=sslhep/servicex_code_gen_raw_uproot:develop
 LOCAL_FOLDER=./temp1
+PORT=8005

--- a/local_test_harness/.env
+++ b/local_test_harness/.env
@@ -1,0 +1,5 @@
+BASH_ENV='/servicex/.bashrc'
+LOG_LEVEL=DEBUG
+SCIENCE=sslhep/servicex_func_adl_uproot_transformer:uproot5
+CODEGEN=sslhep/servicex_code_gen_raw_uproot:develop
+LOCAL_FOLDER=./temp1

--- a/local_test_harness/README.md
+++ b/local_test_harness/README.md
@@ -1,0 +1,36 @@
+Local Test Harness for running the codegen and science image for the root file
+
+### Step1. Configure the config.yml file
+```yaml
+    TestName: local test
+    codegen: 
+    port: 8005 
+    query: '[{"treename": {"nominal": "modified"}, "filter_name": ["lbn"]}]' #provide the query as string
+
+    science:
+    rootfile: root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/user/mgeyik/e7/ee/user.mgeyik.30182995._000093.out.root
+    outputfile: /generated/out.parquet
+    outputformat: root-file
+```
+
+### Step2. Configure the .env for the compose file
+```yaml
+BASH_ENV='/servicex/.bashrc'
+LOG_LEVEL=DEBUG
+SCIENCE=sslhep/servicex_func_adl_uproot_transformer:uproot5 #science image
+CODEGEN=sslhep/servicex_code_gen_raw_uproot:develop #codegen image
+LOCAL_FOLDER=./temp1 #local folder where you want output files
+PORT=8005 # port number for your codegen
+```
+
+### Step3. Setup the proxy and run
+```shell
+python test.py --proxy_image <name of proxy_image>
+```
+
+OR if you already have the proxy setup in your `/tmp`
+
+```shell
+python test.py
+```
+The default proxy image: `sslhep/x509-secrets:develop`

--- a/local_test_harness/compose.yml
+++ b/local_test_harness/compose.yml
@@ -1,0 +1,20 @@
+services:
+  science:
+    image: sslhep/servicex_func_adl_uproot_transformer:uproot5
+    pull_policy: missing
+    environment:
+      - BASH_ENV='/servicex/.bashrc'
+      - LOG_LEVEL=DEBUG
+    # command: >
+    #   bash -c
+    #   "PYTHONPATH=/generated &&
+    #   python /generated/transform_single_file.py \
+    #   root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1 /generated/out.parquet  root-file; tail -F anything"
+    volumes:
+      - sidecar-volume:/servicex/output
+      - /tmp:/tmp/grid-security/
+      - ./temp1:/generated
+    tty: true
+
+volumes:
+  sidecar-volume:

--- a/local_test_harness/compose.yml
+++ b/local_test_harness/compose.yml
@@ -1,20 +1,23 @@
 services:
-  science:
-    image: sslhep/servicex_func_adl_uproot_transformer:uproot5
+
+  codegen:
+    image: $CODEGEN 
+    env_file: .env
     pull_policy: missing
-    environment:
-      - BASH_ENV='/servicex/.bashrc'
-      - LOG_LEVEL=DEBUG
-    # command: >
-    #   bash -c
-    #   "PYTHONPATH=/generated &&
-    #   python /generated/transform_single_file.py \
-    #   root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1 /generated/out.parquet  root-file; tail -F anything"
+    ports:
+      - "8000:5000"
+
+  science:
+    image: $SCIENCE 
+    pull_policy: missing
+    env_file: .env
     volumes:
       - sidecar-volume:/servicex/output
       - /tmp:/tmp/grid-security/
-      - ./temp1:/generated
+      - $LOCAL_FOLDER:/generated
     tty: true
+    depends_on:
+      - codegen
 
 volumes:
   sidecar-volume:

--- a/local_test_harness/compose.yml
+++ b/local_test_harness/compose.yml
@@ -5,7 +5,7 @@ services:
     env_file: .env
     pull_policy: missing
     ports:
-      - "8000:5000"
+      - $PORT:5000
 
   science:
     image: $SCIENCE 

--- a/local_test_harness/config.yml
+++ b/local_test_harness/config.yml
@@ -1,0 +1,9 @@
+TestName: local test
+codegen: 
+  port: 8000
+  query: '[{"treename": {"nominal": "modified"}, "filter_name": ["lbn"]}]'
+
+science:
+  rootfile: root://fax.mwt2.org:1094//pnfs/uchicago.edu/atlaslocalgroupdisk/rucio/user/mgeyik/e7/ee/user.mgeyik.30182995._000093.out.root
+  outputfile: /generated/out.parquet
+  outputformat: root-file

--- a/local_test_harness/test.py
+++ b/local_test_harness/test.py
@@ -1,0 +1,79 @@
+"""
+Step 0: Start the codegen container
+Step 1: Send the request with the query
+Step 3: Set up the x509 proxy at /tmp -- do this manually because you have to provide passphrase
+Step 4: Run the docker compose up with the relevant root file
+
+Input: Query, Root file and output format
+"""
+import requests
+import subprocess
+import os
+import json
+from requests_toolbelt.multipart import decoder
+from io import BytesIO
+from zipfile import ZipFile
+import argparse
+import time
+
+def start_codegen_container():
+    subprocess.run(["docker", "run", "-d", "-p", "8000:5000", "--name","code_gen", "sslhep/servicex_code_gen_raw_uproot:develop"])
+
+def send_request(query):
+    post_url = "http://localhost:8000"
+    query = json.dumps(query)
+    postObj = {"code": query}
+    result = requests.post(post_url + "/servicex/generated-code", json=postObj)
+    return result
+
+def generate_zipfile(result, output_folder):
+    decoder_parts = decoder.MultipartDecoder.from_response(result)
+    transformer_image = (decoder_parts.parts[0].text).strip()
+    transformer_language = (decoder_parts.parts[1].text).strip()
+    transformer_command = (decoder_parts.parts[2].text).strip()
+    zipfile = decoder_parts.parts[3].content
+    zipfile = ZipFile(BytesIO(zipfile))
+
+    if not os.path.exists(output_folder):
+        os.mkdir(output_folder)
+    zipfile.extractall(output_folder)
+
+def run_docker_compose_for_science():
+    subprocess.run(["docker", "compose", "up", "-d", "--remove-orphans"])
+
+def send_root_file_to_science(root_file, output_file, output_format):
+    subprocess.run(["docker","compose","run","science","python",\
+                    "/generated/transform_single_file.py",\
+                    root_file, output_file, output_format])
+
+                    # "root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1",\
+                    # "/generated/out.parquet",  "root-file"])
+
+if __name__ == "__main__":
+    
+    #start codegen
+    start_codegen_container()
+    time.sleep(10)
+    # #send request and extract the zip file to folder
+    query = [{'treename': {'nominal': 'modified'}, 'filter_name': ['lbn']}]
+    result = send_request(query = query)
+    generate_zipfile(result, output_folder="temp1")
+
+    #setup the x509 proxy at your /tmp
+    """
+    Make sure you have the usercert.pem and userkey.pem in your ~/.globus folder
+    Run this command:
+    docker run -it --mount type=bind,source=$HOME/.globus,readonly,target=/globus -v /tmp:/tmp --rm sslhep/x509-secrets:develop voms-proxy-init -voms atlas -cert /globus/usercert.pem -key /globus/userkey.pem -out /tmp/x509up
+    """
+
+    # #run the docker compose for the science container
+    run_docker_compose_for_science()
+    time.sleep(10)
+    
+    # #send the root file to the science container
+    send_root_file_to_science(
+        root_file="root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1",
+        output_file="/generated/out.parquet",
+        output_format="root-file"
+    )
+

--- a/local_test_harness/test.py
+++ b/local_test_harness/test.py
@@ -9,21 +9,35 @@ Input: Query, Root file and output format
 import requests
 import subprocess
 import os
-import json
 from requests_toolbelt.multipart import decoder
 from io import BytesIO
 from zipfile import ZipFile
 import time
+import yaml
+import argparse
 
 
-def start_codegen_container():
-    subprocess.run(["docker", "run", "-d", "-p", "8000:5000", "--name", "code_gen",
-                    "sslhep/servicex_code_gen_raw_uproot:develop"])
+class ConfigReader:
+    
+    def __init__(self, file):
+        self._file = file
+        self._config = None
 
+    def read_config_file(self):
+        with open(self._file) as yaml_file:
+            self._config = yaml.safe_load(yaml_file.read())
 
-def send_request(query):
-    post_url = "http://localhost:8000"
-    query = json.dumps(query)
+    def get_config(self):
+        return self._config
+
+def docker_compose_up():
+    subprocess.run(["docker", "compose", "up", "-d", "--remove-orphans"])
+
+def docker_compose_down():
+    subprocess.run(["docker", "compose", "down"])
+
+def send_request(query, port):
+    post_url = f"http://localhost:{port}"
     postObj = {"code": query}
     result = requests.post(post_url + "/servicex/generated-code", json=postObj)
     return result
@@ -39,7 +53,7 @@ def generate_zipfile(result, output_folder):
     zipfile.extractall(output_folder)
 
 
-def run_docker_compose_for_science():
+def run_docker_compose_for_science(image, filepath):
     subprocess.run(["docker", "compose", "up", "-d", "--remove-orphans"])
 
 
@@ -49,24 +63,39 @@ def send_root_file_to_science(root_file, output_file, output_format):
                     root_file, output_file, output_format])
 
 
+def run_x509_proxy(proxy_image = "sslhep/x509-secrets:develop"):
+    my_env = os.environ.copy()
+    subprocess.run(["docker" ,"run", "-it", "--mount", f"type=bind,source={my_env['HOME']}/.globus,readonly,target=/globus",
+                    "-v", "/tmp:/tmp", "--rm", proxy_image,
+                    "voms-proxy-init", "-voms", "atlas", "-cert",
+                    "/globus/usercert.pem", "-key", "/globus/userkey.pem" ,"-out", "/tmp/x509up"
+                    ]
+                    )
+
+
 if __name__ == "__main__":
+    try:
+        parser = argparse.ArgumentParser(description='Run the servicex codegen and science container')
+        parser.add_argument('--proxy_image', help='Run the x509 proxy for image')
+        args = parser.parse_args()
+        if args.proxy_image:
+            run_x509_proxy(proxy_image = args.proxy_image)
+        
+        a = ConfigReader("config.yml")
+        a.read_config_file()
+        docker_compose_up()
+        time.sleep(10)
 
-    # start codegen
-    start_codegen_container()
-    time.sleep(10)
+        result = send_request(
+                            query=a.get_config()['codegen']['query'] , #query,#,
+                            port=a.get_config()['codegen']['port'])
+        generate_zipfile(result, output_folder="temp1")
 
-    # send request and extract the zip file to folder
-    query = [{'treename': {'nominal': 'modified'}, 'filter_name': ['lbn']}]
-    result = send_request(query=query)
-    generate_zipfile(result, output_folder="temp1")
 
-    # run the docker compose for the science container
-    run_docker_compose_for_science()
-    time.sleep(10)
-
-    # send the root file to the science container
-    send_root_file_to_science(
-        root_file="root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1",  # noqa: E501
-        output_file="/generated/out.parquet",
-        output_format="root-file"
-    )
+        send_root_file_to_science(
+            root_file= a.get_config()['science']['rootfile'],
+            output_file=a.get_config()['science']['outputfile'],
+            output_format=a.get_config()['science']['outputformat']
+        )
+    finally:
+        docker_compose_down()

--- a/local_test_harness/test.py
+++ b/local_test_harness/test.py
@@ -13,11 +13,13 @@ import json
 from requests_toolbelt.multipart import decoder
 from io import BytesIO
 from zipfile import ZipFile
-import argparse
 import time
 
+
 def start_codegen_container():
-    subprocess.run(["docker", "run", "-d", "-p", "8000:5000", "--name","code_gen", "sslhep/servicex_code_gen_raw_uproot:develop"])
+    subprocess.run(["docker", "run", "-d", "-p", "8000:5000", "--name", "code_gen",
+                    "sslhep/servicex_code_gen_raw_uproot:develop"])
+
 
 def send_request(query):
     post_url = "http://localhost:8000"
@@ -26,11 +28,9 @@ def send_request(query):
     result = requests.post(post_url + "/servicex/generated-code", json=postObj)
     return result
 
+
 def generate_zipfile(result, output_folder):
     decoder_parts = decoder.MultipartDecoder.from_response(result)
-    transformer_image = (decoder_parts.parts[0].text).strip()
-    transformer_language = (decoder_parts.parts[1].text).strip()
-    transformer_command = (decoder_parts.parts[2].text).strip()
     zipfile = decoder_parts.parts[3].content
     zipfile = ZipFile(BytesIO(zipfile))
 
@@ -38,42 +38,35 @@ def generate_zipfile(result, output_folder):
         os.mkdir(output_folder)
     zipfile.extractall(output_folder)
 
+
 def run_docker_compose_for_science():
     subprocess.run(["docker", "compose", "up", "-d", "--remove-orphans"])
 
+
 def send_root_file_to_science(root_file, output_file, output_format):
-    subprocess.run(["docker","compose","run","science","python",\
-                    "/generated/transform_single_file.py",\
+    subprocess.run(["docker", "compose", "run", "science", "python",
+                    "/generated/transform_single_file.py",
                     root_file, output_file, output_format])
 
-                    # "root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1",\
-                    # "/generated/out.parquet",  "root-file"])
 
 if __name__ == "__main__":
-    
-    #start codegen
+
+    # start codegen
     start_codegen_container()
     time.sleep(10)
-    # #send request and extract the zip file to folder
+
+    # send request and extract the zip file to folder
     query = [{'treename': {'nominal': 'modified'}, 'filter_name': ['lbn']}]
-    result = send_request(query = query)
+    result = send_request(query=query)
     generate_zipfile(result, output_folder="temp1")
 
-    #setup the x509 proxy at your /tmp
-    """
-    Make sure you have the usercert.pem and userkey.pem in your ~/.globus folder
-    Run this command:
-    docker run -it --mount type=bind,source=$HOME/.globus,readonly,target=/globus -v /tmp:/tmp --rm sslhep/x509-secrets:develop voms-proxy-init -voms atlas -cert /globus/usercert.pem -key /globus/userkey.pem -out /tmp/x509up
-    """
-
-    # #run the docker compose for the science container
+    # run the docker compose for the science container
     run_docker_compose_for_science()
     time.sleep(10)
-    
-    # #send the root file to the science container
+
+    # send the root file to the science container
     send_root_file_to_science(
-        root_file="root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1",
+        root_file="root://xrootd.aglt2.org:1094//pnfs/aglt2.org/atlasdatadisk/rucio/mc20_13TeV/d4/32/DAOD_PHYS.37620644._000804.pool.root.1",  # noqa: E501
         output_file="/generated/out.parquet",
         output_format="root-file"
     )
-


### PR DESCRIPTION
As part of the test harness I have created a docker compose which has the science image
sslhep/servicex_func_adl_uproot_transformer:uproot5

That accepts a root file and transforms it using the generated code to the desired output format.


Step 0: Set up the x509 proxy at /tmp -- do this manually because you have to provide passphrase
Make sure you have the usercert.pem and userkey.pem in your ~/.globus folder
`docker run  -it --mount type=bind,source=$HOME/.globus,readonly,target=/globus -v /tmp:/tmp --rm sslhep/x509-secrets:develop voms-proxy-init -voms atlas -cert /globus/usercert.pem -key /globus/userkey.pem -out /tmp/x509up`

The test script follows the below steps:
Step 1: Start the codegen container
Step 2: Send the request with the query and get the zip file with the generated code
Step 3: Run the `docker compose up` with the relevant root file and output format
