### PR TITLE
Caching behavior of permutation fix #396

### DIFF
--- a/servicex/models.py
+++ b/servicex/models.py
@@ -100,7 +100,7 @@ class TransformRequest(BaseModel):
                     self.codegen,
                     self.image,
                     self.result_format.name,
-                    self.file_list,
+                    sorted(self.file_list),
                 ]
             ).encode("utf-8")
         )

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -100,7 +100,7 @@ class TransformRequest(BaseModel):
                     self.codegen,
                     self.image,
                     self.result_format.name,
-                    sorted(self.file_list),
+                    sorted(self.file_list) if self.file_list else None,
                 ]
             ).encode("utf-8")
         )

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -63,13 +63,13 @@ def test_hash(transform_request):
     assert request1.compute_hash() != request2.compute_hash()
 
     # Add file names and shuffle the order
-    request2 =  request1.model_copy()
+    request2 = request1.model_copy()
     request1.file_list = ["file1.txt", "file2.txt"]
     request2.file_list = ["file2.txt", "file1.txt"]
     assert request1.compute_hash() == request2.compute_hash()
 
     # Add different file names
-    request2 =  request1.model_copy()
+    request2 = request1.model_copy()
     request1.file_list = ["file1.txt", "file2.txt"]
     request2.file_list = ["file3.txt", "file4.txt"]
     assert request1.compute_hash() != request2.compute_hash()

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -62,6 +62,18 @@ def test_hash(transform_request):
     request2.result_format = ResultFormat.root_ttree
     assert request1.compute_hash() != request2.compute_hash()
 
+    # Add file names and shuffle the order
+    request2 =  request1.model_copy()
+    request1.file_list = ["file1.txt", "file2.txt"]
+    request2.file_list = ["file2.txt", "file1.txt"]
+    assert request1.compute_hash() == request2.compute_hash()
+
+    # Add different file names
+    request2 =  request1.model_copy()
+    request1.file_list = ["file1.txt", "file2.txt"]
+    request2.file_list = ["file3.txt", "file4.txt"]
+    assert request1.compute_hash() != request2.compute_hash()
+
 
 def test_cache_transform(transform_request, completed_status):
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
Resolves #396 
Problem:
When submitting multiple requests with same file names but different order different hash were computed hence recomputing results.

Fix:
Simply sort the file names before the hash is calculated
