### PR TITLE
ci: Use astral-sh/setup-uv action to setup uv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,7 @@ jobs:
 
       - name: Lint with Flake8
         run: |
-          python -m pip install --upgrade uv
-          uv pip install --system --upgrade flake8
-          flake8
+          pipx run flake8
 
   test:
     needs:
@@ -44,10 +42,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade uv
-          uv pip install --system --upgrade pip setuptools wheel
           uv pip install --system --upgrade '.[test,docs]'
           uv pip list --system
 

--- a/.github/workflows/ci_production.yaml
+++ b/.github/workflows/ci_production.yaml
@@ -24,10 +24,11 @@ jobs:
         env:
           SERVICEX_YAML: ${{ secrets.SERVICEX_YAML }}
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
       - name: Install package
         run: |
-          python -m pip install --upgrade uv
-          uv pip install --system --upgrade pip setuptools wheel
           uv pip install --system --upgrade '.[test]'
           uv pip list --system
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,10 +30,11 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+
     - name: Install Python dependencies
       run: |
-        python -m pip install uv
-        uv pip install --system --upgrade pip wheel
         uv pip install --system --upgrade ".[docs]"
         uv pip list --system
 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -22,10 +22,11 @@ jobs:
       with:
         python-version: '3.12'
 
+    - name: Install uv
+      uses: astral-sh/setup-uv@v3
+
     - name: Install python-build and twine
       run: |
-        python -m pip install --upgrade uv
-        uv pip install --system --upgrade pip
         uv pip install --system build twine
         uv pip list --system
 


### PR DESCRIPTION
* Use https://github.com/astral-sh/setup-uv to install and setup uv.
* Remove upgrade of setuptools as the build system uses hatchling.
   - Remove upgrade of wheel as the default version is fine.