### PR TITLE
Reduce library dependencies (addresses #432)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
         run: |
           python -m pip install --upgrade uv
           uv pip install --system --upgrade pip setuptools wheel
-          uv pip install --system --upgrade '.[databinder,pandas,test]'
+          uv pip install --system --upgrade '.[test]'
           uv pip list --system
 
       - name: Test with pytest

--- a/.github/workflows/ci_production.yaml
+++ b/.github/workflows/ci_production.yaml
@@ -28,7 +28,7 @@ jobs:
         run: |
           python -m pip install --upgrade uv
           uv pip install --system --upgrade pip setuptools wheel
-          uv pip install --system --upgrade '.[databinder,pandas,test]'
+          uv pip install --system --upgrade '.[test]'
           uv pip list --system
 
       - name: Run example

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,14 +66,6 @@ Homepage = "https://github.com/ssl-hep/ServiceX_frontend"
 
 [project.optional-dependencies]
 
-databinder = [
-    "nest-asyncio>=1.5.7",  # databinder # FIXME: nest-asyncio deprecated
-]
-pandas = [
-    "pandas>=2.0.2",
-    "pyarrow>=12.0.0",
-    "fastparquet>=2023.4.0",
-]
 # Developer extras
 test = [
     "pytest>=7.2.0",
@@ -83,6 +75,8 @@ test = [
     "mypy>=0.981",
     "pytest-asyncio>=0.21.0",
     "asyncmock>=0.4.2",
+    "pandas>=2.0.2",
+    "pyarrow>=12.0.0",
 ]
 docs = [
     "sphinx>=7.0.1",
@@ -91,7 +85,7 @@ docs = [
     "myst-parser>=3.0.1",
 ]
 develop = [
-    "servicex[databinder,pandas,test,docs]",
+    "servicex[test,docs]",
 ]
 
 [project.entry-points.'servicex.query']

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -36,13 +36,6 @@ from typing import List, Optional, Union
 from servicex.expandable_progress import ExpandableProgress
 from rich.logging import RichHandler
 
-
-try:
-    import pandas as pd
-except ModuleNotFoundError:
-    pass
-
-
 from servicex.types import DID
 
 from rich.progress import Progress, TaskID
@@ -557,32 +550,6 @@ class Query:
             )
 
     as_files = make_sync(as_files_async)
-
-    try:
-
-        async def as_pandas_async(
-            self,
-            display_progress: bool = True,
-            provided_progress: Optional[ProgressIndicators] = None,
-        ) -> pd.DataFrame:
-            r"""
-            Return a pandas dataframe containing the results. This only works if you've
-            installed pandas extra
-
-            :return: Pandas Dataframe
-            """
-            self.result_format = ResultFormat.parquet
-            transformed_result = await self.as_files_async(
-                display_progress=display_progress, provided_progress=provided_progress
-            )
-            dataframes = pd.concat(
-                [pd.read_parquet(p) for p in transformed_result.file_list]
-            )
-            return dataframes
-
-        as_pandas = make_sync(as_pandas_async)
-    except NameError:
-        pass
 
     async def as_signed_urls_async(
         self,

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -26,7 +26,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import pytest
-import pandas as pd
 import tempfile
 import os
 
@@ -87,25 +86,6 @@ async def test_as_files_happy(transformed_result):
 
     result = dataset.as_files(display_progress=True, provided_progress=None)
     assert result == transformed_result
-
-
-@pytest.mark.asyncio
-async def test_as_pandas_happy(transformed_result):
-    did = FileListDataset("/foo/bar/baz.root")
-    servicex = AsyncMock()
-    with tempfile.TemporaryDirectory() as temp_dir:
-        config = Configuration(cache_path=temp_dir, api_endpoints=[])
-        cache = QueryCache(config)
-        dataset = Query(dataset_identifier=did, codegen="uproot", sx_adapter=servicex,
-                        title="", config=None,
-                        query_cache=cache)
-        dataset.submit_and_download = AsyncMock()
-        dataset.submit_and_download.return_value = transformed_result
-        result = dataset.as_pandas(display_progress=False)
-        assert isinstance(result, pd.DataFrame)
-        assert not result.empty  # Check if the DataFrame is not empty
-        assert dataset.result_format == ResultFormat.parquet
-        cache.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -40,7 +40,6 @@ from servicex.query_core import ServiceXException
 
 from pathlib import Path
 from servicex.models import (
-    ResultFormat,
     Status,
 )
 from rich.progress import Progress


### PR DESCRIPTION
Make `pandas` a dependency only of tests (where it gets used to interpret data), remove references to it from the main library, remove the pandas extra.

Also remove the databinder extra because the package it installs (`nest-asyncio`) is not actually invoked.