### PR TITLE
ci: Unify docs build around Makefile

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,9 +63,3 @@ jobs:
           env_vars: OS,PYTHON
           files: ./coverage.xml
           flags: unittests
-
-      - name: Build HTML
-        run: |
-          cd docs
-          make clean
-          make html

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,18 +40,18 @@ jobs:
     - name: Test and build docs
       run: |
         pushd docs
-        sphinx-build -b html . _build
+        make html
 
     - name: Fix permissions if needed
       run: |
-        chmod -c -R +rX "docs/_build/" | while read line; do
+        chmod -c -R +rX "docs/_build/html/" | while read line; do
           echo "::warning title=Invalid file permissions automatically fixed::$line"
         done
 
     - name: Upload artifact
       uses: actions/upload-pages-artifact@v3
       with:
-        path: 'docs/_build'
+        path: 'docs/_build/html'
 
   deploy:
     name: Deploy docs to GitHub Pages


### PR DESCRIPTION
* Remove reundant docs build from CI workflow.
* Use 'html' Make target for docs workflow to unify the Makefile experience with the GitHub pages deployment.

Amends PR https://github.com/ssl-hep/ServiceX_frontend/pull/442