### PR TITLE
Remove view source code button from documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ autodoc_pydantic_model_member_order = 'bysource'
 
 html_theme = 'furo'
 html_static_path = ['_static']
+html_show_sourcelink = False
 
 # sphinx-copybutton configuration
 copybutton_prompt_text = r">>> |\.\.\. |\$ "


### PR DESCRIPTION
I don't see a reason why user needs to see source code of documentation readthedoc pages. It's a bit annoying place by default, so I would like to remove it 😄 

Current
<img width="940" alt="Screenshot 2024-11-15 at 3 22 06 PM" src="https://github.com/user-attachments/assets/e2fa8f50-a145-4d45-8c60-430fadb09bff">

New
<img width="784" alt="Screenshot 2024-11-15 at 3 24 53 PM" src="https://github.com/user-attachments/assets/33e5ce9c-1f03-4a2b-a2b6-de3bbc16a9b2">
