### PR TITLE
expose OutputFormatEnum instead of ResultFormat to user

### DIFF
--- a/servicex/__init__.py
+++ b/servicex/__init__.py
@@ -27,12 +27,14 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from servicex.databinder_models import Sample, General, ServiceXSpec
 from servicex.servicex_client import deliver
-from .models import ResultFormat, ResultDestination
+from .models import ResultDestination
 import servicex.dataset as dataset
 import servicex.query as query
 
+OutputFormat = General.OutputFormatEnum
+
 __all__ = [
-    "ResultFormat",
+    "OutputFormat",
     "ResultDestination",
     "Sample",
     "General",

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -2,7 +2,7 @@ import pytest
 from unittest.mock import patch
 from pydantic import ValidationError
 
-from servicex import ServiceXSpec, dataset
+from servicex import ServiceXSpec, dataset, OutputFormat
 from servicex.query_core import ServiceXException
 from servicex.servicex_client import ReturnValueException
 from servicex.dataset import FileList, Rucio
@@ -91,6 +91,21 @@ def test_list_of_root_files():
         "root://eospublic.cern.ch//file1.root",
         "root://eospublic.cern.ch//file2.root",
     ]
+
+
+def test_output_format():
+    spec = basic_spec()
+    spec['General'] = {'OutputFormat': 'root-ttree'}
+    ServiceXSpec.model_validate(spec)
+    spec['General'] = {'OutputFormat': 'parquet'}
+    ServiceXSpec.model_validate(spec)
+    spec['General'] = {'OutputFormat': OutputFormat.root_ttree}
+    ServiceXSpec.model_validate(spec)
+    spec['General'] = {'OutputFormat': OutputFormat.parquet}
+    ServiceXSpec.model_validate(spec)
+    with pytest.raises(ValidationError):
+        spec['General'] = {'OutputFormat': 'root-tree'}
+        ServiceXSpec.model_validate(spec)
 
 
 def test_rucio_did():

--- a/tests/test_dataset_group.py
+++ b/tests/test_dataset_group.py
@@ -29,7 +29,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from servicex import ResultFormat
+from servicex.models import ResultFormat
 from servicex.dataset_group import DatasetGroup
 from servicex.query_core import ServiceXException
 


### PR DESCRIPTION
Resolves #447 by changing the enum that is given to the user to be the one used by Pydantic to validate user input, instead of the one that defines interactions with the backend