### PR TITLE
Truncate sample name to 128 characters

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -90,7 +90,7 @@ class Sample(BaseModel):
         Print warning message
         """
         if len(values["Name"]) > 128:
-            print(logger.warning(f"Truncating Sample name to 128 characters for {values['Name']}"))
+            logger.warning(f"Truncating Sample name to 128 characters for {values['Name']}")
             values["Name"] = values["Name"][0:128]
         return values
 

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -40,7 +40,7 @@ from servicex.models import ResultFormat
 
 
 class Sample(BaseModel):
-    Name: str
+    Name: str = Field(max_length=128)
     Codegen: Optional[str] = None
     RucioDID: Optional[str] = None
     XRootDFiles: Optional[Union[str, List[str]]] = None

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -20,14 +20,14 @@ def test_long_sample_name():
             {
                 "Name": "long_sample_name_long_sample_name_long_sample_name_\
                          long_sample_name_long_sample_name_long_sample_name_\
-                         long_sample_name_long_sampl",
+                         long_sample_name_long_sample_name_long_sample_name",
                 "XRootDFiles": "root://a.root",
                 "Query": "a",
             },
         ],
     }
-    with pytest.raises(ValidationError):
-        ServiceXSpec.model_validate(config)
+    new_config = ServiceXSpec.model_validate(config)
+    assert len(new_config.Sample[0].Name) == 128
 
 
 def test_load_config():

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -14,6 +14,22 @@ def basic_spec(samples=None):
     }
 
 
+def test_long_sample_name():
+    config = {
+        "Sample": [
+            {
+                "Name": "long_sample_name_long_sample_name_long_sample_name_\
+                         long_sample_name_long_sample_name_long_sample_name_\
+                         long_sample_name_long_sampl",
+                "XRootDFiles": "root://a.root",
+                "Query": "a",
+            },
+        ],
+    }
+    with pytest.raises(ValidationError):
+        ServiceXSpec.model_validate(config)
+
+
 def test_load_config():
     config = {
         "General": {


### PR DESCRIPTION
- Truncate Sample name to 128 characters if length is longer than 128 characters
- Print warning for truncated sample
- This resolves https://github.com/iris-hep/idap-200gbps-atlas/issues/140