### PR TITLE
Prevent user passing nfiles=0 when creating a sample

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -101,7 +101,7 @@ class Sample(BaseModel):
         Access the dataset identifier for the sample.
         """
         if self.Dataset:
-            if self.NFiles:
+            if self.NFiles is not None:
                 self.Dataset.num_files = self.NFiles
             return self.Dataset
         elif self.RucioDID:
@@ -125,6 +125,15 @@ class Sample(BaseModel):
         if count == 0:
             raise ValueError("Must specify one of Dataset, XRootDFiles, or RucioDID.")
         return values
+
+    @model_validator(mode="after")
+    def validate_nfiles_is_not_zero(self):
+        """
+        Ensure that NFiles is not set to zero
+        """
+        if self.dataset_identifier.num_files == 0:
+            raise ValueError("NFiles cannot be set to zero for a dataset.")
+        return self
 
     @field_validator("Name", mode="before")
     @classmethod

--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -78,6 +78,7 @@ class FileListDataset(DataSetIdentifier):
 
         :param files: Either a list of URIs or a single URI string
         """
+        self.num_files: Optional[int] = None  # you should pass only the files you want
         self.files: List[str]
         if isinstance(files, str):
             self.files = [files]

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -155,6 +155,56 @@ def test_dataset_rucio_did_numfiles():
     )
 
 
+def test_dataset_zerofiles():
+    # with an actual dataset, giving no files should throw a validation error
+    with pytest.raises(ValidationError):
+        spec = ServiceXSpec.model_validate(
+            basic_spec(
+                samples=[
+                    {
+                        "Name": "sampleA",
+                        "Dataset":
+                            dataset.Rucio("user.ivukotic:user.ivukotic.single_top_tW__nominal"),
+                        "NFiles": 0,
+                        "Query": "a",
+                    }
+                ]
+            )
+        )
+
+    with pytest.raises(ValidationError):
+        spec = ServiceXSpec.model_validate(
+            basic_spec(
+                samples=[
+                    {
+                        "Name": "sampleA",
+                        "Dataset":
+                            dataset.Rucio("user.ivukotic:user.ivukotic.single_top_tW__nominal",
+                                          num_files=0),
+                        "Query": "a",
+                    }
+                ]
+            )
+        )
+
+    # and num files should be ignored for fileset
+    spec = ServiceXSpec.model_validate(
+        basic_spec(
+            samples=[
+                {
+                    "Name": "sampleA",
+                    "Dataset": dataset.FileList([
+                        "root://eospublic.cern.ch//file1.root",
+                        "root://eospublic.cern.ch//file2.root",
+                    ]),
+                    "Query": "a",
+                }
+            ]
+        )
+    )
+    assert spec.Sample[0].dataset_identifier.num_files is None
+
+
 def test_cernopendata():
     spec = ServiceXSpec.model_validate({
         "Sample": [


### PR DESCRIPTION
Resolve #467 by rejecting setting `NFiles=0` (or `num_files=0`) during `Sample` specification