### PR TITLE
Improve docstrings for Pydantic models

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -29,7 +29,6 @@ from enum import Enum
 import hashlib
 from typing import Union, Optional, List
 from pydantic import (
-    BaseModel,
     Field,
     model_validator, field_validator,
 )
@@ -38,15 +37,16 @@ import logging
 from servicex.dataset_identifier import (DataSetIdentifier, RucioDatasetIdentifier,
                                          FileListDataset)
 from servicex.query_core import QueryStringGenerator
-from servicex.models import ResultFormat
+from servicex.models import ResultFormat, DocStringBaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class Sample(BaseModel):
+class Sample(DocStringBaseModel):
     """
     Represents a single transform request within a larger submission.
     """
+    model_config = {'use_attribute_docstrings': True}
 
     Name: str
     """
@@ -164,10 +164,12 @@ class Sample(BaseModel):
         return sha.hexdigest()
 
 
-class General(BaseModel):
+class General(DocStringBaseModel):
     """
     Represents a group of samples to be transformed together.
     """
+    model_config = {'use_attribute_docstrings': True}
+
     class OutputFormatEnum(str, Enum):
         """
         Specifies the output format for the transform request.
@@ -239,10 +241,12 @@ class General(BaseModel):
 _General = General
 
 
-class ServiceXSpec(BaseModel):
+class ServiceXSpec(DocStringBaseModel):
     """
     ServiceX Submission Specification - pass this into the ServiceX `deliver` function
     """
+    model_config = {'use_attribute_docstrings': True}
+
     General: _General = General()
     """
     General settings for the transform request

--- a/servicex/uproot_raw/uproot_raw.py
+++ b/servicex/uproot_raw/uproot_raw.py
@@ -29,21 +29,38 @@
 # pydantic 2 API
 
 import pydantic
+from ..models import DocStringBaseModel
 from typing import List, Union, Mapping, Optional, get_args
 from ..query_core import QueryStringGenerator
 
 
-class TreeSubQuery(pydantic.BaseModel):
+class TreeSubQuery(DocStringBaseModel):
+    """Express an uproot-raw query on an ntuple. Arguments have the same meaning as the
+    ones of the same name for uproot.arrays():
+    https://uproot.readthedocs.io/en/stable/uproot.behaviors.TBranch.HasBranches.html#uproot-behaviors-tbranch-hasbranches-arrays
+    """
+    model_config = {'use_attribute_docstrings': True}
+
     treename: Union[Mapping[str, str], List[str], str]
+    """Name of input ntuple in file"""
     expressions: Optional[Union[List[str], str]] = None
+    """Awkward Array expressions to evaluate for output"""
     cut: Optional[str] = None
+    """Awkward Array expressions to select passing rows"""
     filter_name: Optional[Union[List[str], str]] = None
+    """Expression to filter the list of considered input variables by name"""
     filter_typename: Optional[Union[List[str], str]] = None
+    """Expression to filter the list of considered input variables by type name"""
     aliases: Optional[Mapping[str, str]] = None
+    """Define aliases to use in computation and expressions"""
 
 
-class CopyHistogramSubQuery(pydantic.BaseModel):
+class CopyHistogramSubQuery(DocStringBaseModel):
+    """Request the copying of a ROOT object from the input file to the output."""
+    model_config = {'use_attribute_docstrings': True}
+
     copy_histograms: Union[List[str], str]
+    """Objects to copy"""
 
 
 SubQuery = Union[TreeSubQuery, CopyHistogramSubQuery]


### PR DESCRIPTION
Pydantic model classes had completely unhelpful docstrings. This is a design decision by the Pydantic folks, but they provide a workaround (the ability to change the `__doc__` attribute via a post-initialization hook - see https://github.com/pydantic/pydantic/issues/638#issuecomment-1557258506). This is implemented. Resolves #303