### PR TITLE
Eliminate unnecessary URL options from the command line.

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -13,13 +13,11 @@ Common command line arguments:
 | F   | Long     | What it does                                        |
 | lag | Flag     |                                                     |
 +=====+==========+=====================================================+
-| -u  | –url     | The url of the serviceX ingress                     |
-+-----+----------+-----------------------------------------------------+
 | -b  | –backend | Named backend from the .servicex file endpoints     |
 |     |          | list                                                |
 +-----+----------+-----------------------------------------------------+
 
-If neither url nor backend are specified then the client will attempt to
+If no backend is specified then the client will attempt to
 use the ``default_endpoint`` value to determine who to talk to.
 
 codegens

--- a/servicex/app/cli_options.py
+++ b/servicex/app/cli_options.py
@@ -28,7 +28,6 @@
 import typer
 
 
-url_cli_option = typer.Option(None, "-u", "--url", help="URL of ServiceX server")
 backend_cli_option = typer.Option(None, "-b", "--backend",
                                   help="Name of backend server from .servicex file")
 config_file_option = typer.Option(None, "-c", "--config",

--- a/servicex/app/codegen.py
+++ b/servicex/app/codegen.py
@@ -29,7 +29,7 @@
 import rich
 import typer
 
-from servicex.app.cli_options import url_cli_option, backend_cli_option, config_file_option
+from servicex.app.cli_options import backend_cli_option, config_file_option
 from servicex.servicex_client import ServiceXClient
 from typing import Optional
 
@@ -38,13 +38,12 @@ codegen_app = typer.Typer(name="codegen", no_args_is_help=True)
 
 @codegen_app.command(no_args_is_help=False)
 def flush(
-        url: Optional[str] = url_cli_option,
         backend: Optional[str] = backend_cli_option,
         config_path: Optional[str] = config_file_option):
     """
     Flush the available code generators from the cache
     """
-    sx = ServiceXClient(url=url, backend=backend, config_path=config_path)
+    sx = ServiceXClient(backend=backend, config_path=config_path)
     cache = sx.query_cache
     cache.delete_codegen_by_backend(backend)
     rich.print("Deleted cached code generators.")
@@ -52,11 +51,10 @@ def flush(
 
 @codegen_app.command(no_args_is_help=False)
 def list(
-        url: Optional[str] = url_cli_option,
         backend: Optional[str] = backend_cli_option,
         config_path: Optional[str] = config_file_option):
     """
     List the available code generators
     """
-    sx = ServiceXClient(url=url, backend=backend, config_path=config_path)
+    sx = ServiceXClient(backend=backend, config_path=config_path)
     rich.print_json(data=sx.get_code_generators())

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -30,7 +30,7 @@ from typing import Optional
 
 import rich
 
-from servicex.app.cli_options import url_cli_option, backend_cli_option
+from servicex.app.cli_options import backend_cli_option
 
 import typer
 
@@ -42,7 +42,6 @@ datasets_app = typer.Typer(name="datasets", no_args_is_help=True)
 
 @datasets_app.command(no_args_is_help=True)
 def list(
-        url: Optional[str] = url_cli_option,
         backend: Optional[str] = backend_cli_option,
         did_finder: Optional[str] = typer.Option(
             None,
@@ -58,7 +57,7 @@ def list(
     """
     List the datasets.
     """
-    sx = ServiceXClient(url=url, backend=backend)
+    sx = ServiceXClient(backend=backend)
     table = Table(title="ServiceX Datasets")
     table.add_column("ID")
     table.add_column("Name")
@@ -90,11 +89,10 @@ def list(
 
 @datasets_app.command(no_args_is_help=True)
 def get(
-        url: Optional[str] = url_cli_option,
         backend: Optional[str] = backend_cli_option,
         dataset_id: int = typer.Argument(..., help="The ID of the dataset to get")
 ):
-    sx = ServiceXClient(url=url, backend=backend)
+    sx = ServiceXClient(backend=backend)
     table = Table(title=f"Dataset ID {dataset_id}")
     table.add_column("Paths")
     dataset = asyncio.run(sx.get_dataset(dataset_id))
@@ -114,11 +112,10 @@ def get(
 
 @datasets_app.command(no_args_is_help=True)
 def delete(
-        url: Optional[str] = url_cli_option,
         backend: Optional[str] = backend_cli_option,
         dataset_id: int = typer.Argument(..., help="The ID of the dataset to delete")
 ):
-    sx = ServiceXClient(url=url, backend=backend)
+    sx = ServiceXClient(backend=backend)
     result = asyncio.run(sx.delete_dataset(dataset_id))
     if result:
         typer.echo(f"Dataset {dataset_id} deleted")


### PR DESCRIPTION
This pull request removes the `--url` option from various CLI commands and updates the documentation accordingly. The changes ensure that the client now relies solely on the `--backend` option to determine the ServiceX server.

The --url option was never used. It's easy enough to just add a new entry to .servicex and this option was cluttering up the code

Key changes include:

### Documentation Updates:
* [`docs/command_line.rst`](diffhunk://#diff-c8aa0277057c29741b54e77dc385a622dcee6a8db3d16516eb4e1fb402becd99L16-R20): Removed the `-u`/`--url` option from the list of common command line arguments and updated the description to reflect that only the `--backend` option is required.

### Code Changes:
* [`servicex/app/cli_options.py`](diffhunk://#diff-3cf1e67d032b1142f64d604d40779cd05c81015b8f2a43c8828a99139a48e649L31): Removed the `url_cli_option` definition.
* [`servicex/app/codegen.py`](diffhunk://#diff-fdfcfecd08b455cef999cd2b5c473e61e04d46f2d9cc17a4e97e11393837087eL32-R32): Removed the `url` parameter from the `flush` and `list` commands and their respective `ServiceXClient` instantiations. [[1]](diffhunk://#diff-fdfcfecd08b455cef999cd2b5c473e61e04d46f2d9cc17a4e97e11393837087eL32-R32) [[2]](diffhunk://#diff-fdfcfecd08b455cef999cd2b5c473e61e04d46f2d9cc17a4e97e11393837087eL41-R59)
* [`servicex/app/datasets.py`](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL33-R33): Removed the `url` parameter from the `list`, `get`, and `delete` commands and their respective `ServiceXClient` instantiations. [[1]](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL33-R33) [[2]](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL45) [[3]](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL61-R60) [[4]](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL93-R95) [[5]](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL117-R118)
* [`servicex/app/transforms.py`](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL40-R40): Removed the `url` parameter from the `list`, `files`, `download`, and `logs` commands and their respective `ServiceXClient` instantiations. [[1]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL40-R40) [[2]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL58) [[3]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL67-R66) [[4]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL85) [[5]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL97-R95) [[6]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL110) [[7]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL139-R136) [[8]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL203) [[9]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL216-R212)