### PR TITLE
Delete Dataset From CLI

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -87,3 +87,12 @@ List all of the datasets cached on the server. Accepts a command line argument
 of ``--did-finder`` to filter the list of datasets by a specific DID finder such
 as ``rucio`` or ``user``.
 
+get
+^^^
+Get details about a specific dataset. Provide the dataset ID as a parameter. This
+Will list the physical file paths found for each file in the dataset.
+
+delete
+^^^^^^
+Delete a specific dataset from the cache. Provide the dataset ID as a parameter. This
+will force the service to re-query the dataset for the next request.

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -85,7 +85,9 @@ list
 ^^^^
 List all of the datasets cached on the server. Accepts a command line argument
 of ``--did-finder`` to filter the list of datasets by a specific DID finder such
-as ``rucio`` or ``user``.
+as ``rucio`` or ``user``. By default this will filter out deleted datasets. They
+are still in the cache, but marked as stale. To see deleted datasets, use the
+``--show-deleted`` flag.
 
 get
 ^^^

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -77,3 +77,27 @@ def list(
             d.last_used.strftime('%Y-%m-%dT%H:%M:%S'),
         )
     rich.print(table)
+
+
+@datasets_app.command(no_args_is_help=True)
+def get(
+        url: Optional[str] = url_cli_option,
+        backend: Optional[str] = backend_cli_option,
+        dataset_id: int = typer.Argument(..., help="The ID of the dataset to get")
+):
+    sx = ServiceXClient(url=url, backend=backend)
+    table = Table(title=f"Dataset ID {dataset_id}")
+    table.add_column("Paths")
+    dataset = asyncio.run(sx.get_dataset(dataset_id))
+    for file in dataset.files:
+        sub_table = Table(title="")
+        sub_table.add_column(f"File ID: {file.id}")
+        for path in file.paths.split(','):
+            sub_table.add_row(path)
+
+        table.add_row(
+            sub_table
+        )
+    # Set alternating row styles
+    table.row_styles = ["", ""]
+    rich.print(table)

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -49,6 +49,11 @@ def list(
             help="Filter datasets by DID finder. Some useful values are 'rucio' or 'user'",
             show_default=False,
         ),
+        show_deleted: Optional[bool] = typer.Option(
+            False,
+            help="Show deleted datasets",
+            show_default=True,
+        ),
 ):
     """
     List the datasets.
@@ -61,7 +66,10 @@ def list(
     table.add_column("Size")
     table.add_column("Status")
     table.add_column("Created")
-    datasets = asyncio.run(sx.get_datasets(did_finder=did_finder))
+    if show_deleted:
+        table.add_column("Deleted")
+
+    datasets = asyncio.run(sx.get_datasets(did_finder=did_finder, show_deleted=show_deleted))
     for d in datasets:
         # Format the CachedDataset object into a table row
         # The last_updated field is what we should be displaying, but that is
@@ -75,6 +83,7 @@ def list(
             "{:,}MB".format(round(d.size / 1e6)),
             d.lookup_status,
             d.last_used.strftime('%Y-%m-%dT%H:%M:%S'),
+            "Yes" if d.is_stale else ""
         )
     rich.print(table)
 

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -101,3 +101,17 @@ def get(
     # Set alternating row styles
     table.row_styles = ["", ""]
     rich.print(table)
+
+
+@datasets_app.command(no_args_is_help=True)
+def delete(
+        url: Optional[str] = url_cli_option,
+        backend: Optional[str] = backend_cli_option,
+        dataset_id: int = typer.Argument(..., help="The ID of the dataset to delete")
+):
+    sx = ServiceXClient(url=url, backend=backend)
+    result = asyncio.run(sx.delete_dataset(dataset_id))
+    if result:
+        typer.echo(f"Dataset {dataset_id} deleted")
+    else:
+        typer.echo(f"Dataset {dataset_id} not found")

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -209,6 +209,17 @@ class TransformedResults(DocStringBaseModel):
     """URL for looking up logs on the ServiceX server"""
 
 
+class DatasetFile(BaseModel):
+    """
+    Model for a file in a cached dataset
+    """
+    id: int
+    adler32: Optional[str]
+    file_size: int
+    file_events: int
+    paths: str
+
+
 class CachedDataset(BaseModel):
     """
     Model for a cached dataset held by ServiceX server
@@ -222,3 +233,4 @@ class CachedDataset(BaseModel):
     last_used: datetime
     last_updated: datetime
     lookup_status: str
+    files: Optional[List[DatasetFile]] = []

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -233,4 +233,5 @@ class CachedDataset(BaseModel):
     last_used: datetime
     last_updated: datetime
     lookup_status: str
+    is_stale: bool
     files: Optional[List[DatasetFile]] = []

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -123,11 +123,14 @@ class ServiceXAdapter:
                     f"Not authorized to access serviceX at {self.url}")
             return r.json()
 
-    async def get_datasets(self, did_finder=None) -> List[CachedDataset]:
+    async def get_datasets(self, did_finder=None, show_deleted=False) -> List[CachedDataset]:
         headers = await self._get_authorization()
 
         with httpx.Client() as client:
             params = {"did-finder": did_finder} if did_finder else {}
+            if show_deleted:
+                params['show-deleted'] = True
+
             r = client.get(headers=headers,
                            url=f"{self.url}/servicex/datasets",
                            params=params)

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -139,6 +139,22 @@ class ServiceXAdapter:
             datasets = [CachedDataset(**d) for d in r.json()['datasets']]
             return datasets
 
+    async def get_dataset(self, dataset_id=None) -> CachedDataset:
+        headers = await self._get_authorization()
+
+        with httpx.Client() as client:
+            path_template = '/servicex/datasets/{dataset_id}'
+            url = self.url + path_template.format(dataset_id=dataset_id)
+            r = client.get(headers=headers,
+                           url=url)
+
+            if r.status_code == 403:
+                raise AuthorizationError(
+                    f"Not authorized to access serviceX at {self.url}")
+
+            dataset = CachedDataset(**r.json())
+            return dataset
+
     async def submit_transform(self, transform_request: TransformRequest) -> str:
         headers = await self._get_authorization()
         retry_options = ExponentialRetry(attempts=3, start_timeout=30)

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -155,6 +155,21 @@ class ServiceXAdapter:
             dataset = CachedDataset(**r.json())
             return dataset
 
+    async def delete_dataset(self, dataset_id=None) -> bool:
+        headers = await self._get_authorization()
+
+        with httpx.Client() as client:
+            path_template = '/servicex/datasets/{dataset_id}'
+            url = self.url + path_template.format(dataset_id=dataset_id)
+            r = client.delete(headers=headers,
+                              url=url)
+
+            if r.status_code == 403:
+                raise AuthorizationError(
+                    f"Not authorized to access serviceX at {self.url}")
+
+            return r.status_code == 200
+
     async def submit_transform(self, transform_request: TransformRequest) -> str:
         headers = await self._get_authorization()
         retry_options = ExponentialRetry(attempts=3, start_timeout=30)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -280,12 +280,12 @@ class ServiceXClient:
 
     get_transform_status = make_sync(get_transform_status_async)
 
-    def get_datasets(self, did_finder=None):
+    def get_datasets(self, did_finder=None, show_deleted=False):
         r"""
         Retrieve all datasets you have run on the server
         :return: List of Query objects
         """
-        return self.servicex.get_datasets(did_finder)
+        return self.servicex.get_datasets(did_finder, show_deleted)
 
     def get_dataset(self, dataset_id):
         r"""

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -294,6 +294,13 @@ class ServiceXClient:
         """
         return self.servicex.get_dataset(dataset_id)
 
+    def delete_dataset(self, dataset_id):
+        r"""
+        Delete a dataset by its ID
+        :return: A Query object
+        """
+        return self.servicex.delete_dataset(dataset_id)
+
     def get_code_generators(self, backend=None):
         r"""
         Retrieve the code generators deployed with the serviceX instance

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -287,6 +287,13 @@ class ServiceXClient:
         """
         return self.servicex.get_datasets(did_finder)
 
+    def get_dataset(self, dataset_id):
+        r"""
+        Retrieve a dataset by its ID
+        :return: A Query object
+        """
+        return self.servicex.get_dataset(dataset_id)
+
     def get_code_generators(self, backend=None):
         r"""
         Retrieve the code generators deployed with the serviceX instance

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -202,6 +202,29 @@ async def test_get_dataset(get, servicex):
 
 
 @pytest.mark.asyncio
+@patch('servicex.servicex_adapter.httpx.Client.delete')
+async def test_delete_dataset(delete, servicex):
+    delete.return_value = httpx.Response(200, json={
+        'dataset-id': 123,
+        'stale': True
+    })
+    await servicex.delete_dataset(123)
+    delete.assert_called_with(
+        url='https://servicex.org/servicex/datasets/123',
+        headers={}
+    )
+
+
+@pytest.mark.asyncio
+@patch('servicex.servicex_adapter.httpx.Client.delete')
+async def test_delete_dataset_auth_error(delete, servicex):
+    delete.return_value = httpx.Response(403)
+    with pytest.raises(AuthorizationError) as err:
+        await servicex.delete_dataset(123)
+        assert "Not authorized to access serviceX at" in str(err.value)
+
+
+@pytest.mark.asyncio
 @patch('servicex.servicex_adapter.RetryClient.post')
 async def test_submit(post, servicex):
     post.return_value.__aenter__.return_value.json.return_value = {"request_id": "123-456-789"}

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -175,6 +175,33 @@ async def test_get_datasets_auth_error(get, servicex):
 
 
 @pytest.mark.asyncio
+@patch('servicex.servicex_adapter.httpx.Client.get')
+async def test_get_dataset(get, servicex):
+    get.return_value = httpx.Response(200, json={
+        "id": 123,
+        "name": "rucio://user.mtost:user.mtost.700349.Sh.DAOD_PHYS.e8351_s3681_r13144_r13146_p6026.Jul13_less_jet_and_new_GN?files=7",  # NOQA: E501
+        "did_finder": "rucio",
+        "n_files": 7,
+        "size": 1359895862,
+        "events": 0,
+        "last_used": "2024-11-12T01:59:19.161655Z",
+        "last_updated": "1969-12-31T18:00:00.000000Z",
+        "lookup_status": "complete",
+        "files": [
+            {
+                "id": 12,
+                "adler32": "62c594d4",
+                "file_size": 34831129,
+                "file_events": 0,
+                "paths": "https://xenia.nevis.columbia.edu:1094/atlas/dq2/rucio/user/mtost/06/a1/user.mtost.40294033._000002.less_jet_and_new_GN.root"  # NOQA: E501
+            }]
+    })
+    c = await servicex.get_dataset(123)
+    assert c
+    assert c.id == 123
+
+
+@pytest.mark.asyncio
 @patch('servicex.servicex_adapter.RetryClient.post')
 async def test_submit(post, servicex):
     post.return_value.__aenter__.return_value.json.return_value = {"request_id": "123-456-789"}

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -61,3 +61,9 @@ def test_get_datasets(mock_cache, servicex_adaptor):
     sx = ServiceXClient(config_path="tests/example_config.yaml")
     sx.get_datasets()
     servicex_adaptor.get_datasets.assert_called_once()
+
+
+def test_get_dataset(mock_cache, servicex_adaptor):
+    sx = ServiceXClient(config_path="tests/example_config.yaml")
+    sx.get_dataset("123")
+    servicex_adaptor.get_dataset.assert_called_once_with("123")

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -67,3 +67,9 @@ def test_get_dataset(mock_cache, servicex_adaptor):
     sx = ServiceXClient(config_path="tests/example_config.yaml")
     sx.get_dataset("123")
     servicex_adaptor.get_dataset.assert_called_once_with("123")
+
+
+def test_delete_dataset(mock_cache, servicex_adaptor):
+    sx = ServiceXClient(config_path="tests/example_config.yaml")
+    sx.delete_dataset("123")
+    servicex_adaptor.delete_dataset.assert_called_once_with("123")


### PR DESCRIPTION
# Problem
User's can't delete a dataset from the cache. They also can't see the details of a DID to debug

# Approach
Add some new commands to the CLI

```bash
servicex datasets get -b testing2 15
```
This gets back the details of Dataset ID 15... 
```
                                             
                                                                        Dataset ID 15                                                                        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Paths                                                                                                                                                     ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓         │
│ ┃ File ID: 968                                                                                                                                  ┃         │
│ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩         │
│ │ https://xenia.nevis.columbia.edu:1094/atlas/dq2/rucio/user/mtost/06/a1/user.mtost.40294033._000002.less_jet_and_new_GN.root                   │         │
│ │ root://xrootd.data.net2.mghpcc.org:1094//USATLAS/atlasscratchdisk/rucio/user/mtost/06/a1/user.mtost.40294033._000002.less_jet_and_new_GN.root │         │
│ └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘         │
│ ┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓         │
│ ┃ File ID: 969                                                                                                                                  ┃         │
│ ┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩         │
│ │ https://xenia.nevis.columbia.edu:1094/atlas/dq2/rucio/user/mtost/23/8b/user.mtost.40294033._000001.less_jet_and_new_GN.root                   │         │
│ │ root://xrootd.data.net2.mghpcc.org:1094//USATLAS/atlasscratchdisk/rucio/user/mtost/23/8b/user.mtost.40294033._000001.less_jet_and_new_GN.root │         │
│ └───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘         │
```

You can delete a dataset with the new command
```
servicex datasets delete -b testing2 1  
```

Do this and the server will refreash the dataset when you submit a new request.

Finally, there is a command line option to see deleted datasets (by default they are omited from the dataset report)

```
 servicex datasets list -b localhost --show-deleted 
```

The ServiceX deployed on testing2 has been updated to have the endpoints needed for testing this