### PR TITLE
Update the download progress bar (both unsigned and dowload) when initial transform request doesn't return all files

### DIFF
--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -378,11 +378,19 @@ class Query:
                     progress.start_task(task_id=download_task, task_type="Download")
 
             if progress:
+                # update the transform progress bar to get the total number of files
                 progress.update(
                     progress_task,
                     progress_bar_title,
                     total=self.current_status.files,
                     completed=self.current_status.files_completed,
+                )
+
+                # update the download progress bar to get the total number of files
+                progress.update(
+                    download_task,
+                    download_bar_title,
+                    total=self.current_status.files
                 )
 
             if self.current_status.status in DONE_STATUS:


### PR DESCRIPTION
### Problem
When the user submits many requests, sometimes the transform status returns only partial number of files.
After subsequent polling, the correct number of files are returned. However, the download progress bar wasn't geting updated.
![image](https://github.com/user-attachments/assets/31d1464b-4d5a-4783-a509-6dd7ac088ef6)


### Solution
Inside the `transform_status_listener` added the update logic for download progress bar.