### PR TITLE
Require tree name to be set for `FuncADLQuery_Uproot` queries

### DIFF
--- a/servicex/func_adl/func_adl_dataset.py
+++ b/servicex/func_adl/func_adl_dataset.py
@@ -209,8 +209,27 @@ class FuncADLQuery_Uproot(FuncADLQuery):
     yaml_tag = '!FuncADL_Uproot'
     default_codegen = 'uproot'
 
+    def __init__(
+        self,
+        item_type: Type = Any,
+    ):
+        super().__init__(item_type)
+        self.tree_is_set = False
+
     def FromTree(self, tree_name):
+        self.tree_is_set = True
         return self.set_tree(tree_name=tree_name)
+
+    def generate_selection_string(self):
+        if not self.tree_is_set:
+            raise ValueError('Uproot FuncADL query requires that you set a tree name with FromTree()')
+        return super().generate_selection_string()
+    
+    def set_provided_qastle(self, qastle_query: str):
+        # we do not validate provided qastle, so we don't know if a tree name is specified.
+        # assume user knows what they're doing
+        self.tree_is_set = True
+        super().set_provided_qastle(qastle_query)
 
     @classmethod
     def from_yaml(cls, _, node):

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -393,6 +393,7 @@ Sample:
     RucioDID: user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v11
     Query: !FuncADL_Uproot |
                 Select(lambda e: {'lep_pt': e['lep_pt']})
+                .FromTree("nominal")
   - Name: ttH3
     RucioDID: user.kchoi:user.kchoi.fcnc_tHq_ML.ttH.v11
     Query: !UprootRaw |

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -223,7 +223,7 @@ async def test_submit(mocker):
         query_cache=mock_cache,
         config=Configuration(api_endpoints=[]),
     )
-    datasource.query_string_generator = FuncADLQuery_Uproot()
+    datasource.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
     with ExpandableProgress(display_progress=False) as progress:
         datasource.result_format = ResultFormat.parquet
         result = await datasource.submit_and_download(signed_urls_only=False,
@@ -264,7 +264,7 @@ async def test_submit_partial_success(mocker):
         query_cache=mock_cache,
         config=Configuration(api_endpoints=[]),
     )
-    datasource.query_string_generator = FuncADLQuery_Uproot()
+    datasource.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
     with ExpandableProgress(display_progress=False) as progress:
         datasource.result_format = ResultFormat.parquet
         result = await datasource.submit_and_download(signed_urls_only=False,
@@ -304,7 +304,7 @@ async def test_use_of_cache(mocker):
             query_cache=cache,
             config=config,
         )
-        datasource.query_string_generator = FuncADLQuery_Uproot()
+        datasource.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
         datasource.result_format = ResultFormat.parquet
         upd = mocker.patch.object(cache, 'update_record', side_effect=cache.update_record)
         with ExpandableProgress(display_progress=False) as progress:
@@ -326,7 +326,7 @@ async def test_use_of_cache(mocker):
                 query_cache=cache,
                 config=config,
             )
-            datasource2.query_string_generator = FuncADLQuery_Uproot()
+            datasource2.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
             datasource2.result_format = ResultFormat.parquet
             result2 = await datasource2.submit_and_download(signed_urls_only=True,
                                                             expandable_progress=progress)
@@ -388,7 +388,7 @@ async def test_submit_cancel(mocker):
         query_cache=mock_cache,
         config=Configuration(api_endpoints=[]),
     )
-    datasource.query_string_generator = FuncADLQuery_Uproot()
+    datasource.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
     with ExpandableProgress(display_progress=False) as progress:
         datasource.result_format = ResultFormat.parquet
         with pytest.raises(ServiceXException):
@@ -426,7 +426,7 @@ async def test_submit_fatal(mocker):
         query_cache=mock_cache,
         config=Configuration(api_endpoints=[]),
     )
-    datasource.query_string_generator = FuncADLQuery_Uproot()
+    datasource.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
     with ExpandableProgress(display_progress=False) as progress:
         datasource.result_format = ResultFormat.parquet
         with pytest.raises(ServiceXException):
@@ -580,7 +580,7 @@ async def test_use_of_ignore_cache(mocker, servicex):
             query_cache=cache,
             config=config,
         )
-        datasource_without_ignore_cache.query_string_generator = FuncADLQuery_Uproot()
+        datasource_without_ignore_cache.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
         datasource_without_ignore_cache.result_format = ResultFormat.parquet
 
         # Datasouce with ignore cache
@@ -593,7 +593,7 @@ async def test_use_of_ignore_cache(mocker, servicex):
             config=config,
             ignore_cache=True
         )
-        datasource_with_ignore_cache.query_string_generator = FuncADLQuery_Uproot()
+        datasource_with_ignore_cache.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
         datasource_with_ignore_cache.result_format = ResultFormat.parquet
 
         # 1st time sending the request


### PR DESCRIPTION
Resolves #452. Throw an exception if `FuncADLQuery_Uproot` is used without specifying a tree name.