### PR TITLE
Change names following #362

### DIFF
--- a/examples/config_definition.yaml
+++ b/examples/config_definition.yaml
@@ -1,5 +1,5 @@
 Definition:
-  - &DEF_output_format root-file
+  - &DEF_output_format root-ttree
   - &DEF_ttH_nominal_query !FuncADL_Uproot  |
     FromTree('mini').Select(lambda e: {'lep_pt': e['lep_pt']}).Where(lambda e: e['lep_pt'] > 1000)
   - &DEF_ggH_input "root://eospublic.cern.ch//eos/opendata/atlas/OutreachDatasets\

--- a/examples/config_multipe_sample.yaml
+++ b/examples/config_multipe_sample.yaml
@@ -14,7 +14,7 @@ Definition:
     FromTree('mini').Select(lambda e: {'lep_pt': e['lep_pt']}).Where(lambda e: e['lep_pt'] > 1000)
 
 General:
-  OutputFormat: root-file
+  OutputFormat: root-ttree
   Delivery: LocalCache
 
 Sample:

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -117,14 +117,8 @@ class General(BaseModel):
         URLs = "URLs"
 
     Codegen: Optional[str] = None
-    OutputFormat: OutputFormatEnum = (
-        Field(default=OutputFormatEnum.root_ttree, pattern="^(parquet|root-ttree)$")
-    )  # NOQA F722
-
-    Delivery: DeliveryEnum = Field(
-        default=DeliveryEnum.LocalCache, pattern="^(LocalCache|URLs)$"
-    )  # NOQA F722
-
+    OutputFormat: OutputFormatEnum = Field(default=OutputFormatEnum.root_ttree)
+    Delivery: DeliveryEnum = Field(default=DeliveryEnum.LocalCache)
     OutputDirectory: Optional[str] = None
     OutFilesetName: str = 'servicex_fileset'
 

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -98,19 +98,27 @@ class Sample(BaseModel):
 class General(BaseModel):
     class OutputFormatEnum(str, Enum):
         parquet = "parquet"
-        root = "root-file"
+        root_ttree = "root-ttree"
+
+        def to_ResultFormat(self) -> ResultFormat:
+            if self == self.parquet:
+                return ResultFormat.parquet
+            elif self == self.root_ttree:
+                return ResultFormat.root_ttree
+            else:
+                raise RuntimeError(f"Bad OutputFormatEnum {self}")
 
     class DeliveryEnum(str, Enum):
         LocalCache = "LocalCache"
-        SignedURLs = "SignedURLs"
+        URLs = "URLs"
 
     Codegen: Optional[str] = None
-    OutputFormat: ResultFormat = (
-        Field(default=ResultFormat.root, pattern="^(parquet|root-file)$")
+    OutputFormat: OutputFormatEnum = (
+        Field(default=OutputFormatEnum.root_ttree, pattern="^(parquet|root-ttree)$")
     )  # NOQA F722
 
     Delivery: DeliveryEnum = Field(
-        default=DeliveryEnum.LocalCache, pattern="^(LocalCache|SignedURLs)$"
+        default=DeliveryEnum.LocalCache, pattern="^(LocalCache|URLs)$"
     )  # NOQA F722
 
     OutputDirectory: Optional[str] = None

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -101,11 +101,15 @@ class General(BaseModel):
         root_ttree = "root-ttree"
 
         def to_ResultFormat(self) -> ResultFormat:
+            """ This method is used to convert the OutputFormatEnum enum to the ResultFormat enum,
+                which is what is actually used for the TransformRequest. This allows us to use
+                different string values in the two enum classes to maintain backend compatibility
+            """
             if self == self.parquet:
                 return ResultFormat.parquet
             elif self == self.root_ttree:
                 return ResultFormat.root_ttree
-            else:
+            else:  # pragma: no cover
                 raise RuntimeError(f"Bad OutputFormatEnum {self}")
 
     class DeliveryEnum(str, Enum):

--- a/servicex/func_adl/func_adl_dataset.py
+++ b/servicex/func_adl/func_adl_dataset.py
@@ -111,7 +111,7 @@ class FuncADLQuery(QueryStringGenerator, EventDataset[T], ABC):
         source = a
         if top_function in self._execute_locally:
             # Request the default type here
-            default_format = self._ds.first_supported_datatype(["parquet", "root-file"])
+            default_format = self._ds.first_supported_datatype(["parquet", "root-ttree"])
             assert default_format is not None, "Unsupported ServiceX returned format"
             method_to_call = self._format_map[default_format]
 

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -48,7 +48,7 @@ class ResultFormat(str, Enum):
     """
 
     parquet = "parquet"
-    root = "root-file"
+    root_ttree = "root-file"
 
 
 class Status(str, Enum):

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -139,7 +139,7 @@ def _build_datasets(config, config_path, servicex_name):
             dataset_identifier=sample.dataset_identifier,
             title=sample.Name,
             codegen=get_codegen(sample, config.General),
-            result_format=config.General.OutputFormat,
+            result_format=config.General.OutputFormat.to_ResultFormat(),
             ignore_cache=sample.IgnoreLocalCache,
             query=sample.Query,
         )
@@ -153,7 +153,7 @@ def _build_datasets(config, config_path, servicex_name):
 def _output_handler(config: ServiceXSpec, requests: List[Query],
                     results: List[Union[TransformedResults, Exception]]):
     matched_results = zip(requests, results)
-    if config.General.Delivery == General.DeliveryEnum.SignedURLs:
+    if config.General.Delivery == General.DeliveryEnum.URLs:
         out_dict = {obj[0].title: GuardList(obj[1].signed_url_list
                                             if not isinstance(obj[1], Exception)
                                             else obj[1])
@@ -189,7 +189,7 @@ def deliver(
 
     group = DatasetGroup(datasets)
 
-    if config.General.Delivery == General.DeliveryEnum.SignedURLs:
+    if config.General.Delivery == General.DeliveryEnum.URLs:
         results = group.as_signed_urls(return_exceptions=return_exceptions)
         return _output_handler(config, datasets, results)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -174,7 +174,7 @@ def transformed_result(dummy_parquet_file) -> TransformedResults:
         file_list=[dummy_parquet_file],
         signed_url_list=[],
         files=2,
-        result_format=ResultFormat.root,
+        result_format=ResultFormat.root_ttree,
     )
 
 
@@ -190,7 +190,7 @@ def transformed_result_signed_url() -> TransformedResults:
         file_list=[],
         signed_url_list=['https://dummy.junk.io/1.parquet', 'https://dummy.junk.io/2.parquet'],
         files=2,
-        result_format=ResultFormat.root,
+        result_format=ResultFormat.root_ttree,
     )
 
 

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -224,7 +224,7 @@ def test_submit_mapping_signed_urls(transformed_result_signed_url, codegen_list)
     from servicex import deliver
     spec = {
         "General": {
-            "Delivery": "SignedURLs"
+            "Delivery": "URLs"
         },
         "Sample": [
             {
@@ -270,7 +270,7 @@ def test_submit_mapping_failure(transformed_result, codegen_list):
 def test_submit_mapping_failure_signed_urls(codegen_list):
     from servicex import deliver
     spec = {
-        "General": {"Delivery": "SignedURLs"},
+        "General": {"Delivery": "URLs"},
         "Sample": [
             {
                 "Name": "sampleA",
@@ -298,7 +298,7 @@ def test_yaml(tmp_path):
     with open(path := (tmp_path / "python.yaml"), "w") as f:
         f.write("""
 General:
-  OutputFormat: root-file
+  OutputFormat: root-ttree
   Delivery: LocalCache
 
 Sample:
@@ -348,7 +348,7 @@ Sample:
     with open(path := (tmp_path / "python.yaml"), "w") as f:
         f.write("""
 General:
-  OutputFormat: root-file
+  OutputFormat: root-ttree
   Delivery: LocalCache
 
 Sample:
@@ -378,7 +378,7 @@ Definitions:
     !include definitions.yaml
 
 General:
-  OutputFormat: root-file
+  OutputFormat: root-ttree
   Delivery: LocalCache
 
 Sample:
@@ -539,6 +539,10 @@ def test_generic_query(codegen_list):
         query = sx.generic_query(dataset_identifier=spec.Sample[0].RucioDID,
                                  codegen=spec.General.Codegen, query=spec.Sample[0].Query)
         assert query.generate_selection_string() == "[{'treename': 'nominal'}]"
+        query = sx.generic_query(dataset_identifier=spec.Sample[0].RucioDID,
+                                 result_format=spec.General.OutputFormat.to_ResultFormat(),
+                                 codegen=spec.General.Codegen, query=spec.Sample[0].Query)
+        assert query.result_format == 'root-file'
         query.query_string_generator = None
         with pytest.raises(RuntimeError):
             query.generate_selection_string()

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -519,6 +519,29 @@ def test_uproot_raw_query(transformed_result, codegen_list):
         deliver(spec, config_path='tests/example_config.yaml')
 
 
+def test_uproot_raw_query_parquet(transformed_result, codegen_list):
+    from servicex import deliver
+    from servicex.query import UprootRaw  # type: ignore
+    spec = ServiceXSpec.model_validate({
+        "General": {
+            "OutputFormat": "parquet"
+        },
+        "Sample": [
+            {
+                "Name": "sampleA",
+                "RucioDID": "user.ivukotic:user.ivukotic.single_top_tW__nominal",
+                "Query": UprootRaw([{"treename": "nominal"}])
+            }
+        ]
+    })
+    print(spec)
+    with patch('servicex.dataset_group.DatasetGroup.as_files',
+               return_value=[transformed_result]), \
+         patch('servicex.servicex_client.ServiceXClient.get_code_generators',
+               return_value=codegen_list):
+        deliver(spec, config_path='tests/example_config.yaml')
+
+
 def test_generic_query(codegen_list):
     from servicex.servicex_client import ServiceXClient
     spec = ServiceXSpec.model_validate({

--- a/tests/test_dataset_group.py
+++ b/tests/test_dataset_group.py
@@ -38,9 +38,9 @@ def test_set_result_format(mocker):
     ds1 = mocker.Mock()
     ds2 = mocker.Mock()
     group = DatasetGroup([ds1, ds2])
-    group.set_result_format(ResultFormat.root)
-    ds1.set_result_format.assert_called_once_with(ResultFormat.root)
-    ds2.set_result_format.assert_called_once_with(ResultFormat.root)
+    group.set_result_format(ResultFormat.root_ttree)
+    ds1.set_result_format.assert_called_once_with(ResultFormat.root_ttree)
+    ds2.set_result_format.assert_called_once_with(ResultFormat.root_ttree)
 
 
 @pytest.mark.asyncio

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -59,7 +59,7 @@ def test_hash(transform_request):
 
     # Changing result_format does
     request2 = request1.model_copy()
-    request2.result_format = ResultFormat.root
+    request2.result_format = ResultFormat.root_ttree
     assert request1.compute_hash() != request2.compute_hash()
 
 

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -48,7 +48,7 @@ def test_result_formats():
     servicex.resources.transformation.submit.SubmitTransformationRequest.make_api
     """
     assert ResultFormat.parquet == "parquet"
-    assert ResultFormat.root == "root-file"
+    assert ResultFormat.root_ttree == "root-file"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* SignedURLs -> URLs
* Users specify "root-ttree" instead of "root-file" and enum names are changed to "root_ttree".  This involves splitting the types `ResultFormat` and `OutputFormatEnum` : the latter is now used in the `ServiceXSpec` and is translated to a `ResultFormat` when creating the actual request, so that the string sent to the server is still `root-file`. 

Important Note: 
The `ResultFormat` is still what you get back from the server, though, so the cache will continue to handle `root-file` and not `root-ttree`. If at some point we change this string it'll have the side-effect of invalidating caches.
