### PR TITLE
New argument `fail_if_incomplete` to raise an exception if any files fail

### DIFF
--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -79,6 +79,7 @@ class Query:
         result_format: ResultFormat = ResultFormat.parquet,
         ignore_cache: bool = False,
         query_string_generator: Optional[QueryStringGenerator] = None,
+        fail_if_incomplete: bool = True,
     ):
         r"""
         This is the main class for constructing transform requests and receiving the
@@ -96,6 +97,7 @@ class Query:
                                         for new files?
         :param result_format:
         :param ignore_cache:  If true, ignore the cache and always submit a new transform
+        :param fail_if_incomplete: If true, raise an exception if we don't have 100% completion
         """
         self.servicex = sx_adapter
         self.configuration = config
@@ -116,6 +118,7 @@ class Query:
 
         self.request_id = None
         self.ignore_cache = ignore_cache
+        self.fail_if_incomplete = fail_if_incomplete
         self.query_string_generator = query_string_generator
 
         # Number of seconds in between ServiceX status polls
@@ -209,11 +212,16 @@ class Query:
                     self.cache.delete_record_by_request_id(self.request_id)
                     titlestr = (f'"{self.current_status.title}" '
                                 if self.current_status.title is not None else '')
-                    logger.error(
+                    errorstr = (
                         f"Transform {titlestr}completed with failures: "
                         f"{self.current_status.files_failed}/"
                         f"{self.current_status.files} files failed. Will not cache."
                     )
+                    failedfiles = (self.servicex.url + '/transformation-request/'
+                                   + f'/{self.request_id}/results?status=failure')
+                    errorstr2 = ("A list of failed files is at [bold red on white]"
+                                 f"[link={failedfiles}]this link[/link][/bold red on white]")
+                    logger.error(errorstr2)
                     logger.error(
                         f"Transform Request id: {self.current_status.request_id}"
                     )
@@ -224,6 +232,8 @@ class Query:
                                                           LogLevel.error,
                                                           TimeFrame.month)
                         logger.error(f"More information of '{self.title}' [bold red on white][link={kibana_link}]HERE[/link][/bold red on white]")  # NOQA: E501
+                    if self.fail_if_incomplete:
+                        raise ServiceXException(errorstr)
                 else:
                     logger.info("Transforms completed successfully")
             else:  # pragma: no cover
@@ -233,7 +243,8 @@ class Query:
         sx_request_hash = sx_request.compute_hash()
 
         # Invalidate the cache if the hash already present but if the user ignores cache
-        if self.ignore_cache and self.cache.contains_hash(sx_request_hash):
+        if self.ignore_cache and (self.cache.contains_hash(sx_request_hash)
+                                  or self.cache.is_transform_request_submitted(sx_request_hash)):
             self.cache.delete_record_by_hash(sx_request_hash)
 
         # Let's see if this is in the cache already, but respect the user's wishes

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -137,7 +137,7 @@ def _load_ServiceXSpec(
     return config
 
 
-def _build_datasets(config, config_path, servicex_name):
+def _build_datasets(config, config_path, servicex_name, fail_if_incomplete):
     def get_codegen(_sample: Sample, _general: General):
         if _sample.Codegen is not None:
             return _sample.Codegen
@@ -158,6 +158,7 @@ def _build_datasets(config, config_path, servicex_name):
             result_format=config.General.OutputFormat.to_ResultFormat(),
             ignore_cache=sample.IgnoreLocalCache,
             query=sample.Query,
+            fail_if_incomplete=fail_if_incomplete
         )
         logger.debug(f"Query string: {query.generate_selection_string()}")
         query.ignore_cache = sample.IgnoreLocalCache
@@ -197,11 +198,12 @@ def deliver(
     config: Union[ServiceXSpec, Mapping[str, Any], str, Path],
     config_path: Optional[str] = None,
     servicex_name: Optional[str] = None,
-    return_exceptions: bool = True
+    return_exceptions: bool = True,
+    fail_if_incomplete: bool = True
 ):
     config = _load_ServiceXSpec(config)
 
-    datasets = _build_datasets(config, config_path, servicex_name)
+    datasets = _build_datasets(config, config_path, servicex_name, fail_if_incomplete)
 
     group = DatasetGroup(datasets)
 
@@ -302,6 +304,7 @@ class ServiceXClient:
         title: str = "ServiceX Client",
         result_format: ResultFormat = ResultFormat.parquet,
         ignore_cache: bool = False,
+        fail_if_incomplete: bool = True,
     ) -> Query:
         r"""
         Generate a Query object for a generic codegen specification
@@ -345,6 +348,7 @@ class ServiceXClient:
             query_cache=self.query_cache,
             result_format=result_format,
             ignore_cache=ignore_cache,
-            query_string_generator=query
+            query_string_generator=query,
+            fail_if_incomplete=fail_if_incomplete
         )
         return qobj


### PR DESCRIPTION
Change `deliver()` to fail for a sample (by default) if any files fail. Can be disabled by passing `fail_if_incomplete=False`.