### PR TITLE
Do a preflight authentication call

### DIFF
--- a/servicex/dataset_group.py
+++ b/servicex/dataset_group.py
@@ -66,6 +66,9 @@ class DatasetGroup:
         provided_progress: Optional[Progress] = None,
         return_exceptions: bool = False,
     ) -> List[Union[TransformedResults, BaseException]]:
+        # preflight auth
+        if self.datasets:
+            await self.datasets[0].servicex._get_authorization()
         with ExpandableProgress(display_progress, provided_progress) as progress:
             self.tasks = [
                 d.as_signed_urls_async(provided_progress=progress)
@@ -80,6 +83,9 @@ class DatasetGroup:
                              provided_progress: Optional[Progress] = None,
                              return_exceptions: bool = False,
                              ) -> List[Union[TransformedResults, BaseException]]:
+        # preflight auth
+        if self.datasets:
+            await self.datasets[0].servicex._get_authorization()
         with ExpandableProgress(display_progress, provided_progress) as progress:
             self.tasks = [
                 d.as_files_async(provided_progress=progress)

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -68,7 +68,7 @@ class ServiceXAdapter:
                     self.token = o['access_token']
                 else:
                     raise AuthorizationError(
-                        f"ServiceX access token request rejected: {r.status}"
+                        f"ServiceX access token request rejected [{r.status} {r.reason}]"
                     )
 
     @staticmethod

--- a/tests/test_dataset_group.py
+++ b/tests/test_dataset_group.py
@@ -47,6 +47,7 @@ def test_set_result_format(mocker):
 async def test_as_signed_urls(mocker, transformed_result):
     ds1 = mocker.Mock()
     ds1.as_signed_urls_async = AsyncMock(return_value=transformed_result)
+    ds1.servicex._get_authorization = AsyncMock()
 
     ds2 = mocker.Mock()
     ds2.as_signed_urls_async = AsyncMock(return_value=transformed_result.model_copy(
@@ -64,6 +65,7 @@ async def test_as_signed_urls(mocker, transformed_result):
 async def test_as_files(mocker, transformed_result):
     ds1 = mocker.Mock()
     ds1.as_files_async = AsyncMock(return_value=transformed_result)
+    ds1.servicex._get_authorization = AsyncMock()
 
     ds2 = mocker.Mock()
     ds2.as_files_async = AsyncMock(return_value=transformed_result.model_copy(
@@ -81,6 +83,7 @@ async def test_as_files(mocker, transformed_result):
 async def test_failure(mocker, transformed_result):
     ds1 = mocker.Mock()
     ds1.as_signed_urls_async = AsyncMock(return_value=transformed_result)
+    ds1.servicex._get_authorization = AsyncMock()
 
     ds2 = mocker.Mock()
     ds2.as_signed_urls_async = AsyncMock(side_effect=ServiceXException("dummy"))


### PR DESCRIPTION
Resolves #506. Get authentication before actually doing submission, so we can raise an exception early and not hide it in the `GuardList` in the return value of `deliver`.