### PR TITLE
Avoid race condition between status monitoring and download tasks

### DIFF
--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -562,7 +562,8 @@ class Query:
             # signing urls for a previous transform then we know it is complete as well
             if cached_record or (
                 self.current_status
-                and self.current_status.status in DONE_STATUS
+                and (self.current_status.status in DONE_STATUS
+                     and self.current_status.files_completed == len(files_seen))
             ):
                 break
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -116,7 +116,7 @@ async def test_download_files(python_dataset):
     progress_mock = Mock()
     python_dataset.minio_polling_interval = 0
     python_dataset.minio = minio_mock
-    python_dataset.current_status = Mock(status="Complete")
+    python_dataset.current_status = Mock(status="Complete", files_completed=2)
     python_dataset.configuration.shortened_downloaded_filename = False
 
     result_uris = await python_dataset.download_files(
@@ -142,7 +142,7 @@ async def test_download_files_with_signed_urls(python_dataset):
 
     python_dataset.minio_polling_interval = 0
     python_dataset.minio = minio_mock
-    python_dataset.current_status = Mock(status="Complete")
+    python_dataset.current_status = Mock(status="Complete", files_completed=2)
     python_dataset.configuration.shortened_downloaded_filename = False
 
     result_uris = await python_dataset.download_files(


### PR DESCRIPTION
If a transform task completed while the download polling was going on, we might miss some outstanding files to download. Do not terminate the polling loop now until all files are seen in the object store.