### PR TITLE
Avoid minio connection if cache is sufficient

### DIFF
--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -493,6 +493,10 @@ class Query:
         while True:
             if not cached_record:
                 await asyncio.sleep(self.minio_polling_interval)
+            if cached_record:
+                if ((cached_record.signed_url_list and signed_urls_only)
+                        or (cached_record.file_list and not signed_urls_only)):
+                    break
             if self.minio:
                 files = await self.minio.list_bucket()
                 for file in files:

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -241,10 +241,8 @@ class Query:
         # (Downloaded, or obtained pre-signed URLs)
         if cached_record:
             if (
-                signed_urls_only
-                and cached_record.signed_url_list
-                or not signed_urls_only
-                and cached_record.file_list
+                (signed_urls_only and cached_record.signed_url_list)
+                or (not signed_urls_only and cached_record.file_list)
             ):
                 logger.info("Returning results from cache")
                 return cached_record
@@ -493,10 +491,6 @@ class Query:
         while True:
             if not cached_record:
                 await asyncio.sleep(self.minio_polling_interval)
-            if cached_record:
-                if ((cached_record.signed_url_list and signed_urls_only)
-                        or (cached_record.file_list and not signed_urls_only)):
-                    break
             if self.minio:
                 files = await self.minio.list_bucket()
                 for file in files:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -173,8 +173,8 @@ def transformed_result(dummy_parquet_file) -> TransformedResults:
         data_dir="/foo/bar",
         file_list=[dummy_parquet_file],
         signed_url_list=[],
-        files=2,
-        result_format=ResultFormat.root_ttree,
+        files=1,
+        result_format=ResultFormat.parquet,
     )
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -102,7 +102,7 @@ async def test_as_files_cached(transformed_result, python_dataset):
 
 
 @pytest.mark.asyncio
-async def test_download_files(python_dataset, transformed_result):
+async def test_download_files(python_dataset):
     signed_urls_only = False
     download_progress = "download_task_id"
     minio_mock = AsyncMock()
@@ -114,22 +114,21 @@ async def test_download_files(python_dataset, transformed_result):
                                            Mock(filename="file2.txt")]
 
     progress_mock = Mock()
-    cached_record_mock = Mock(return_value=transformed_result)
     python_dataset.minio_polling_interval = 0
     python_dataset.minio = minio_mock
-    python_dataset.current_status = Mock(status="complete")
+    python_dataset.current_status = Mock(status="Complete")
     python_dataset.configuration.shortened_downloaded_filename = False
 
     result_uris = await python_dataset.download_files(
-        signed_urls_only, progress_mock, download_progress, cached_record_mock
+        signed_urls_only, progress_mock, download_progress, None
     )
-    minio_mock.download_file.assert_called()
-    minio_mock.get_signed_url.assert_not_called()
+    minio_mock.download_file.assert_awaited()
+    minio_mock.get_signed_url.assert_not_awaited()
     assert result_uris == ["/path/to/downloaded_file", "/path/to/downloaded_file"]
 
 
 @pytest.mark.asyncio
-async def test_download_files_with_signed_urls(python_dataset, transformed_result):
+async def test_download_files_with_signed_urls(python_dataset):
     signed_urls_only = True
     download_progress = "download_task_id"
     minio_mock = AsyncMock()
@@ -140,15 +139,14 @@ async def test_download_files_with_signed_urls(python_dataset, transformed_resul
     minio_mock.list_bucket.return_value = [Mock(filename="file1.txt"),
                                            Mock(filename="file2.txt")]
     progress_mock = Mock()
-    cached_record_mock = Mock(return_value=transformed_result)
 
     python_dataset.minio_polling_interval = 0
     python_dataset.minio = minio_mock
-    python_dataset.current_status = Mock(status="complete")
+    python_dataset.current_status = Mock(status="Complete")
     python_dataset.configuration.shortened_downloaded_filename = False
 
     result_uris = await python_dataset.download_files(
-        signed_urls_only, progress_mock, download_progress, cached_record_mock
+        signed_urls_only, progress_mock, download_progress, None
     )
     minio_mock.download_file.assert_not_called()
     minio_mock.get_signed_url.assert_called()

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -269,11 +269,10 @@ async def test_use_of_cache(mocker):
     servicex.get_transform_status = AsyncMock()
     servicex.get_transform_status.side_effect = [
         transform_status1,
-        transform_status2,
         transform_status3,
     ]
     mock_minio = AsyncMock()
-    mock_minio.list_bucket = AsyncMock(side_effect=[[file1], [file1]])
+    mock_minio.list_bucket = AsyncMock(return_value=[file1, file2])
     mock_minio.download_file = AsyncMock(side_effect=lambda a, _, shorten_filename: PurePath(a))
     mock_minio.get_signed_url = AsyncMock(side_effect=['http://file1', 'http://file2'])
 
@@ -299,10 +298,27 @@ async def test_use_of_cache(mocker):
                                                            expandable_progress=progress)
         upd.assert_not_called()
         upd.reset_mock()
-        # second round, should hit the cache (and not call update_record)
+        assert mock_minio.get_signed_url.await_count == 2
+        # second round, should hit the cache (and not call the sx_adapter, minio, or update_record)
         with ExpandableProgress(display_progress=False) as progress:
-            result2 = await datasource.submit_and_download(signed_urls_only=True,
-                                                           expandable_progress=progress)
+            servicex2 = AsyncMock()
+            mock_minio.list_bucket.reset_mock()
+            mock_minio.get_signed_url.reset_mock()
+            datasource2 = Query(
+                dataset_identifier=did,
+                title="ServiceX Client",
+                codegen="uproot",
+                sx_adapter=servicex2,
+                query_cache=cache,
+                config=config,
+            )
+            datasource2.query_string_generator = FuncADLQuery_Uproot()
+            datasource2.result_format = ResultFormat.parquet
+            result2 = await datasource2.submit_and_download(signed_urls_only=True,
+                                                            expandable_progress=progress)
+            servicex2.assert_not_awaited()
+            mock_minio.list_bucket.assert_not_awaited()
+            mock_minio.get_signed_url.assert_not_awaited()
         upd.assert_not_called()
         assert result1 == result2
         upd.reset_mock()
@@ -313,6 +329,18 @@ async def test_use_of_cache(mocker):
         with ExpandableProgress(display_progress=False) as progress:
             await datasource.submit_and_download(signed_urls_only=False,
                                                  expandable_progress=progress)
+        servicex.assert_not_awaited()
+        assert mock_minio.download_file.await_count == 2
+        upd.assert_called_once()
+        # fourth round, should hit the cache (and nothing else)
+        mock_minio.list_bucket.reset_mock()
+        mock_minio.download_file.reset_mock()
+        with ExpandableProgress(display_progress=False) as progress:
+            await datasource.submit_and_download(signed_urls_only=False,
+                                                 expandable_progress=progress)
+        servicex.assert_not_awaited()
+        mock_minio.list_bucket.assert_not_awaited()
+        mock_minio.download_file.assert_not_awaited()
         upd.assert_called_once()
         cache.close()
 

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -325,7 +325,7 @@ async def test_use_of_cache(mocker):
         servicex.get_transform_status.reset_mock(side_effect=True)
         servicex.get_transform_status.return_value = transform_status3
         mock_minio.list_bucket.reset_mock(side_effect=True)
-        # third round, should hit the cache (and call update_record)
+        # third round, should hit the cache and download files (and call update_record)
         with ExpandableProgress(display_progress=False) as progress:
             await datasource.submit_and_download(signed_urls_only=False,
                                                  expandable_progress=progress)


### PR DESCRIPTION
Address #295 by only verifying that we only list the S3 buckets when we have a cached record if we are trying to get local files when only signed URLs are cached, or vice versa. Fix a number of tests.