### PR TITLE
Check for return value on dataset delete

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -171,7 +171,7 @@ class ServiceXAdapter:
             dataset = CachedDataset(**result)
             return dataset
 
-    async def delete_dataset(self, dataset_id=None):
+    async def delete_dataset(self, dataset_id=None) -> bool:
         headers = await self._get_authorization()
         path_template = '/servicex/datasets/{dataset_id}'
         url = self.url + path_template.format(dataset_id=dataset_id)
@@ -189,6 +189,8 @@ class ServiceXAdapter:
                 elif r.status != 200:
                     msg = await _extract_message(r)
                     raise RuntimeError(f"Failed to delete dataset {dataset_id} - {msg}")
+                result = await r.json()
+                return result['stale']
 
     async def submit_transform(self, transform_request: TransformRequest) -> str:
         headers = await self._get_authorization()

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -247,11 +247,12 @@ async def test_delete_dataset(delete, servicex):
     }
     delete.return_value.__aenter__.return_value.status = 200
 
-    await servicex.delete_dataset(123)
+    r = await servicex.delete_dataset(123)
     delete.assert_called_with(
         url='https://servicex.org/servicex/datasets/123',
         headers={}
     )
+    assert r
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Problem
The delete command in the dataset cli tests for a True return value from the ServiceXAdapter. Unfortunately, the `delete_dataset` method doesn't return anything.

# Approach
Add a check for the `stale` property in the value returned from the server and return that from the method