### PR TITLE
Add pre-commit to developer extras [DROPS PYTHON 3.8 SUPPORT]

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ test = [
     "asyncmock>=0.4.2",
     "pandas>=2.0.2",
     "pyarrow>=12.0.0",
+    "pre-commit>=4.0.1",
 ]
 docs = [
     "sphinx>=7.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ version = "3.0.1-alpha.1"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [
     { name = "Ben Galewsky", email = "bengal1@illinois.edu" },
     { name = "Gordon Watts", email = "gwatts@uw.edu" },

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -202,11 +202,7 @@ class Query:
                 )
                 self.cache.delete_record_by_request_id(self.request_id)
                 if download_files_task:
-                    import sys
-                    if sys.version_info < (3, 9):
-                        download_files_task.cancel()
-                    else:
-                        download_files_task.cancel("Transform failed")
+                    download_files_task.cancel("Transform failed")
                 raise task.exception()
 
             if self.current_status.status in DONE_STATUS:


### PR DESCRIPTION
Fixes `pre-commit` being missing when building development containers