### PR TITLE
Improve GuardList traceback handling

### DIFF
--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -53,10 +53,12 @@ logger = logging.getLogger(__name__)
 class ReturnValueException(Exception):
     """ An exception occurred at some point while obtaining this result from ServiceX """
     def __init__(self, exc):
+        import copy
         message = ('Exception occurred while making ServiceX request.\n'
                    + (''.join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
                    )
         super().__init__(message)
+        self._exc = copy.copy(exc)
 
 
 class GuardList(Sequence):
@@ -91,7 +93,8 @@ class GuardList(Sequence):
         if self.valid():
             return repr(self._data)
         else:
-            return f'Invalid GuardList: {repr(self._data)}'
+            data = cast(ReturnValueException, self._data)
+            return f'Invalid GuardList: {repr(data._exc)}'
 
 
 def _load_ServiceXSpec(

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -44,16 +44,29 @@ from servicex.dataset_group import DatasetGroup
 from make_it_sync import make_sync
 from servicex.databinder_models import ServiceXSpec, General, Sample
 from collections.abc import Sequence
+import traceback
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
+
+
+class ReturnValueException(Exception):
+    """ An exception occurred at some point while obtaining this result from ServiceX """
+    def __init__(self, exc):
+        message = ('Exception occurred while making ServiceX request.\n'
+                   + (''.join(traceback.format_exception(type(exc), exc, exc.__traceback__)))
+                   )
+        super().__init__(message)
 
 
 class GuardList(Sequence):
     def __init__(self, data: Union[Sequence, Exception]):
         import copy
         super().__init__()
-        self._data = copy.copy(data)
+        if isinstance(data, Exception):
+            self._data = ReturnValueException(data)
+        else:
+            self._data = copy.copy(data)
 
     def valid(self) -> bool:
         return not isinstance(self._data, Exception)

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -263,7 +263,8 @@ def test_submit_mapping_failure(transformed_result, codegen_list):
                return_value=codegen_list):
         results = deliver(spec, config_path='tests/example_config.yaml')
         assert len(results) == 1
-        with pytest.raises(ReturnValueException):  # should expect an exception to be thrown on access
+        with pytest.raises(ReturnValueException):
+            # should expect an exception to be thrown on access
             for _ in results['sampleA']:
                 pass
 
@@ -287,7 +288,8 @@ def test_submit_mapping_failure_signed_urls(codegen_list):
                return_value=codegen_list):
         results = deliver(spec, config_path='tests/example_config.yaml', return_exceptions=False)
         assert len(results) == 1
-        with pytest.raises(ReturnValueException):  # should expect an exception to be thrown on access
+        with pytest.raises(ReturnValueException):
+            # should expect an exception to be thrown on access
             for _ in results['sampleA']:
                 pass
 

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 
 from servicex import ServiceXSpec, dataset
 from servicex.query_core import ServiceXException
+from servicex.servicex_client import ReturnValueException
 from servicex.dataset import FileList, Rucio
 
 
@@ -262,7 +263,7 @@ def test_submit_mapping_failure(transformed_result, codegen_list):
                return_value=codegen_list):
         results = deliver(spec, config_path='tests/example_config.yaml')
         assert len(results) == 1
-        with pytest.raises(ServiceXException):  # should expect an exception to be thrown on access
+        with pytest.raises(ReturnValueException):  # should expect an exception to be thrown on access
             for _ in results['sampleA']:
                 pass
 
@@ -286,7 +287,7 @@ def test_submit_mapping_failure_signed_urls(codegen_list):
                return_value=codegen_list):
         results = deliver(spec, config_path='tests/example_config.yaml', return_exceptions=False)
         assert len(results) == 1
-        with pytest.raises(ServiceXException):  # should expect an exception to be thrown on access
+        with pytest.raises(ReturnValueException):  # should expect an exception to be thrown on access
             for _ in results['sampleA']:
                 pass
 

--- a/tests/test_guardlist.py
+++ b/tests/test_guardlist.py
@@ -1,4 +1,4 @@
-from servicex.servicex_client import GuardList
+from servicex.servicex_client import GuardList, ReturnValueException
 import pytest
 
 
@@ -8,7 +8,7 @@ def test_guardlist():
     assert gl1[0] == 1
     gl2 = GuardList(ValueError())
     assert str(gl2) == 'Invalid GuardList: ValueError()'
-    with pytest.raises(ValueError):
+    with pytest.raises(ReturnValueException):
         gl2[0]
-    with pytest.raises(ValueError):
+    with pytest.raises(ReturnValueException):
         len(gl2)


### PR DESCRIPTION
Instead of storing the original exception in the GuardList, wrap the traceback in a new exception type for better debugging