### PR TITLE
Resume request when client fails fixes #468

### DIFF
--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -126,6 +126,11 @@ class QueryCache:
         else:
             return TransformRequest(**records[0])
 
+    def queue_delete_record(self, record: TransformRequest):
+        hash_value = record.compute_hash()
+        with self.lock:
+            self.queue.remove(where('hash') == hash_value)
+
     def cache_transform(self, record: TransformedResults):
         with self.lock:
             if not self.contains_hash(record.hash):

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -215,13 +215,3 @@ class QueryCache:
         with self.lock:
             self.db.remove(where('backend') == backend)
 
-    async def get_request_id(self, request: TransformRequest):
-        transform = Query()
-        with self.lock:
-            hash = request.compute_hash()
-            record = self.db.search(transform.hash == hash)
-
-        if not record:
-            return None
-
-        return TransformedResults(**record[0]).request_id

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -49,9 +49,6 @@ class QueryCache:
         self.lock = FileLock(os.path.join(self.config.cache_path, "db.lock"))
         self.queue = TinyDB(os.path.join(self.config.cache_path, "queue.json"))
 
-    def close_queue(self):
-        self.queue.close()
-
     def close(self):
         self.db.close()
         self.queue.close()

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -214,4 +214,3 @@ class QueryCache:
     def delete_codegen_by_backend(self, backend: str):
         with self.lock:
             self.db.remove(where('backend') == backend)
-

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -70,7 +70,8 @@ class QueryCache:
 
     def cache_transform(self, record: TransformedResults):
         with self.lock:
-            self.db.insert(json.loads(record.model_dump_json()))
+            if not self.contains_hash(record.hash):
+                self.db.insert(json.loads(record.model_dump_json()))
 
     def update_record(self, record: TransformedResults):
         transforms = Query()

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -73,11 +73,11 @@ class QueryCache:
             result_format=transform.result_format,
             log_url=completed_status.log_url
         )
-    
+
     def queue_contains_hash(self, hash: str):
         tranform_request = Query()
         with self.lock:
-            records = self.queue.search(tranform_request.hash==hash)
+            records = self.queue.search(tranform_request.hash == hash)
         return len(records) > 0
 
     def queue_transform(self, record: TransformRequest):
@@ -85,7 +85,7 @@ class QueryCache:
             hash_value = record.compute_hash()
             if not self.queue_contains_hash(hash_value):
                 record = json.loads(record.model_dump_json())
-                record["hash"]= hash_value
+                record["hash"] = hash_value
                 # record["request_id"] = request_id
                 self.queue.insert(record)
 
@@ -93,8 +93,7 @@ class QueryCache:
         transforms = Query()
         with self.lock:
             hash_value = record.compute_hash()
-            self.queue.upsert({'request_id': request_id},
-                           transforms.hash == hash_value)
+            self.queue.upsert({'request_id': request_id}, transforms.hash == hash_value)
 
     async def queue_get_transform_request_id(self, request: TransformRequest) -> str:
         transform_request = Query()
@@ -126,7 +125,6 @@ class QueryCache:
             raise CacheException("Multiple records found in db for hash")
         else:
             return TransformRequest(**records[0])
-
 
     def cache_transform(self, record: TransformedResults):
         with self.lock:
@@ -225,5 +223,5 @@ class QueryCache:
 
         if not record:
             return None
-        
+
         return TransformedResults(**record[0]).request_id

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -190,7 +190,7 @@ class QueryCache:
         with self.lock:
             self.db.remove(where('backend') == backend)
 
-    def get_request_id(self, request: TransformRequest):
+    async def get_request_id(self, request: TransformRequest):
         transform = Query()
         with self.lock:
             hash = request.compute_hash()

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -243,12 +243,11 @@ class Query:
         )
 
         # Let's see if the request is already in the queue to be processed
-        queued_record = ( 
+        queued_record = (
             self.cache.queue_get_transform_request_hash(sx_request_hash)
             if not self.ignore_cache
             else None
         )
-
 
         # And that we grabbed the resulting files in the way that the user requested
         # (Downloaded, or obtained pre-signed URLs)
@@ -297,10 +296,11 @@ class Query:
                 self.cache.queue_transform(sx_request)
                 self.request_id = await self.servicex.submit_transform(sx_request)
                 self.cache.queue_transform_update(sx_request, self.request_id)
-                
-            else:
-                self.request_id = await loop.create_task(self.cache.queue_get_transform_request_id(sx_request))
 
+            else:
+                self.request_id = await loop.create_task(
+                    self.cache.queue_get_transform_request_id(sx_request)
+                    ) # noqa
 
             monitor_task = loop.create_task(
                 self.transform_status_listener(

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -242,6 +242,13 @@ class Query:
             else None
         )
 
+        # Let's see if the request is already in the queue to be processed
+        queued_record = self.cache.queue_get_transform_request_hash(sx_request_hash) 
+
+        # Add to queue if not queued already
+        if not queued_record:
+            self.cache.queue_transform(sx_request)
+
         # And that we grabbed the resulting files in the way that the user requested
         # (Downloaded, or obtained pre-signed URLs)
         if cached_record:
@@ -285,7 +292,11 @@ class Query:
         )
 
         if not cached_record:
+            # if not queued_record:
             self.request_id = await self.servicex.submit_transform(sx_request)
+            # else:
+            #     self.request_id = await self.cache_record.get_request_id(sx_request)
+
 
             monitor_task = loop.create_task(
                 self.transform_status_listener(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -244,11 +244,14 @@ async def test_submit_and_download_cache_miss(python_dataset, completed_status):
         python_dataset.servicex = AsyncMock()
         python_dataset.cache.get_transform_by_hash = Mock()
         python_dataset.cache.get_transform_by_hash.return_value = None
+        python_dataset.cache.queue_get_transform_request_hash = Mock()
+        python_dataset.cache.queue_get_transform_request_hash.return_value = None
         python_dataset.servicex.get_transform_status = AsyncMock(id="12345")
         python_dataset.servicex.get_transform_status.return_value = completed_status
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
+        python_dataset.cache.queue_transform_update = Mock()
 
         signed_urls_only = False
         expandable_progress = ExpandableProgress()
@@ -277,6 +280,7 @@ async def test_submit_and_download_cache_miss_overall_progress(python_dataset, c
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
+        python_dataset.cache.queue_transform_update = Mock()
 
         signed_urls_only = False
         expandable_progress = ExpandableProgress(overall_progress=True)
@@ -338,6 +342,7 @@ async def test_submit_and_download_cache_miss_signed_urls_only(python_dataset, c
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
+        python_dataset.cache.queue_transform_update = Mock()
 
         signed_urls_only = True
         expandable_progress = ExpandableProgress()

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -32,7 +32,7 @@ import pytest
 
 from servicex.configuration import Configuration
 from servicex.models import ResultFormat
-from servicex.query_cache import QueryCache, CacheException
+from servicex.query_cache import QueryCache
 from tinydb import Query
 
 file_uris = ["/tmp/foo1.root", "/tmp/foo2.root"]
@@ -103,15 +103,7 @@ def test_cache_transform(transform_request, completed_status):
             )
         )
 
-        with pytest.raises(CacheException):
-            _ = cache.get_transform_by_hash(transform_request.compute_hash())
-
-        with pytest.raises(CacheException):
-            _ = cache.get_transform_by_request_id(
-                "b8c508d0-ccf2-4deb-a1f7-65c839eebabf"
-            )
-
-        assert len(cache.cached_queries()) == 2
+        assert len(cache.cached_queries()) == 1
 
         cache.delete_record_by_request_id("b8c508d0-ccf2-4deb-a1f7-65c839eebabf")
         assert len(cache.cached_queries()) == 0
@@ -142,7 +134,7 @@ def test_record_delete(transform_request, completed_status):
                 signed_urls=[],
             )
         )
-
+        transform_request.did = "rucio://foo.baz"
         cache.cache_transform(
             cache.transformed_results(
                 transform=transform_request,
@@ -154,7 +146,6 @@ def test_record_delete(transform_request, completed_status):
                 signed_urls=[],
             )
         )
-
         assert len(cache.cached_queries()) == 2
         cache.delete_record_by_request_id("02c64494-4529-49a7-a4a6-95661ea3936e")
         assert len(cache.cached_queries()) == 1

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -394,3 +394,16 @@ def test_queue_get_transform_request_hash(transform_request):
             cache.queue_get_transform_request_hash(hash_value)
 
         cache.close()
+
+
+def test_queue_delete_record(transform_request):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config = Configuration(cache_path=temp_dir, api_endpoints=[])  # type: ignore
+        cache = QueryCache(config)
+        cache.queue_transform(transform_request)
+        hash_value = transform_request.compute_hash()
+        assert cache.queue_get_transform_request_hash(hash_value).title == "Test submission"
+
+        cache.queue_delete_record(transform_request)
+        assert cache.queue_get_transform_request_hash(hash_value) is None
+        cache.close()


### PR DESCRIPTION
Resolves #468
### Problem
When the client submits the request but encounters client failure, there is no way of resuming the transforms from the last point. The client is forced to rerun the request which triggers the backend again.

### Fix
This PR fixes the broken client problem. The client will be able to resume the request from the last point. Given the client submits the same request again (important since the request hash is calculated and compared with any pending requests)
Future scope:
- Provide a CLI option to rerun all the jobs which are stale due to client failures
- Download the files which are already processed by the backend by providing a request id (CLI)

### Approach
Created a new instance of tinydb whose sole purpose is to keep track of the transform request submissions. 
I had a discussion with @ponyisi whether we should have the cache use additional columns and flags. The cache currently holds the TransformationResults AFTER the request is processed. We could technically have additional columns, but it would mean changing previous cache specific functions.
I propose to create a new instance of tinydb which stores the submitted transform request ( I have named it as `queue`). This will allow to add transform request submission related functions to be separate from the cache features. Thus keeping the existing code intact and only adding the necessary steps in between.
Also this will allow us to add the future scope (CLI) option without much modification.

Open to design inputs


### Details of this PR
- Created a separat instance of tinydb called `queue` which records each new transform_request
- Incase of multiple transform request with same hash only one record is maintained and only one submission to backend is created saving redundant requests
- Incase of failure on the client side, the queue resumes when you run the same request again. However, if you submit is with 'ignore cache` parameter, it will rerun the request to the backend.
