### PR TITLE
Fix Sample option `NFiles` for Dataset

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -54,7 +54,10 @@ class Sample(BaseModel):
     @property
     def dataset_identifier(self) -> DataSetIdentifier:
         if self.Dataset:
-            return self.Dataset
+            if isinstance(self.Dataset, RucioDatasetIdentifier):
+                return RucioDatasetIdentifier(self.Dataset.dataset, num_files=self.NFiles)
+            else:
+                return self.Dataset
         elif self.RucioDID:
             return RucioDatasetIdentifier(self.RucioDID, num_files=self.NFiles)
         elif self.XRootDFiles:

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -54,7 +54,7 @@ class Sample(BaseModel):
     @property
     def dataset_identifier(self) -> DataSetIdentifier:
         if self.Dataset:
-            if isinstance(self.Dataset, RucioDatasetIdentifier):
+            if issubclass(RucioDatasetIdentifier, type(self.Dataset)):
                 return RucioDatasetIdentifier(self.Dataset.dataset, num_files=self.NFiles)
             else:
                 return self.Dataset

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -54,8 +54,9 @@ class Sample(BaseModel):
     @property
     def dataset_identifier(self) -> DataSetIdentifier:
         if self.Dataset:
-            if issubclass(RucioDatasetIdentifier, type(self.Dataset)):
-                return RucioDatasetIdentifier(self.Dataset.dataset, num_files=self.NFiles)
+            if self.NFiles:
+                self.Dataset.num_files = self.NFiles
+                return self.Dataset
             else:
                 return self.Dataset
         elif self.RucioDID:

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -56,9 +56,7 @@ class Sample(BaseModel):
         if self.Dataset:
             if self.NFiles:
                 self.Dataset.num_files = self.NFiles
-                return self.Dataset
-            else:
-                return self.Dataset
+            return self.Dataset
         elif self.RucioDID:
             return RucioDatasetIdentifier(self.RucioDID, num_files=self.NFiles)
         elif self.XRootDFiles:

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -117,6 +117,27 @@ def test_rucio_did_numfiles():
     )
 
 
+def test_dataset_rucio_did_numfiles():
+    spec = ServiceXSpec.model_validate(
+        basic_spec(
+            samples=[
+                {
+                    "Name": "sampleA",
+                    "Dataset": dataset.Rucio("user.ivukotic:user.ivukotic.single_top_tW__nominal"),
+                    "NFiles": 12,
+                    "Query": "a",
+                }
+            ]
+        )
+    )
+
+    assert isinstance(spec.Sample[0].dataset_identifier, Rucio)
+    assert (
+        spec.Sample[0].dataset_identifier.did
+        == "rucio://user.ivukotic:user.ivukotic.single_top_tW__nominal?files=12"
+    )
+
+
 def test_cernopendata():
     spec = ServiceXSpec.model_validate({
         "Sample": [


### PR DESCRIPTION
- Sample option `NFiles` is properly propagated for `RucioDID` but not for Rucio dataset defined via `Dataset`. e.g. `Dataset: servicex.dataset.Rucio("mc20_13TeV:EXAMPLE_DID")`
- This PR fixes this and includes a test