### PR TITLE
Cache Collision when the user ignores the cache and hash is present in the db Fix #375

### DIFF
--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -77,6 +77,12 @@ class QueryCache:
         with self.lock:
             self.db.update(json.loads(record.model_dump_json()), transforms.hash == record.hash)
 
+    def contains_hash(self, hash: str) -> bool:
+        transforms = Query()
+        with self.lock:
+            records = self.db.search(transforms.hash == hash)
+        return len(records) > 0
+
     def get_transform_by_hash(self, hash: str) -> Optional[TransformedResults]:
         transforms = Query()
         with self.lock:
@@ -121,6 +127,11 @@ class QueryCache:
     def delete_record_by_request_id(self, request_id: str):
         with self.lock:
             self.db.remove(where('request_id') == request_id)
+
+    def delete_record_by_hash(self, hash: str):
+        transforms = Query()
+        with self.lock:
+            self.db.remove(transforms.hash == hash)
 
     def get_codegen_by_backend(self, backend: str) -> Optional[dict]:
         codegens = Query()

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -228,11 +228,16 @@ class Query:
                 logger.info(f"Transforms finished with code {self.current_status.status}")
 
         sx_request = self.transform_request
+        sx_request_hash = sx_request.compute_hash()
+
+        # Invalidate the cache if the hash already present but if the user ignores cache
+        if self.ignore_cache and self.cache.contains_hash(sx_request_hash):
+            self.cache.delete_record_by_hash(sx_request_hash)
 
         # Let's see if this is in the cache already, but respect the user's wishes
         # to ignore the cache
         cached_record = (
-            self.cache.get_transform_by_hash(sx_request.compute_hash())
+            self.cache.get_transform_by_hash(sx_request_hash)
             if not self.ignore_cache
             else None
         )

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -528,6 +528,7 @@ def test_transform_request():
                               "(list (subscript e 'lep_pt')))))"
         cache.close()
 
+
 @pytest.mark.asyncio
 async def test_use_of_cache_ignore_cache(mocker):
     """ Do we pick up the cache on the second request for the same transform? """
@@ -563,8 +564,8 @@ async def test_use_of_cache_ignore_cache(mocker):
         datasource.result_format = ResultFormat.parquet
         upd = mocker.patch.object(cache, 'update_record', side_effect=cache.update_record)
         with ExpandableProgress(display_progress=False) as progress:
-            result1 = await datasource.submit_and_download(signed_urls_only=True,
-                                                           expandable_progress=progress)
+            await datasource.submit_and_download(signed_urls_only=True,
+                                                 expandable_progress=progress)
         upd.assert_not_called()
         upd.reset_mock()
         assert mock_minio.get_signed_url.await_count == 2
@@ -583,8 +584,8 @@ async def test_use_of_cache_ignore_cache(mocker):
         datasource2.result_format = ResultFormat.parquet
         upd = mocker.patch.object(cache, 'update_record', side_effect=cache.update_record)
         with ExpandableProgress(display_progress=False) as progress:
-            result1 = await datasource2.submit_and_download(signed_urls_only=True,
-                                                           expandable_progress=progress)
+            await datasource2.submit_and_download(signed_urls_only=True,
+                                                  expandable_progress=progress)
         upd.assert_not_called()
         upd.reset_mock()
         assert mock_minio.get_signed_url.await_count == 2


### PR DESCRIPTION
### Problem
Resolve #375 

```
cached_record = (
            self.cache.get_transform_by_hash(sx_request_hash)   # this raises exception when 2 records are present
            if not self.ignore_cache
            else None
        )
```
When the user submits a transform without `ignore-cache` -> records are inserted as expected
When the user submits same transform with `ignore-cache` -> a NEW record is still created (tiny db has no unique value contraints)
When the user submits same tranform without `ignore-cache` -> 2 records are present hence raises exception

### Fix

When the user submits a query and selects ignore_cache -
Check if we have a previous hash already present and if present delete that record since we are going to run the transform again.


