### PR TITLE
docs: Add conda-forge badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![Code Coverage](https://codecov.io/gh/ssl-hep/ServiceX_frontend/graph/badge.svg)](https://codecov.io/gh/ssl-hep/ServiceX_frontend)
 
 [![PyPI version](https://badge.fury.io/py/servicex.svg)](https://badge.fury.io/py/servicex)
+[![conda-forge version](https://img.shields.io/conda/vn/conda-forge/servicex.svg)](https://github.com/conda-forge/servicex-feedstock.git)
 [![Supported Python versions](https://img.shields.io/pypi/pyversions/servicex.svg)](https://pypi.org/project/servicex/)
 
 [![Docs](https://readthedocs.org/projects/docs/badge/?version=latest)](https://servicex-frontend.readthedocs.io)

--- a/docs/connect_servicex.rst
+++ b/docs/connect_servicex.rst
@@ -87,7 +87,7 @@ Setting to false preserves the full filename from the dataset.
 
 ServiceX Client Installation
 ----------------------------
-ServiceX client Python package is a python library for users to communicate 
+ServiceX client Python package is a python library for users to communicate
 with ServiceX backend (or server) to make transformation requests and handling
 of outputs.
 
@@ -101,8 +101,16 @@ Prerequisites
 Installation
 ~~~~~~~~~~~~
 
+The ServiceX client library can be installed either with ``pip``
+
 .. code-block:: bash
-    
-    pip install servicex
+
+    python -m pip install servicex
+
+or with ``conda``
+
+.. code-block:: bash
+
+    conda install --channel conda-forge servicex
 
 You're all set to make your ServiceX transformation request!

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -11,9 +11,17 @@ Installation
 -------------
 
 
+The ServiceX client library can be installed either with ``pip``
+
 .. code-block:: bash
-    
-    pip install servicex
+
+    python -m pip install servicex
+
+or with ``conda``
+
+.. code-block:: bash
+
+    conda install --channel conda-forge servicex
 
 This installs the servicex command line tool and the servicex Python package.
 


### PR DESCRIPTION
Resolves #352 

* Add conda-forge badge to README [![conda-forge version](https://img.shields.io/conda/vn/conda-forge/servicex.svg)](https://github.com/conda-forge/servicex-feedstock.git)
* Add conda-forge install instructions to docs