### PR TITLE
Added Test cases for Servicex_Adapter

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -119,7 +119,8 @@ class ServiceXAdapter:
                     raise AuthorizationError(
                         f"Not authorized to access serviceX at {self.url}")
                 elif r.status == 400:
-                    raise ValueError(f"Invalid transform request: {r.json()['message']}")
+                    o = await r.json()
+                    raise ValueError(f"Invalid transform request: {o.get('message')}")
                 elif r.status > 400:
                     o = await r.json()
                     error_message = o.get('message', str(r))


### PR DESCRIPTION
In light of using the new Aiohttp module for making async get and post requests, the typical httpx.Response was not working.
Since we were dealing with double context managers e.g
```
        async with RetryClient() as client:
            async with client.post(url, headers=headers, json=None) as r:
```

Found a way to patch the get request
Decorate the test functions with
`@patch("servicex.servicex_adapter.RetryClient.get")`

Mock response and status
```
get.return_value.__aenter__.return_value.json.return_value = transform_status_response
get.return_value.__aenter__.return_value.status = 200
```

Resources:
https://stackoverflow.com/questions/28850070/python-mocking-a-context-manager
https://blog.sneawo.com/blog/2019/05/22/mock-aiohttp-request-in-unittests/


Optimizations:
```
get.return_value.__aenter__.return_value.json.return_value = transform_status_response
get.return_value.__aenter__.return_value.status = 200
```
Any help in compressing the 2 lines into one so that we can pass the response(with json and status code) directly to the get.return_value
Typical httpx.Response() doesn't work