### PR TITLE
Add lock to tinydb

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
     "make-it-sync",  # compatible versions controlled through func_adl
     "ruamel.yaml>=0.18",
     "ccorp-yaml-include-relative-path>=0.0.4",
+    "filelock>=3.12.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
# Problem
TinyDB is not reentrant. Multiple simultaneous requests can result in a corrupt database.

Fixes #361 

# Approach
Since we need to protect the database from multiple processes, we've used the [filelock](https://py-filelock.readthedocs.io/en/latest/index.html#) library. We create a lock file in the same directory where the cache lives and wrap all interactions with the DB in a context manager that acquires the lock