### PR TITLE
Badges on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,15 @@
 # ServiceX Client Library
+
+
+[![GitHub Actions Status](https://github.com/ssl-hep/ServiceX_frontend/workflows/CI/CD/badge.svg?branch=master)](https://github.com/ssl-hep/ServiceX_frontend/actions)
+[![Code Coverage](https://codecov.io/gh/ssl-hep/ServiceX_frontend/graph/badge.svg)](https://codecov.io/gh/ssl-hep/ServiceX_frontend)
+
+[![PyPI version](https://badge.fury.io/py/servicex.svg)](https://badge.fury.io/py/servicex)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/servicex.svg)](https://pypi.org/project/servicex/)
+
+[![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](https://servicex-frontend.readthedocs.io)
+
+
 Python SDK and CLI Client for ServiceX
 
 ## Documentation

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -1,6 +1,6 @@
-Command Line Interface
-=======================
-*\*Experimental*
+Command Line Interface (Experimental)
+======================================
+*\*The command line interface is an under-development feature that is not supported in the 3.0.0 release*
 
 The command line interface (CLI) is a text-based interface used to interact with the system.
 When installed, the client provides a new command in your shell,


### PR DESCRIPTION
1. Added badges on the readme page

[![GitHub Actions Status](https://github.com/ssl-hep/ServiceX_frontend/workflows/CI/CD/badge.svg?branch=master)](https://github.com/ssl-hep/ServiceX_frontend/actions)
[![Code Coverage](https://codecov.io/gh/ssl-hep/ServiceX_frontend/graph/badge.svg)](https://codecov.io/gh/ssl-hep/ServiceX_frontend)

[![PyPI version](https://badge.fury.io/py/servicex.svg)](https://badge.fury.io/py/servicex)
[![Supported Python versions](https://img.shields.io/pypi/pyversions/servicex.svg)](https://pypi.org/project/servicex/)

[![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](https://servicex-frontend.readthedocs.io)


2. Changed heading for command line page