### PR TITLE
Improve handling of error codes from server

### DIFF
--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -197,7 +197,8 @@ class Query:
             expandable_progress.refresh()
             if task.exception():
                 logger.error(
-                    "ServiceX Exception", exc_info=task.exception()
+                    f"ServiceX Exception for request ID {self.request_id} ({self.title})\"",
+                    exc_info=task.exception()
                 )
                 self.cache.delete_record_by_request_id(self.request_id)
                 if download_files_task:


### PR DESCRIPTION
Resolve #502. Do not assume that error responses from the backend are JSON except for specific HTTP codes.