### PR TITLE
Better handling of tokens near expiry

### DIFF
--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -27,7 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 import tempfile
-from unittest.mock import patch, AsyncMock
+from unittest.mock import patch
 import httpx
 import pytest
 from pytest_asyncio import fixture

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -27,12 +27,13 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import patch, AsyncMock
 import httpx
 import pytest
 from pytest_asyncio import fixture
 from servicex.models import TransformRequest, ResultDestination, ResultFormat
 from servicex.servicex_adapter import ServiceXAdapter, AuthorizationError
+import time
 
 
 @fixture
@@ -213,7 +214,9 @@ async def test_get_tranform_status_retry_error(get,
 
 
 @pytest.mark.asyncio
+# @patch('google.auth.jwt.decode', return_value={'exp': time.time() + 90})
 async def test_get_authorization(servicex):
     servicex.token = "token"
-    r = await servicex._get_authorization()
-    assert r.get("Authorization") == "Bearer token"
+    with patch('google.auth.jwt.decode', return_value={'exp': time.time() + 90}):
+        r = await servicex._get_authorization()
+        assert r.get("Authorization") == "Bearer token"


### PR DESCRIPTION
Resolves #473:
* if an auth token is within 60 seconds of expiry, renew it before proceeding with request;
* if a transformation status query returns an auth error, attempt a retry with an updated token;
* add better handling of other error codes when querying transformation status.