### PR TITLE
Introduce example of app testing with patches

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ test = [
     "pytest>=7.2.0",
     "pytest-mock>=3.10.0",
     "pytest-cov>=4.0.0",
+    "pytest-console-scripts>=1.4.1",
     "flake8>=5.0.4",
     "mypy>=0.981",
     "pytest-asyncio>=0.21.0",

--- a/servicex/app/cli_options.py
+++ b/servicex/app/cli_options.py
@@ -31,3 +31,5 @@ import typer
 url_cli_option = typer.Option(None, "-u", "--url", help="URL of ServiceX server")
 backend_cli_option = typer.Option(None, "-b", "--backend",
                                   help="Name of backend server from .servicex file")
+config_file_option = typer.Option(None, "-c", "--config",
+                                  help="ServiceX client configuration file")


### PR DESCRIPTION
Use pytest-console-scripts to allow us to test the `servicex` CLI with patches to backend code. This is not at all intended to be comprehensive, but to establish a framework. Starts to address #351 