### PR TITLE
Readthedocs with pyproject.toml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,7 +19,7 @@ build:
     - uv pip install --system --upgrade pip wheel
     - uv pip install --system --upgrade ".[docs]"
     - uv pip list --system
-    - pushd docs
+    - cd docs
     - make html
 
 # Build documentation in the "docs/" directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,18 +9,6 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
-    # You can also specify other tool versions:
-    # nodejs: "20"
-    # rust: "1.70"
-    # golang: "1.20"
-  
-  # commands:
-  #   - python -m pip install uv
-  #   - uv pip install --system --upgrade pip wheel
-  #   - uv pip install --system --upgrade ".[docs]"
-  #   - uv pip list --system
-  #   - cd docs
-  #   - make html
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:
@@ -33,7 +21,6 @@ sphinx:
 # Optionally build your docs in additional formats such as PDF and ePub
 formats:
   - pdf
-#   - epub
 
 # Optional but recommended, declare the Python requirements required
 # to build your documentation

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,19 +14,19 @@ build:
     # rust: "1.70"
     # golang: "1.20"
   
-  commands:
-    - python -m pip install uv
-    - uv pip install --system --upgrade pip wheel
-    - uv pip install --system --upgrade ".[docs]"
-    - uv pip list --system
-    - cd docs
-    - make html
+  # commands:
+  #   - python -m pip install uv
+  #   - uv pip install --system --upgrade pip wheel
+  #   - uv pip install --system --upgrade ".[docs]"
+  #   - uv pip list --system
+  #   - cd docs
+  #   - make html
 
 # Build documentation in the "docs/" directory with Sphinx
-# sphinx:
-#   configuration: docs/conf.py
+sphinx:
+  configuration: docs/conf.py
 #   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
-#   builder: html
+  builder: html
   # Fail on all warnings to avoid broken references
   # fail_on_warning: true
 
@@ -38,9 +38,9 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
-#     - method: pip
-#       path: .
-#       extra_requirements:
-#         - docs
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,13 +13,12 @@ build:
     # nodejs: "20"
     # rust: "1.70"
     # golang: "1.20"
-  jobs:
-    post_create_environment:
-      - python -m pip install uv
-      - uv pip install --system --upgrade pip wheel
-      - uv pip install --system --upgrade ".[docs]"
-      - uv pip list --system
+  
   commands:
+    - python -m pip install uv
+    - uv pip install --system --upgrade pip wheel
+    - uv pip install --system --upgrade ".[docs]"
+    - uv pip list --system
     - pushd docs
     - make html
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,12 +13,21 @@ build:
     # nodejs: "20"
     # rust: "1.70"
     # golang: "1.20"
+  jobs:
+    post_create_environment:
+      - python -m pip install uv
+      - uv pip install --system --upgrade pip wheel
+      - uv pip install --system --upgrade ".[docs]"
+      - uv pip list --system
+  commands:
+    - pushd docs
+    - make html
 
 # Build documentation in the "docs/" directory with Sphinx
-sphinx:
-  configuration: docs/conf.py
-  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
-  builder: html
+# sphinx:
+#   configuration: docs/conf.py
+#   # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+#   builder: html
   # Fail on all warnings to avoid broken references
   # fail_on_warning: true
 
@@ -30,10 +39,9 @@ formats:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-python:
-  install:
-    - requirements: docs/requirements.txt
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
+# python:
+#   install:
+#     - method: pip
+#       path: .
+#       extra_requirements:
+#         - docs


### PR DESCRIPTION
Configured the .readthedocs.yaml to run with pyproject.toml
The .yaml file takes the following
```
python:
  install:
    - method: pip
      path: .
      extra_requirements:
        - docs
```
which is equivalent to `pip install .[docs]`
https://docs.readthedocs.io/en/stable/config-file/v2.html#python-install
