### PR TITLE
docs: Add sphinx-copybutton support

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -27,7 +27,8 @@ extensions = [
     'code_include.extension',
     'myst_parser',
     'sphinxcontrib.autodoc_pydantic',
-    'sphinx_tabs.tabs'
+    'sphinx_tabs.tabs',
+    'sphinx_copybutton',
 ]
 
 templates_path = ['_templates']
@@ -50,3 +51,8 @@ autodoc_pydantic_model_member_order = 'bysource'
 
 html_theme = 'furo'
 html_static_path = ['_static']
+
+# sphinx-copybutton configuration
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
+copybutton_here_doc_delimiter = "EOF"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,8 @@ docs = [
     "myst-parser>=3.0.1",
     "func-adl-servicex-xaodr22",
     "autodoc-pydantic==2.2.0",
-    "sphinx-tabs>=3.4.5"
+    "sphinx-tabs>=3.4.5",
+    "sphinx-copybutton>=0.5.2",
 ]
 develop = [
     "servicex[test,docs]",


### PR DESCRIPTION
Resolves #462 

* Add sphinx-copybutton v0.5.2+ to the 'docs' extra.
* Enable sphinx-copybutton support in the Sphinx conf.py.

![image](https://github.com/user-attachments/assets/f6523b4c-d2b3-41df-bde2-3c55d0246d88)
