### PR TITLE
Fix minio handling of buckets in rare cases

### DIFF
--- a/servicex/minio_adapter.py
+++ b/servicex/minio_adapter.py
@@ -77,7 +77,7 @@ class MinioAdapter:
                 size=obj.size,
                 extension=obj.object_name.split(".")[-1],
             )
-            for obj in objects
+            for obj in objects if not obj.is_dir
         ]
 
     async def download_file(


### PR DESCRIPTION
Sometimes listing the bucket for an in-progress transformation gives objects that look like directories, not files. These have no file size reported and would raise an exception due to the coercion in the `ResultFile` constructor. Avoid these problematic objects.