### PR TITLE
Add cli command to list datasets

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -76,3 +76,14 @@ clear
 Clear all of the transforms from the cache. Add ``-y`` to force the
 operation without confirming with the console.
 
+datasets
+~~~~~~~~
+
+These commands interact with datasets cached on the server
+
+list
+^^^^
+List all of the datasets cached on the server. Accepts a command line argument
+of ``--did-finder`` to filter the list of datasets by a specific DID finder such
+as ``rucio`` or ``user``.
+

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -170,3 +170,18 @@ class TransformedResults(BaseModel):
     files: int
     result_format: ResultFormat
     log_url: Optional[str] = None
+
+
+class CachedDataset(BaseModel):
+    """
+    Model for a cached dataset held by ServiceX server
+    """
+    id: int
+    name: str
+    did_finder: str
+    n_files: int
+    size: int
+    events: int
+    last_used: datetime
+    last_updated: datetime
+    lookup_status: str

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -109,12 +109,14 @@ class ServiceXAdapter:
                     f"Not authorized to access serviceX at {self.url}")
             return r.json()
 
-    async def get_datasets(self) -> List[CachedDataset]:
+    async def get_datasets(self, did_finder=None) -> List[CachedDataset]:
         headers = await self._get_authorization()
 
         with httpx.Client() as client:
+            params = {"did-finder": did_finder} if did_finder else {}
             r = client.get(headers=headers,
-                           url=f"{self.url}/servicex/datasets")
+                           url=f"{self.url}/servicex/datasets",
+                           params=params)
 
             if r.status_code == 403:
                 raise AuthorizationError(

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -34,7 +34,7 @@ from aiohttp_retry import RetryClient, ExponentialRetry
 from google.auth import jwt
 from tenacity import AsyncRetrying, stop_after_attempt, wait_fixed, retry_if_not_exception_type
 
-from servicex.models import TransformRequest, TransformStatus
+from servicex.models import TransformRequest, TransformStatus, CachedDataset
 
 
 class AuthorizationError(BaseException):
@@ -108,6 +108,20 @@ class ServiceXAdapter:
                 raise AuthorizationError(
                     f"Not authorized to access serviceX at {self.url}")
             return r.json()
+
+    async def get_datasets(self) -> List[CachedDataset]:
+        headers = await self._get_authorization()
+
+        with httpx.Client() as client:
+            r = client.get(headers=headers,
+                           url=f"{self.url}/servicex/datasets")
+
+            if r.status_code == 403:
+                raise AuthorizationError(
+                    f"Not authorized to access serviceX at {self.url}")
+
+            datasets = [CachedDataset(**d) for d in r.json()['datasets']]
+            return datasets
 
     async def submit_transform(self, transform_request: TransformRequest):
         headers = await self._get_authorization()

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -280,6 +280,13 @@ class ServiceXClient:
 
     get_transform_status = make_sync(get_transform_status_async)
 
+    def get_datasets(self):
+        r"""
+        Retrieve all datasets you have run on the server
+        :return: List of Query objects
+        """
+        return self.servicex.get_datasets()
+
     def get_code_generators(self, backend=None):
         r"""
         Retrieve the code generators deployed with the serviceX instance

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -280,12 +280,12 @@ class ServiceXClient:
 
     get_transform_status = make_sync(get_transform_status_async)
 
-    def get_datasets(self):
+    def get_datasets(self, did_finder=None):
         r"""
         Retrieve all datasets you have run on the server
         :return: List of Query objects
         """
-        return self.servicex.get_datasets()
+        return self.servicex.get_datasets(did_finder)
 
     def get_code_generators(self, backend=None):
         r"""

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -154,6 +154,15 @@ async def test_get_datasets(get, servicex):
 
 
 @pytest.mark.asyncio
+@patch('servicex.servicex_adapter.httpx.Client.get')
+async def test_get_datasets_auth_error(get, servicex):
+    get.return_value = httpx.Response(403)
+    with pytest.raises(AuthorizationError) as err:
+        await servicex.get_datasets()
+        assert "Not authorized to access serviceX at" in str(err.value)
+
+
+@pytest.mark.asyncio
 @patch('servicex.servicex_adapter.RetryClient.post')
 async def test_submit(post, servicex):
     post.return_value.__aenter__.return_value.json.return_value = {"request_id": "123-456-789"}

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -130,6 +130,30 @@ def test_get_codegens_error(get, servicex):
 
 
 @pytest.mark.asyncio
+@patch('servicex.servicex_adapter.httpx.Client.get')
+async def test_get_datasets(get, servicex):
+    get.return_value = httpx.Response(200, json={
+        "datasets": [
+            {
+                "id": "123",
+                "name": "dataset1",
+                "events": 100,
+                "size": 1000,
+                "n_files": 1,
+                "last_used": "2022-01-01T00:00:00.000000Z",
+                "last_updated": "2022-01-01T00:00:00.000000Z",
+                "lookup_status": "looking",
+                "did_finder": "rucio"
+            }
+
+        ]
+    })
+    c = await servicex.get_datasets()
+    assert len(c) == 1
+    assert c[0].id == 123
+
+
+@pytest.mark.asyncio
 @patch('servicex.servicex_adapter.RetryClient.post')
 async def test_submit(post, servicex):
     post.return_value.__aenter__.return_value.json.return_value = {"request_id": "123-456-789"}

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2024, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from unittest.mock import MagicMock
+
+from pytest_asyncio import fixture
+
+from servicex.query_cache import QueryCache
+from servicex.servicex_adapter import ServiceXAdapter
+from servicex.servicex_client import ServiceXClient
+
+
+@fixture
+def servicex_adaptor(mocker):
+    adapter_mock = mocker.patch('servicex.servicex_client.ServiceXAdapter')
+    mock_adapter = MagicMock(spec=ServiceXAdapter)
+
+    adapter_mock.return_value = mock_adapter
+    return mock_adapter
+
+
+@fixture
+def mock_cache(mocker):
+    cache_mock = mocker.patch('servicex.servicex_client.QueryCache')
+    mock_cache = MagicMock(spec=QueryCache)
+    mock_cache.get_codegen_by_backend.return_value = {
+        "codegens": {
+            "ROOT": "my_root_generator",
+            "UPROOT": "my_uproot_generator"
+        }
+    }
+    cache_mock.return_value = mock_cache
+    return cache_mock
+
+
+def test_get_datasets(mock_cache, servicex_adaptor):
+    sx = ServiceXClient(config_path="tests/example_config.yaml")
+    sx.get_datasets()
+    servicex_adaptor.get_datasets.assert_called_once()


### PR DESCRIPTION
This PR depends on the [Service PR 907](https://github.com/ssl-hep/ServiceX/pull/907)

Add a new command to the CLI

```bash
servicex datasets list -b testing1
```

Also accepts an optional argument `--did-finder` to filter on a specific DID Finder such as `rucio` or `user`.

## Example
```bash
% servicex datasets list -b testing2 --did-finder rucio                       
                                                                               ServiceX Datasets                                                                               
┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━┳━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━┓
┃ ID ┃ Name                                                                                                                ┃ Files ┃ Size    ┃ Status   ┃ Created             ┃
┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━╇━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━┩
│ 1  │ rucio://user.mtost:user.mtost.singletop.p6026.Jun13                                                                 │ 27    │ 4,833MB │ complete │ 2024-09-09T22:27:30 │
│ 15 │ rucio://user.mtost:user.mtost.700349.Sh.DAOD_PHYS.e8351_s3681_r13144_r13146_p6026.Jul13_less_jet_and_new_GN?files=7 │ 7     │ 1,360MB │ complete │ 2024-11-05T21:11:23 │
└────┴─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┴───────┴─────────┴──────────┴─────────────────────┘
``` 