### PR TITLE
Single Database instance -- Resume request when client fails fixes #468 

### DIFF
--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -84,21 +84,24 @@ class QueryCache:
         """
         transforms = Query()
         with self.lock:
-            records = self.db.search((transforms.hash == hash) & (transforms.files.exists()))
+            records = self.db.search((transforms.hash == hash)
+                                     & ~(transforms.status == 'SUBMITTED'))
         return len(records) > 0
 
-    def get_transform_request_status(self, hash_value: str) -> Optional[str]:
+    def is_transform_request_submitted(self, hash_value: str) -> bool:
         """
         Get the status of a transform request
         """
         transform = Query()
         with self.lock:
-            records = self.db.search((transform.hash == hash_value)
-                                     & (transform.status.exists()))
+            records = self.db.search((transform.hash == hash_value))
 
         if not records:
-            return None
-        return records[0]['status']
+            return False
+
+        if "status" in records[0] and records[0]["status"] == 'SUBMITTED':
+            return True
+        return False
 
     def get_transform_request_id(self, hash_value: str) -> Optional[str]:
         """
@@ -137,7 +140,7 @@ class QueryCache:
         transforms = Query()
         with self.lock:
             records = records = self.db.search((transforms.hash == hash)
-                                               & (transforms.files.exists()))
+                                               & ~(transforms.status == 'SUBMITTED'))
 
         if not records:
             return None

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -79,12 +79,18 @@ class QueryCache:
             self.db.update(json.loads(record.model_dump_json()), transforms.hash == record.hash)
 
     def contains_hash(self, hash: str) -> bool:
+        """
+        Check if the cache has completed records for a hash
+        """
         transforms = Query()
         with self.lock:
             records = self.db.search((transforms.hash == hash) & (transforms.files.exists()))
         return len(records) > 0
 
     def get_transform_request_status(self, hash_value: str) -> Optional[str]:
+        """
+        Get the status of a transform request
+        """
         transform = Query()
         with self.lock:
             records = self.db.search((transform.hash == hash_value)
@@ -95,6 +101,9 @@ class QueryCache:
         return records[0]['status']
 
     def get_transform_request_id(self, hash_value: str) -> Optional[str]:
+        """
+        Return the request id of cached record
+        """
         transform = Query()
 
         with self.lock:
@@ -105,17 +114,26 @@ class QueryCache:
         return records[0]["request_id"]
 
     def update_transform_status(self, hash_value: str, status: str) -> None:
+        """
+        Update the cached record status
+        """
         transform = Query()
         with self.lock:
             self.db.upsert({"hash": hash_value, "status": status}, transform.hash == hash_value)
 
     def update_transform_request_id(self, hash_value: str, request_id: str) -> None:
+        """
+        Update the cached record request id
+        """
         transform = Query()
         with self.lock:
             self.db.upsert({"hash": hash_value, "request_id": request_id},
                            transform.hash == hash_value)
 
     def get_transform_by_hash(self, hash: str) -> Optional[TransformedResults]:
+        """
+        Returns completed transformations by hash
+        """
         transforms = Query()
         with self.lock:
             records = records = self.db.search((transforms.hash == hash)
@@ -130,6 +148,9 @@ class QueryCache:
             return TransformedResults(**records[0])
 
     def get_transform_by_request_id(self, request_id: str) -> Optional[TransformedResults]:
+        """
+        Returns completed transformed results using a request id
+        """
         transforms = Query()
 
         with self.lock:

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -90,7 +90,9 @@ class QueryCache:
 
     def is_transform_request_submitted(self, hash_value: str) -> bool:
         """
-        Get the status of a transform request
+        Returns True if request is submitted
+        Returns False if the request is not in the cache at all
+        or not submitted
         """
         transform = Query()
         with self.lock:

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -72,9 +72,7 @@ class QueryCache:
     def cache_transform(self, record: TransformedResults):
         transforms = Query()
         with self.lock:
-            # if not self.contains_hash(record.hash):
-            self.db.upsert(json.loads(record.model_dump_json()),
-                           transforms.hash == record.hash)
+            self.db.upsert(json.loads(record.model_dump_json()), transforms.hash == record.hash)
 
     def update_record(self, record: TransformedResults):
         transforms = Query()
@@ -84,26 +82,25 @@ class QueryCache:
     def contains_hash(self, hash: str) -> bool:
         transforms = Query()
         with self.lock:
-            records = self.db.search((transforms.hash == hash) & (transforms.status.exists()) & 
-                                     (transforms.status == 'COMPLETE'))
+            records = self.db.search((transforms.hash == hash) & (transforms.status.exists())
+                                     & (transforms.status == 'COMPLETE'))
         return len(records) > 0
 
     def get_transform_request_status(self, hash_value: str) -> Optional[str]:
         transform = Query()
-        # hash_value = request.compute_hash()
         with self.lock:
-            records = self.db.search((transform.hash==hash_value) & (transform.status.exists()))
-        
+            records = self.db.search((transform.hash == hash_value)
+                                     & (transform.status.exists()))
+
         if not records:
             return None
         if len(records) != 1:
             raise CacheException("Multiple records found in db for hash")
         else:
             return records[0]['status']
-        
+
     async def get_transform_request_id(self, hash_value: str) -> Optional[str]:
         transform = Query()
-        # hash_value = request.compute_hash()
         while True:
             with self.lock:
                 records = self.db.search(transform.hash == hash_value)
@@ -118,23 +115,23 @@ class QueryCache:
                     return records[0]["request_id"]
                 else:
                     await asyncio.sleep(1)
-        
+
     def update_transform_status(self, hash_value: str, status: str) -> None:
         transform = Query()
         with self.lock:
-            self.db.upsert({"hash":hash_value, "status":status}, transform.hash==hash_value)
+            self.db.upsert({"hash": hash_value, "status": status}, transform.hash == hash_value)
 
     def update_transform_request_id(self, hash_value: str, request_id: str) -> None:
         transform = Query()
-        # hash_value = request.compute_hash()
         with self.lock:
-            self.db.upsert({"hash":hash_value, "request_id":request_id}, transform.hash==hash_value)
+            self.db.upsert({"hash": hash_value, "request_id": request_id},
+                           transform.hash == hash_value)
 
     def get_transform_by_hash(self, hash: str) -> Optional[TransformedResults]:
         transforms = Query()
         with self.lock:
-            records = self.db.search((transforms.hash == hash) & (transforms.status.exists()) & 
-                                     (transforms.status == 'COMPLETE'))
+            records = self.db.search((transforms.hash == hash) & (transforms.status.exists())
+                                     & (transforms.status == 'COMPLETE'))
 
         if not records:
             return None

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -288,7 +288,7 @@ class Query:
 
         if not cached_record:
 
-            if self.cache.get_transform_request_status(sx_request_hash) == "SUBMITTED":
+            if self.cache.is_transform_request_submitted(sx_request_hash):
                 self.request_id = self.cache.get_transform_request_id(sx_request_hash)
             else:
                 self.request_id = await self.servicex.submit_transform(sx_request)

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -237,7 +237,7 @@ class Query:
         # Let's see if this is in the cache already, but respect the user's wishes
         # to ignore the cache
         cached_record = (
-            self.cache.get_transform_by_hash(sx_request_hash)  ### change this function ###
+            self.cache.get_transform_by_hash(sx_request_hash)
             if not self.ignore_cache
             else None
         )
@@ -285,17 +285,6 @@ class Query:
         )
 
         if not cached_record:
-            ###
-            # if the transform request is pending 
-            # if self.cache.get_transform_request_status(sx_request_hash):
-            #     self.request_id = await self.cache.get_transform_request_id(sx_request_hash)  # wait for the request id
-                
-            # elif not self.cache.get_transform_request_status(sx_request_hash):
-            #     self.cache.cache_transform_request(sx_request_hash)  # add the transform request to cache
-            #     self.request_id = await self.servicex.submit_transform(sx_request)  # submit the transform request
-            #     self.cache.update_transform_request_id(sx_request_hash, self.request_id) # update the cache with request id
-            ###
-            # self.request_id = await self.servicex.submit_transform(sx_request)
 
             if self.cache.get_transform_request_status(sx_request_hash) == "SUBMITTED":
                 self.request_id = await self.cache.get_transform_request_id(sx_request_hash)
@@ -303,7 +292,6 @@ class Query:
                 self.request_id = await self.servicex.submit_transform(sx_request)
                 self.cache.update_transform_request_id(sx_request_hash, self.request_id)
                 self.cache.update_transform_status(sx_request_hash, "SUBMITTED")
-
 
             monitor_task = loop.create_task(
                 self.transform_status_listener(

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -195,6 +195,7 @@ class Query:
                 logger.error(
                     "ServiceX Exception", exc_info=task.exception()
                 )
+                self.cache.delete_record_by_request_id(self.request_id)
                 if download_files_task:
                     import sys
                     if sys.version_info < (3, 9):
@@ -205,6 +206,7 @@ class Query:
 
             if self.current_status.status in DONE_STATUS:
                 if self.current_status.files_failed:
+                    self.cache.delete_record_by_request_id(self.request_id)
                     titlestr = (f'"{self.current_status.title}" '
                                 if self.current_status.title is not None else '')
                     logger.error(
@@ -287,7 +289,7 @@ class Query:
         if not cached_record:
 
             if self.cache.get_transform_request_status(sx_request_hash) == "SUBMITTED":
-                self.request_id = await self.cache.get_transform_request_id(sx_request_hash)
+                self.request_id = self.cache.get_transform_request_id(sx_request_hash)
             else:
                 self.request_id = await self.servicex.submit_transform(sx_request)
                 self.cache.update_transform_request_id(sx_request_hash, self.request_id)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -279,7 +279,6 @@ async def test_submit_and_download_cache_miss_overall_progress(python_dataset, c
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
         python_dataset.cache.update_transform_request_id = Mock()
-        # python_dataset.cache.update_transform_status = Mock()
 
         signed_urls_only = False
         expandable_progress = ExpandableProgress(overall_progress=True)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -455,7 +455,7 @@ async def test_submit_and_download_get_request_id_from_previous_submitted_reques
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
-        python_dataset.cache.get_transform_request_status = Mock(return_value='SUBMITTED')
+        python_dataset.cache.is_transform_request_submitted = Mock(return_value=True)
         python_dataset.cache.get_transform_request_id = Mock(return_value="b8c508d0-ccf2-4deb-a1f7-65c839eebabf")  # noqa
         signed_urls_only = True
         expandable_progress = ExpandableProgress()

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -456,6 +456,7 @@ async def test_submit_and_download_get_request_id_from_previous_submitted_reques
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
         python_dataset.cache.get_transform_request_status = Mock(return_value='SUBMITTED')
+        python_dataset.cache.get_transform_request_id = Mock(return_value="b8c508d0-ccf2-4deb-a1f7-65c839eebabf")  # noqa
         signed_urls_only = True
         expandable_progress = ExpandableProgress()
         result = await python_dataset.submit_and_download(signed_urls_only, expandable_progress)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -249,6 +249,7 @@ async def test_submit_and_download_cache_miss(python_dataset, completed_status):
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
+        python_dataset.cache.update_transform_request_id = Mock()
 
         signed_urls_only = False
         expandable_progress = ExpandableProgress()
@@ -277,6 +278,8 @@ async def test_submit_and_download_cache_miss_overall_progress(python_dataset, c
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
+        python_dataset.cache.update_transform_request_id = Mock()
+        # python_dataset.cache.update_transform_status = Mock()
 
         signed_urls_only = False
         expandable_progress = ExpandableProgress(overall_progress=True)
@@ -338,6 +341,7 @@ async def test_submit_and_download_cache_miss_signed_urls_only(python_dataset, c
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
+        python_dataset.cache.update_transform_request_id = Mock()
 
         signed_urls_only = True
         expandable_progress = ExpandableProgress()
@@ -429,4 +433,33 @@ async def test_network_loss(python_dataset, transformed_result):
         result = await python_dataset.submit_and_download(signed_urls_only, expandable_progress)
         assert result is not None
         assert result.request_id == "123-45-6789"
+        cache.close()
+
+
+@pytest.mark.asyncio
+async def test_submit_and_download_get_request_id_from_previous_submitted_request(
+        python_dataset,
+        completed_status):
+    with tempfile.TemporaryDirectory() as temp_dir:
+        python_dataset.current_status = None
+        python_dataset.servicex = AsyncMock()
+        config = Configuration(cache_path=temp_dir, api_endpoints=[])
+        cache = QueryCache(config)
+        python_dataset.cache = cache
+        python_dataset.configuration = config
+        python_dataset.servicex = AsyncMock()
+        python_dataset.cache.get_transform_by_hash = Mock()
+        python_dataset.cache.get_transform_by_hash.return_value = None
+        python_dataset.servicex.get_transform_status = AsyncMock(id="12345")
+        python_dataset.servicex.get_transform_status.return_value = completed_status
+        python_dataset.servicex.submit_transform = AsyncMock()
+        python_dataset.download_files = AsyncMock()
+        python_dataset.download_files.return_value = []
+        python_dataset.cache.get_transform_request_status = Mock(return_value='SUBMITTED')
+        signed_urls_only = True
+        expandable_progress = ExpandableProgress()
+        result = await python_dataset.submit_and_download(signed_urls_only, expandable_progress)
+
+        assert result is not None
+        assert result.request_id == "b8c508d0-ccf2-4deb-a1f7-65c839eebabf"
         cache.close()

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -333,7 +333,7 @@ def test_get_transform_request_status(transform_request, completed_status):
         cache = QueryCache(config)
         hash_value = transform_request.compute_hash()
 
-        assert cache.get_transform_request_status(hash_value) is None
+        assert cache.is_transform_request_submitted(hash_value) is False
 
         # cache transform
         cache.update_transform_status(hash_value, "COMPLETE")
@@ -347,6 +347,20 @@ def test_get_transform_request_status(transform_request, completed_status):
             )
         )
 
-        assert cache.get_transform_request_status(hash_value) == "COMPLETE"
+        assert cache.is_transform_request_submitted(hash_value) is False
+
+        # cache transform
+        cache.update_transform_status(hash_value, "SUBMITTED")
+        cache.cache_transform(
+            cache.transformed_results(
+                transform=transform_request,
+                completed_status=completed_status,
+                data_dir="/foo/bar",
+                file_list=file_uris,
+                signed_urls=[],
+            )
+        )
+
+        assert cache.is_transform_request_submitted(hash_value) is True
 
         cache.close()

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -29,7 +29,6 @@ import os
 import tempfile
 import json
 import pytest
-import asyncio
 
 from servicex.configuration import Configuration
 from servicex.models import ResultFormat
@@ -308,34 +307,22 @@ def test_contains_hash(transform_request, completed_status):
         cache.close()
 
 
-@pytest.mark.asyncio
-async def test_get_transform_request_id(transform_request, completed_status):
+def test_get_transform_request_id(transform_request, completed_status):
     with tempfile.TemporaryDirectory() as temp_dir:
         config = Configuration(cache_path=temp_dir, api_endpoints=[])  # type: ignore
         cache = QueryCache(config)
         hash_value = transform_request.compute_hash()
 
         # if the transform request id is not cached
-        request_id = await cache.get_transform_request_id(hash_value)
-        assert request_id is None
+        with pytest.raises(CacheException):
+            request_id = cache.get_transform_request_id(hash_value)
+            print(request_id)
 
         # update the transform request with a request id and then check for the request id
-        # Create 2 tasks to mimic asynchronous requests
-        loop = asyncio.get_event_loop()
         cache.update_transform_status(hash_value, 'SUBMITTED')
-        task1 = loop.create_task(cache.get_transform_request_id(hash_value))
-        await asyncio.sleep(3)
         cache.update_transform_request_id(hash_value, "123456")
-        task2 = loop.create_task(cache.get_transform_request_id(hash_value))
-        request_id = await task1
-        request_id2 = await task2
+        request_id = cache.get_transform_request_id(hash_value)
         assert request_id == "123456"
-        assert request_id == request_id2
-
-        # force duplicate records in queue
-        cache.db.insert({"hash": transform_request.compute_hash(), "key": "value"})
-        with pytest.raises(CacheException):
-            await cache.get_transform_request_id(hash_value)
 
         cache.close()
 
@@ -361,21 +348,5 @@ def test_get_transform_request_status(transform_request, completed_status):
         )
 
         assert cache.get_transform_request_status(hash_value) == "COMPLETE"
-
-        # force add duplicate values in cache
-        record = json.loads(
-            cache.transformed_results(
-                transform=transform_request,
-                completed_status=completed_status,
-                data_dir="/foo/baz",
-                file_list=file_uris,
-                signed_urls=[],
-            ).model_dump_json())
-        record["hash"] = transform_request.compute_hash()
-        record["status"] = "COMPLETE"
-        cache.db.insert(record)
-
-        with pytest.raises(CacheException):
-            cache.get_transform_request_status(hash_value)
 
         cache.close()


### PR DESCRIPTION
Resolves https://github.com/ssl-hep/ServiceX_frontend/issues/468

Problem
When the client submits the request but encounters client failure, there is no way of resuming the transforms from the last point. The client is forced to rerun the request which triggers the backend again.

Fix
Single Database instance -- Added flag
This PR fixes the broken client problem. The client will be able to resume the request from the last point. Given the client submits the same request again (important since the request hash is calculated and compared with any pending requests)