### PR TITLE
ci: Fix file name error

### DIFF
--- a/.github/workflows/ci_production.yaml
+++ b/.github/workflows/ci_production.yaml
@@ -34,5 +34,5 @@ jobs:
 
       - name: Run example
         working-directory: examples
-        run: python3 Uproot_UprootRaw_Dict.py
+        run: python UprootRaw_Dict.py
 


### PR DESCRIPTION
* `examples/Uproot_UprootRaw_Dict.py` doesn't exist but [`examples/UprootRaw_Dict.py`](https://github.com/ssl-hep/ServiceX_frontend/blob/048723250e6bf0e2734c6d12980cf9a1dc6ff4bc/examples/UprootRaw_Dict.py) does.