### PR TITLE
Validate multi samples fixes #499

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -262,7 +262,6 @@ class ServiceXSpec(BaseModel):
     @classmethod
     def validate_unique_sample(cls, v):
         hash_set = set([i.hash for i in v])
-        if len(hash_set)!=len(v):
+        if len(hash_set) != len(v):
             raise RuntimeError("Duplicate samples detected")
         return v
-

--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from typing import List, Union, Optional
+import hashlib
 
 from servicex.models import TransformRequest
 
@@ -48,6 +49,17 @@ class DataSetIdentifier:
     def populate_transform_request(self, transform_request: TransformRequest) -> None:
         transform_request.did = self.did
         transform_request.file_list = None
+
+    @property
+    def hash(self):
+        sha = hashlib.sha256(
+            str(
+                [
+                    self.dataset
+                ]
+            ).encode("utf-8")
+        )
+        return sha.hexdigest()
 
 
 class RucioDatasetIdentifier(DataSetIdentifier):
@@ -98,6 +110,18 @@ class FileListDataset(DataSetIdentifier):
     @classmethod
     def from_yaml(cls, constructor, node):
         return cls(constructor.construct_sequence(node))
+    
+    @property
+    def hash(self):
+        self.files.sort()
+        sha = hashlib.sha256(
+            str(
+                [
+                    self.files
+                ]
+            ).encode("utf-8")
+        )
+        return sha.hexdigest()
 
 
 class CERNOpenDataDatasetIdentifier(DataSetIdentifier):

--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -110,7 +110,7 @@ class FileListDataset(DataSetIdentifier):
     @classmethod
     def from_yaml(cls, constructor, node):
         return cls(constructor.construct_sequence(node))
-    
+
     @property
     def hash(self):
         self.files.sort()

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -371,7 +371,7 @@ def test_submit_mapping_failure_signed_urls(codegen_list):
             for _ in results['sampleA']:
                 pass
 
-        
+
 def test_yaml(tmp_path):
     from servicex.servicex_client import _load_ServiceXSpec
     from servicex.dataset import FileList, Rucio, CERNOpenData

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -371,7 +371,7 @@ def test_submit_mapping_failure_signed_urls(codegen_list):
             for _ in results['sampleA']:
                 pass
 
-
+        
 def test_yaml(tmp_path):
     from servicex.servicex_client import _load_ServiceXSpec
     from servicex.dataset import FileList, Rucio, CERNOpenData
@@ -398,7 +398,7 @@ Sample:
     Query: !UprootRaw |
                 [{"treename": "nominal"}]
   - Name: ttH4
-    Dataset: !Rucio user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v11
+    Dataset: !Rucio user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v112
     Query: !UprootRaw '[{"treename": "nominal"}]'
   - Name: ttH5
     Dataset: !FileList ["/path/to/file1.root", "/path/to/file2.root"]
@@ -416,7 +416,7 @@ Sample:
         assert type(result.Sample[2].Query).__name__ == 'UprootRawQuery'
         assert isinstance(result.Sample[3].dataset_identifier, Rucio)
         assert (result.Sample[3].dataset_identifier.did
-                == 'rucio://user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v11')
+                == 'rucio://user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v112')
         assert isinstance(result.Sample[4].dataset_identifier, FileList)
         assert (result.Sample[4].dataset_identifier.files
                 == ["/path/to/file1.root", "/path/to/file2.root"])
@@ -445,6 +445,50 @@ Sample:
 """)
         f.flush()
         with pytest.raises(SyntaxError):
+            _load_ServiceXSpec(path)
+
+    with open(path := (tmp_path / "python.yaml"), "w") as f:
+        f.write("""
+General:
+  OutputFormat: root-ttree
+  Delivery: LocalCache
+
+Sample:
+  - Name: ttH3
+    RucioDID: user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v11
+    Query: !UprootRaw |
+                [{"treename": "nominal"}]
+  - Name: ttH4
+    Dataset: !Rucio user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v11
+    Query: !UprootRaw '[{"treename": "nominal"}]'
+  - Name: ttH5
+    Dataset: !FileList ["/path/to/file1.root", "/path/to/file2.root"]
+    Query: !UprootRaw '[{"treename": "nominal"}]'
+    """)
+        f.flush()
+        with pytest.raises(RuntimeError):
+            _load_ServiceXSpec(path)
+
+    with open(path := (tmp_path / "python.yaml"), "w") as f:
+        f.write("""
+General:
+  OutputFormat: root-ttree
+  Delivery: LocalCache
+
+Sample:
+  - Name: ttH3
+    RucioDID: user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v11
+    Query: !UprootRaw |
+                [{"treename": "nominal"}]
+  - Name: ttH5
+    Dataset: !FileList ["/path/to/file2.root", "/path/to/file1.root"]
+    Query: !UprootRaw '[{"treename": "nominal"}]'
+  - Name: ttH5
+    Dataset: !FileList ["/path/to/file1.root", "/path/to/file2.root"]
+    Query: !UprootRaw '[{"treename": "nominal"}]'
+    """)
+        f.flush()
+        with pytest.raises(RuntimeError):
             _load_ServiceXSpec(path)
 
 


### PR DESCRIPTION
Resolves #499 

Added a validation step that raises an exception if duplicate samples are submitted. 
Used the dataset, query and codegen to create the hash of the sample.