### PR TITLE
Require namespace in Rucio DIDs

### DIFF
--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -74,6 +74,11 @@ class RucioDatasetIdentifier(DataSetIdentifier):
             returns the same subset of files.
 
         """
+        if ':' not in dataset:
+            # Missing a colon means that no namespace is specified and the request
+            # will fail on the backend
+            raise ValueError(f'Specified dataset {dataset} is missing a Rucio namespace. '
+                             'Please specify the dataset ID in the form "namespace:dataset".')
         super().__init__("rucio", dataset, num_files=num_files)
 
     yaml_tag = '!Rucio'

--- a/tests/test_dataset_identifier.py
+++ b/tests/test_dataset_identifier.py
@@ -27,16 +27,22 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from servicex.dataset_identifier import DataSetIdentifier, RucioDatasetIdentifier, \
     FileListDataset
+import pytest
 
 
 def test_did():
-    did = DataSetIdentifier(scheme="rucio", dataset="123-455")
-    assert did.did == "rucio://123-455"
+    did = DataSetIdentifier(scheme="rucio", dataset="abc:123-455")
+    assert did.did == "rucio://abc:123-455"
 
 
 def test_rucio():
-    did = RucioDatasetIdentifier("123-456")
-    assert did.did == "rucio://123-456"
+    did = RucioDatasetIdentifier("abc:123-456")
+    assert did.did == "rucio://abc:123-456"
+
+
+def test_rucio_no_namespace():
+    with pytest.raises(ValueError):
+        RucioDatasetIdentifier("123-456")
 
 
 def test_file_list():
@@ -54,6 +60,6 @@ def test_populate_transform_request(transform_request):
     did.populate_transform_request(transform_request)
     assert transform_request.file_list == ["c:/foo.bar"]
 
-    did2 = RucioDatasetIdentifier("123-456")
+    did2 = RucioDatasetIdentifier("abc:123-456")
     did2.populate_transform_request(transform_request)
-    assert transform_request.did == "rucio://123-456"
+    assert transform_request.did == "rucio://abc:123-456"


### PR DESCRIPTION
Resolves #31. `RucioDatasetIdentifier` will throw an exception if a namespace isn't specified.