### PR TITLE
Cleanup cli

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -20,6 +20,13 @@ Common command line arguments:
 If no backend is specified then the client will attempt to
 use the ``default_endpoint`` value to determine who to talk to.
 
+deliver
+~~~~~~~
+This command is used to submit a yaml configuration file to the serviceX backend.
+It will print the paths to the resulting files.
+
+Provide the path to the configuration file as an argument to the command.
+
 codegens
 ~~~~~~~~
 

--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -61,6 +61,11 @@ delete
 
 Delete a transform and its associated result files. Provide the transform request ID as an argument.
 
+cancel
+^^^^^^
+
+Cancel a running transform. Provide the transform request ID as an argument.
+
 cache
 ~~~~~
 

--- a/servicex/app/__init__.py
+++ b/servicex/app/__init__.py
@@ -25,3 +25,22 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+def is_terminal_output():
+    import sys
+    return sys.stdout.isatty()
+
+
+def pipeable_table(title: str):
+    """
+    Create a table that can be used in a pipeable command. Make it pretty if we
+    are outputting to a terminal, otherwise just make it as simple as possible.
+    """
+    from rich.table import Table
+    import rich.box
+
+    table = Table(title=title if is_terminal_output() else None,
+                  show_header=is_terminal_output(),
+                  box=rich.box.HEAVY_HEAD if is_terminal_output() else None)
+
+    return table

--- a/servicex/app/cache.py
+++ b/servicex/app/cache.py
@@ -30,8 +30,8 @@ import shutil
 import rich
 import typer
 from rich.prompt import Confirm
-from rich.table import Table
 
+from servicex.app import pipeable_table
 from servicex.servicex_client import ServiceXClient
 
 cache_app = typer.Typer(name="cache", no_args_is_help=True)
@@ -52,7 +52,7 @@ def list():
     """
     sx = ServiceXClient()
     cache = sx.query_cache
-    table = Table(title="Cached Queries")
+    table = pipeable_table(title="Cached Queries")
     table.add_column("Title")
     table.add_column("Codegen")
     table.add_column("Transform ID")

--- a/servicex/app/cache.py
+++ b/servicex/app/cache.py
@@ -90,11 +90,5 @@ def delete(transform_id: str = typer.Argument(help="Transform ID")):
     Delete a cached query. Use -t to specify the transform ID
     """
     sx = ServiceXClient()
-    cache = sx.query_cache
-    rec = cache.get_transform_by_request_id(transform_id)
-    if not rec:
+    if not sx.delete_transform_from_cache(transform_id):
         rich.print(f"Transform {transform_id} not found in cache")
-        return
-
-    shutil.rmtree(rec.data_dir, ignore_errors=True)
-    cache.delete_record_by_request_id(rec.request_id)

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -31,7 +31,7 @@ from typing import Optional
 import rich
 
 from servicex.app import pipeable_table, is_terminal_output
-from servicex.app.cli_options import backend_cli_option
+from servicex.app.cli_options import backend_cli_option, config_file_option
 
 import typer
 
@@ -44,6 +44,7 @@ datasets_app = typer.Typer(name="datasets", no_args_is_help=True)
 @datasets_app.command(no_args_is_help=True)
 def list(
         backend: Optional[str] = backend_cli_option,
+        config_path: Optional[str] = config_file_option,
         did_finder: Optional[str] = typer.Option(
             None,
             help="Filter datasets by DID finder. Some useful values are 'rucio' or 'user'",
@@ -59,7 +60,7 @@ def list(
     List the datasets. Use fancy formatting if printing to a terminal.
     Output as plain text if redirected.
     """
-    sx = ServiceXClient(backend=backend)
+    sx = ServiceXClient(backend=backend, config_path=config_path)
     table = pipeable_table(title="ServiceX Datasets")
     table.add_column("ID")
     table.add_column("Name")
@@ -95,13 +96,14 @@ def list(
 @datasets_app.command(no_args_is_help=True)
 def get(
         backend: Optional[str] = backend_cli_option,
+        config_path: Optional[str] = config_file_option,
         dataset_id: int = typer.Argument(..., help="The ID of the dataset to get")
 ):
     """
     Get the details of a dataset. Output as a pretty, nested table if printing to a terminal.
     Output as json if redirected.
     """
-    sx = ServiceXClient(backend=backend)
+    sx = ServiceXClient(backend=backend, config_path=config_path)
     if is_terminal_output():
         table = Table(title=f"Dataset ID {dataset_id}")
         table.add_column("Paths")
@@ -137,11 +139,13 @@ def get(
 @datasets_app.command(no_args_is_help=True)
 def delete(
         backend: Optional[str] = backend_cli_option,
+        config_path: Optional[str] = config_file_option,
         dataset_id: int = typer.Argument(..., help="The ID of the dataset to delete")
 ):
-    sx = ServiceXClient(backend=backend)
+    sx = ServiceXClient(backend=backend, config_path=config_path)
     result = asyncio.run(sx.delete_dataset(dataset_id))
     if result:
         typer.echo(f"Dataset {dataset_id} deleted")
     else:
         typer.echo(f"Dataset {dataset_id} not found")
+        raise typer.Abort()

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -41,7 +41,7 @@ from rich.table import Table
 datasets_app = typer.Typer(name="datasets", no_args_is_help=True)
 
 
-@datasets_app.command(no_args_is_help=True)
+@datasets_app.command(no_args_is_help=False)
 def list(
         backend: Optional[str] = backend_cli_option,
         config_path: Optional[str] = config_file_option,

--- a/servicex/app/main.py
+++ b/servicex/app/main.py
@@ -69,13 +69,18 @@ def main_info(
 def deliver(
         backend: Optional[str] = backend_cli_option,
         config_path: Optional[str] = config_file_option,
-        spec_file: str = typer.Argument(..., help="Spec file to submit to serviceX")):
+        spec_file: str = typer.Argument(..., help="Spec file to submit to serviceX"),
+        ignore_cache: Optional[bool] = typer.Option(
+        None, "--ignore-cache", help="Ignore local cache and always submit to ServiceX")
+):
     """
     Deliver a file to the ServiceX cache.
     """
 
     print(f"Delivering {spec_file} to ServiceX cache")
-    results = servicex_client.deliver(spec_file, servicex_name=backend, config_path=config_path)
+    results = servicex_client.deliver(spec_file, servicex_name=backend,
+                                      config_path=config_path,
+                                      ignore_local_cache=ignore_cache)
     rich.print(results)
 
 

--- a/servicex/app/main.py
+++ b/servicex/app/main.py
@@ -30,7 +30,9 @@ from typing import Optional
 import rich
 import typer
 
+from servicex import servicex_client
 from servicex._version import __version__
+from servicex.app.cli_options import backend_cli_option, config_file_option
 from servicex.app.datasets import datasets_app
 from servicex.app.transforms import transforms_app
 from servicex.app.cache import cache_app
@@ -61,6 +63,20 @@ def main_info(
     ServiceX Client
     """
     pass
+
+
+@app.command()
+def deliver(
+        backend: Optional[str] = backend_cli_option,
+        config_path: Optional[str] = config_file_option,
+        spec_file: str = typer.Argument(..., help="Spec file to submit to serviceX")):
+    """
+    Deliver a file to the ServiceX cache.
+    """
+
+    print(f"Delivering {spec_file} to ServiceX cache")
+    results = servicex_client.deliver(spec_file, servicex_name=backend, config_path=config_path)
+    rich.print(results)
 
 
 if __name__ == "__main__":

--- a/servicex/app/transforms.py
+++ b/servicex/app/transforms.py
@@ -54,7 +54,7 @@ def transforms():
     pass
 
 
-@transforms_app.command(no_args_is_help=True)
+@transforms_app.command(no_args_is_help=False)
 def list(
     backend: Optional[str] = backend_cli_option,
     config_path: Optional[str] = config_file_option,

--- a/servicex/app/transforms.py
+++ b/servicex/app/transforms.py
@@ -175,6 +175,21 @@ def delete(
         print(f"Transform {transform_id} deleted")
 
 
+@transforms_app.command(no_args_is_help=True)
+def cancel(
+        backend: Optional[str] = backend_cli_option,
+        config_path: Optional[str] = config_file_option,
+        transform_id_list: List[str] = typer.Argument(help="Transform ID"),
+):
+    """
+    Cancel a running transform request.
+    """
+    sx = ServiceXClient(backend=backend, config_path=config_path)
+    for transform_id in transform_id_list:
+        asyncio.run(sx.cancel_transform(transform_id))
+        print(f"Transform {transform_id} cancelled")
+
+
 class TimeFrame(str, Enum):
     r"""
     Time Frame levels: 'day', 'week' & 'month'

--- a/servicex/app/transforms.py
+++ b/servicex/app/transforms.py
@@ -33,10 +33,11 @@ import re
 from enum import Enum
 
 import rich
+import rich.box
 import typer
 from rich.progress import Progress
-from rich.table import Table
 
+from servicex.app import pipeable_table
 from servicex.app.cli_options import backend_cli_option
 from servicex.minio_adapter import MinioAdapter
 from servicex.models import Status, ResultFile
@@ -64,7 +65,8 @@ def list(
     List the transforms that have been run.
     """
     sx = ServiceXClient(backend=backend)
-    table = Table(title="ServiceX Transforms")
+
+    table = pipeable_table(title="ServiceX Transforms")
     table.add_column("Transform ID")
     table.add_column("Title")
     table.add_column("Status")
@@ -94,7 +96,7 @@ def files(
 
     sx = ServiceXClient(backend=backend)
     result_files = asyncio.run(list_files(sx, transform_id))
-    table = rich.table.Table(title=f"Files from {transform_id}")
+    table = pipeable_table(title=f"Files from {transform_id}")
     table.add_column("filename")
     table.add_column("Size(Mb)")
     table.add_column("Filetype")

--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -235,6 +235,11 @@ class General(DocStringBaseModel):
     Name of the yaml file that will be created in the output directory.
     """
 
+    IgnoreLocalCache: bool = False
+    """
+    Flag to ignore local cache for all samples.
+    """
+
 
 # TODO: ServiceXSpec class has a field name General and it clashes with the class name General
 # when it is called General() to initialize default values for General class

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -211,6 +211,25 @@ class ServiceXAdapter:
                     msg = await _extract_message(r)
                     raise RuntimeError(f"Failed to delete transform {transform_id} - {msg}")
 
+    async def cancel_transform(self, transform_id=None):
+        headers = await self._get_authorization()
+        path_template = f'/servicex/transformation/{transform_id}/cancel'
+        url = self.url + path_template.format(transform_id=transform_id)
+
+        async with ClientSession() as session:
+            async with session.get(
+                    headers=headers,
+                    url=url) as r:
+
+                if r.status == 403:
+                    raise AuthorizationError(
+                        f"Not authorized to access serviceX at {self.url}")
+                elif r.status == 404:
+                    raise ValueError(f"Transform {transform_id} not found")
+                elif r.status != 200:
+                    msg = await _extract_message(r)
+                    raise RuntimeError(f"Failed to cancel transform {transform_id} - {msg}")
+
     async def submit_transform(self, transform_request: TransformRequest) -> str:
         headers = await self._get_authorization()
         retry_options = ExponentialRetry(attempts=3, start_timeout=30)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import logging
+import shutil
 from typing import Optional, List, TypeVar, Any, Mapping, Union, cast
 from pathlib import Path
 
@@ -380,3 +381,13 @@ class ServiceXClient:
             fail_if_incomplete=fail_if_incomplete
         )
         return qobj
+
+    def delete_transform_from_cache(self, transform_id: str):
+        cache = self.query_cache
+        rec = cache.get_transform_by_request_id(transform_id)
+        if not rec:
+            return False
+
+        shutil.rmtree(rec.data_dir, ignore_errors=True)
+        cache.delete_record_by_request_id(rec.request_id)
+        return True

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -309,6 +309,13 @@ class ServiceXClient:
         """
         return self.servicex.delete_transform(transform_id)
 
+    def cancel_transform(self, transform_id):
+        r"""
+        Cancel a Transform by its request ID
+        :return: A Query object
+        """
+        return self.servicex.cancel_transform(transform_id)
+
     def get_code_generators(self, backend=None):
         r"""
         Retrieve the code generators deployed with the serviceX instance

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -200,9 +200,15 @@ def deliver(
     config_path: Optional[str] = None,
     servicex_name: Optional[str] = None,
     return_exceptions: bool = True,
-    fail_if_incomplete: bool = True
+    fail_if_incomplete: bool = True,
+    ignore_local_cache: bool = False
+
 ):
     config = _load_ServiceXSpec(config)
+
+    if ignore_local_cache:
+        for sample in config.Sample:
+            sample.IgnoreLocalCache = True
 
     datasets = _build_datasets(config, config_path, servicex_name, fail_if_incomplete)
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -206,7 +206,7 @@ def deliver(
 ):
     config = _load_ServiceXSpec(config)
 
-    if ignore_local_cache:
+    if ignore_local_cache or config.General.IgnoreLocalCache:
         for sample in config.Sample:
             sample.IgnoreLocalCache = True
 

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -25,6 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from unittest.mock import Mock, patch
 
 
 def test_app_version(script_runner):
@@ -32,3 +33,17 @@ def test_app_version(script_runner):
     result = script_runner.run(['servicex', '--version'])
     assert result.returncode == 0
     assert result.stdout == f'ServiceX {servicex._version.__version__}\n'
+
+
+def test_deliver(script_runner):
+    with patch('servicex.app.main.servicex_client') as mock_servicex_client:
+        mock_servicex_client.deliver = Mock(return_value={
+            "UprootRaw_YAML": [
+                "/tmp/foo.root",
+                "/tmp/bar.root"
+            ]})
+        result = script_runner.run(['servicex', 'deliver', "foo.yaml"])
+        assert result.returncode == 0
+        result_rows = result.stdout.split('\n')
+        assert result_rows[0] == 'Delivering foo.yaml to ServiceX cache'
+        assert result_rows[1] == "{'UprootRaw_YAML': ['/tmp/foo.root', '/tmp/bar.root']}"

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -26,35 +26,9 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from unittest.mock import patch
-
 
 def test_app_version(script_runner):
     import servicex._version
     result = script_runner.run(['servicex', '--version'])
     assert result.returncode == 0
     assert result.stdout == f'ServiceX {servicex._version.__version__}\n'
-
-
-def test_codegen_list(script_runner):
-    with patch('servicex.servicex_adapter.ServiceXAdapter.get_code_generators', return_value={
-        "uproot": "http://uproot-codegen",
-        "xaod": "http://xaod-codegen"
-    }):
-        result = script_runner.run(['servicex', 'codegen', 'list', '-c',
-                                    'tests/example_config.yaml'])
-        assert result.returncode == 0
-        assert result.stdout == '''{
-  "uproot": "http://uproot-codegen",
-  "xaod": "http://xaod-codegen"
-}
-'''
-
-
-def test_codegen_flush(script_runner):
-    with patch('servicex.query_cache.QueryCache.delete_codegen_by_backend') as p:
-        result = script_runner.run(['servicex', 'codegen', 'flush',
-                                    '-c', 'tests/example_config.yaml',
-                                    '-b', 'localhost'])
-        assert result.returncode == 0
-        p.assert_called_once_with('localhost')

--- a/tests/app/test_codegen.py
+++ b/tests/app/test_codegen.py
@@ -1,0 +1,48 @@
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from unittest.mock import patch
+
+
+def test_codegen_list(script_runner):
+    with patch('servicex.servicex_adapter.ServiceXAdapter.get_code_generators', return_value={
+        "uproot": "http://uproot-codegen",
+        "xaod": "http://xaod-codegen"
+    }):
+        result = script_runner.run(['servicex', 'codegen', 'list', '-c',
+                                    'tests/example_config.yaml'])
+        assert result.returncode == 0
+        assert result.stdout == '''{
+  "uproot": "http://uproot-codegen",
+  "xaod": "http://xaod-codegen"
+}
+'''
+
+
+def test_codegen_flush(script_runner):
+    with patch('servicex.query_cache.QueryCache.delete_codegen_by_backend') as p:
+        result = script_runner.run(['servicex', 'codegen', 'flush',
+                                    '-c', 'tests/example_config.yaml',
+                                    '-b', 'localhost'])
+        assert result.returncode == 0
+        p.assert_called_once_with('localhost')

--- a/tests/app/test_datasets.py
+++ b/tests/app/test_datasets.py
@@ -1,0 +1,130 @@
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import json
+from datetime import datetime
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from servicex.models import CachedDataset, DatasetFile
+
+
+@pytest.fixture
+def dataset():
+    dataset_files = [
+        DatasetFile(
+            id=1,
+            adler32="some_adler32_hash",
+            file_size=1024,
+            file_events=100,
+            paths="/path/to/file1"
+        ),
+        DatasetFile(
+            id=2,
+            adler32="another_adler32_hash",
+            file_size=2048,
+            file_events=200,
+            paths="/path/to/file2"
+        )
+    ]
+
+    cached_dataset = CachedDataset(
+        id=42,
+        name="test_dataset",
+        did_finder="some_finder",
+        n_files=2,
+        size=3072,
+        events=300,
+        last_used=datetime.now(),
+        last_updated=datetime.now(),
+        lookup_status="completed",
+        is_stale=False,
+        files=dataset_files
+    )
+    return cached_dataset
+
+
+@pytest.mark.asyncio
+def test_datasets_list(script_runner, dataset):
+    with patch('servicex.app.datasets.ServiceXClient') as mock_servicex:
+        mock_get_datasets = AsyncMock(return_value=[dataset])
+        mock_servicex.return_value.get_datasets = mock_get_datasets
+
+        result = script_runner.run(['servicex', 'datasets', 'list',
+                                    '-c', 'tests/example_config.yaml'])
+        assert result.returncode == 0
+        result_row = result.stdout.split("  ")
+        assert len(result_row) == 7, f"Expected 7 elements, got {len(result_row)}"
+
+        # Assert specific index values
+        assert result_row[0].strip() == '42'
+        assert result_row[1] == 'test_dataset'
+        assert result_row[2] == '2'
+        assert result_row[3] == '0MB'
+        assert result_row[4] == 'completed'
+
+        mock_get_datasets.assert_called_once_with(did_finder=None, show_deleted=False)
+
+        mock_get_datasets.reset_mock()
+        result = script_runner.run(['servicex', 'datasets', 'list',
+                                    '-c', 'tests/example_config.yaml',
+                                    '--did-finder', 'some_finder',
+                                    '--show-deleted'])
+        assert result.returncode == 0
+        mock_get_datasets.assert_called_once_with(did_finder='some_finder', show_deleted=True)
+
+
+def test_dataset_get(script_runner, dataset):
+    with patch('servicex.app.datasets.ServiceXClient') as mock_servicex:
+        mock_get_dataset = AsyncMock(return_value=dataset)
+        mock_servicex.return_value.get_dataset = mock_get_dataset
+
+        result = script_runner.run(['servicex', 'datasets', 'get', '42',
+                                    '-c', 'tests/example_config.yaml'])
+        assert result.returncode == 0
+        mock_get_dataset.assert_called_once_with(42)
+
+        # The output is a json document
+        result_doc = json.loads(result.stdout)
+        assert result_doc['dataset']['id'] == 42
+        assert len(result_doc['dataset']['files']) == 2
+
+
+def test_dataset_delete(script_runner):
+    with patch('servicex.app.datasets.ServiceXClient') as mock_servicex:
+        mock_delete_dataset = AsyncMock(return_value=True)
+        mock_servicex.return_value.delete_dataset = mock_delete_dataset
+
+        result = script_runner.run(['servicex', 'datasets', 'delete',
+                                    '-c', 'tests/example_config.yaml', '42'])
+        assert result.returncode == 0
+        assert result.stdout == "Dataset 42 deleted\n"
+        mock_delete_dataset.assert_called_once_with(42)
+
+        mock_delete_dataset_not_found = AsyncMock(return_value=False)
+        mock_servicex.return_value.delete_dataset = mock_delete_dataset_not_found
+        result = script_runner.run(['servicex', 'datasets', 'delete',
+                                    '-c', 'tests/example_config.yaml', '42'])
+        assert result.returncode == 1
+        mock_delete_dataset.assert_called_once_with(42)
+        assert result.stdout == "Dataset 42 not found\n"

--- a/tests/app/test_transforms.py
+++ b/tests/app/test_transforms.py
@@ -210,3 +210,16 @@ def test_delete_transform(script_runner, transform_status_record):
         assert result.returncode == 0
         assert result.stdout == "Transform test-request-123 deleted\n"
         mock_delete_transform.assert_called_once_with('test-request-123')
+
+
+def test_cancel_transform(script_runner, transform_status_record):
+    with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
+        mock_cancel_transform = AsyncMock(return_value=True)
+        mock_servicex.return_value.cancel_transform = mock_cancel_transform
+
+        result = script_runner.run(['servicex', 'transforms', 'cancel',
+                                    '-c', 'tests/example_config.yaml',
+                                    'test-request-123'])
+        assert result.returncode == 0
+        assert result.stdout == "Transform test-request-123 cancelled\n"
+        mock_cancel_transform.assert_called_once_with('test-request-123')

--- a/tests/app/test_transforms.py
+++ b/tests/app/test_transforms.py
@@ -30,7 +30,7 @@ from servicex.models import TransformStatus, ResultDestination, ResultFormat, St
 
 
 @pytest.fixture
-def transform_status() -> TransformStatus:
+def transform_status_record() -> TransformStatus:
     """
     Pytest fixture generating a realistic TransformStatus instance for testing.
 
@@ -82,10 +82,10 @@ def result_files():
         )]
 
 
-def test_transforms_list(script_runner, transform_status):
+def test_transforms_list(script_runner, transform_status_record):
     with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
-        transform_status.status = Status.running
-        mock_list_transforms = Mock(return_value=[transform_status])
+        transform_status_record.status = Status.running
+        mock_list_transforms = Mock(return_value=[transform_status_record])
         mock_servicex.return_value.get_transforms = mock_list_transforms
         result = script_runner.run(['servicex', 'transforms', 'list',
                                     '-c', 'tests/example_config.yaml'])
@@ -107,10 +107,47 @@ def test_transforms_list(script_runner, transform_status):
         assert len(result.stdout.strip()) == 0
 
 
-def test_list_files(script_runner, transform_status, result_files):
+@pytest.mark.parametrize("transform_state, report_complete, report_running, expected", [
+    # Scenario 1: No flags set (report all)
+    (Status.complete, False, False, True),
+    (Status.running, False, False, True),
+
+    # Scenario 2: Complete records only
+    (Status.complete, True, False, True),
+    (Status.running, True, False, False),
+
+    # Scenario 3: Running records only
+    (Status.complete, False, True, False),
+    (Status.running, False, True, True),
+
+    # Scenario 4: Both flags set
+    (Status.complete, True, True, True),
+    (Status.running, True, True, True),
+])
+def test_transforms_list_filters(script_runner, transform_status_record,
+                                 transform_state, report_complete, report_running, expected):
+    with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
+        transform_status_record.status = transform_state
+        mock_list_transforms = Mock(return_value=[transform_status_record])
+        mock_servicex.return_value.get_transforms = mock_list_transforms
+        command_line = ['servicex', 'transforms', 'list',
+                                    '-c', 'tests/example_config.yaml']
+
+        if report_complete:
+            command_line.append('--complete')
+        if report_running:
+            command_line.append('--running')
+
+        result = script_runner.run(command_line)
+
+        assert result.returncode == 0
+        assert len(result.stdout.strip()) if expected else len(result.stdout.strip()) == 0
+
+
+def test_list_files(script_runner, transform_status_record, result_files):
     with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
         with patch('servicex.app.transforms.MinioAdapter') as mock_minio:
-            mock_transform_status = AsyncMock(return_value=transform_status)
+            mock_transform_status = AsyncMock(return_value=transform_status_record)
             mock_servicex.return_value.get_transform_status_async = mock_transform_status
 
             mock_minio_adapter = Mock()
@@ -128,14 +165,14 @@ def test_list_files(script_runner, transform_status, result_files):
             assert result_row[2] == 'parquet'
 
             mock_transform_status.assert_called_once_with('test-request-123')
-            mock_minio.for_transform.assert_called_once_with(transform_status)
+            mock_minio.for_transform.assert_called_once_with(transform_status_record)
             mock_minio_adapter.list_bucket.assert_called_once()
 
 
-def test_download_files(script_runner, transform_status, result_files):
+def test_download_files(script_runner, transform_status_record, result_files):
     with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
         with patch('servicex.app.transforms.MinioAdapter') as mock_minio:
-            mock_transform_status = AsyncMock(return_value=transform_status)
+            mock_transform_status = AsyncMock(return_value=transform_status_record)
             mock_servicex.return_value.get_transform_status_async = mock_transform_status
 
             mock_minio_adapter = Mock()
@@ -153,13 +190,13 @@ def test_download_files(script_runner, transform_status, result_files):
             assert result_rows[1] == "/tmp/test_file.parquet"
 
             mock_transform_status.assert_called_once_with('test-request-123')
-            mock_minio.for_transform.assert_called_once_with(transform_status)
+            mock_minio.for_transform.assert_called_once_with(transform_status_record)
             mock_minio_adapter.list_bucket.assert_called_once()
             assert mock_minio_adapter.download_file.call_count == 2
             assert mock_minio_adapter.download_file.mock_calls[0].args[0] == 'test_file'
 
 
-def test_delete_transform(script_runner, transform_status):
+def test_delete_transform(script_runner, transform_status_record):
     with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
         mock_delete_transform = AsyncMock(return_value=True)
         mock_servicex.return_value.delete_transform = mock_delete_transform

--- a/tests/app/test_transforms.py
+++ b/tests/app/test_transforms.py
@@ -1,0 +1,175 @@
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch, AsyncMock, Mock
+
+import pytest
+
+from servicex.models import TransformStatus, ResultDestination, ResultFormat, Status, ResultFile
+
+
+@pytest.fixture
+def transform_status() -> TransformStatus:
+    """
+    Pytest fixture generating a realistic TransformStatus instance for testing.
+
+    Returns:
+        TransformStatus: A populated TransformStatus object with sample data
+    """
+
+    # Default data that can be overridden
+    base_data = {
+        "request_id": "test-request-123",
+        "did": "test-did-456",
+        "title": "Test Transform Job",
+        "selection": "(muon_pt > 20)",
+        "tree-name": "mytree",
+        "image": "servicex/transformer:latest",
+        "result-destination": ResultDestination.object_store,
+        "result-format": ResultFormat.parquet,
+        "generated-code-cm": "generated-test-code",
+        "status": Status.complete,
+        "app-version": "1.2.3",
+        "files": 10,
+        "files-completed": 8,
+        "files-failed": 1,
+        "files-remaining": 1,
+        "submit_time": datetime.now(),
+        "finish_time": datetime.now(),
+        "minio_endpoint": "minio.example.com",
+        "minio_secured": True,
+        "minio_access_key": "test-access-key",
+        "minio_secret_key": "test-secret-key",
+        "log_url": "https://logs.example.com/test-job"
+    }
+
+    return TransformStatus(**base_data)
+
+
+@pytest.fixture
+def result_files():
+    return [
+        ResultFile(
+            filename="test_file",
+            size=1024,
+            extension="parquet"
+        ),
+        ResultFile(
+            filename="test_file2",
+            size=2048,
+            extension="parquet"
+        )]
+
+
+def test_transforms_list(script_runner, transform_status):
+    with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
+        transform_status.status = Status.running
+        mock_list_transforms = Mock(return_value=[transform_status])
+        mock_servicex.return_value.get_transforms = mock_list_transforms
+        result = script_runner.run(['servicex', 'transforms', 'list',
+                                    '-c', 'tests/example_config.yaml'])
+
+        assert result.returncode == 0
+        result_row = result.stdout.split("  ")
+        assert len(result_row) == 4
+        assert result_row[0].strip() == 'test-request-123'
+        assert result_row[1] == 'Test Transform Job'
+        assert result_row[2] == 'Running'
+        assert result_row[3].strip() == '8'
+
+        mock_list_transforms.assert_called_once()
+        mock_list_transforms.reset_mock()
+        result = script_runner.run(['servicex', 'transforms', 'list',
+                                    '-c', 'tests/example_config.yaml',
+                                    '--complete'])
+        assert result.returncode == 0
+        assert len(result.stdout.strip()) == 0
+
+
+def test_list_files(script_runner, transform_status, result_files):
+    with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
+        with patch('servicex.app.transforms.MinioAdapter') as mock_minio:
+            mock_transform_status = AsyncMock(return_value=transform_status)
+            mock_servicex.return_value.get_transform_status_async = mock_transform_status
+
+            mock_minio_adapter = Mock()
+            mock_minio_adapter.list_bucket = AsyncMock(return_value=result_files)
+            mock_minio.for_transform = Mock(return_value=mock_minio_adapter)
+            result = script_runner.run(['servicex', 'transforms', 'files',
+                                        '-c', 'tests/example_config.yaml',
+                                        'test-request-123'])
+            assert result.returncode == 0
+            result_rows = result.stdout.strip().split("\n")
+            assert len(result_rows) == 2
+            result_row = result_rows[1].split("  ")
+            assert result_row[0].strip() == 'test_file2'
+            assert result_row[1] == '0.00'
+            assert result_row[2] == 'parquet'
+
+            mock_transform_status.assert_called_once_with('test-request-123')
+            mock_minio.for_transform.assert_called_once_with(transform_status)
+            mock_minio_adapter.list_bucket.assert_called_once()
+
+
+def test_download_files(script_runner, transform_status, result_files):
+    with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
+        with patch('servicex.app.transforms.MinioAdapter') as mock_minio:
+            mock_transform_status = AsyncMock(return_value=transform_status)
+            mock_servicex.return_value.get_transform_status_async = mock_transform_status
+
+            mock_minio_adapter = Mock()
+            mock_minio_adapter.list_bucket = AsyncMock(return_value=result_files)
+            mock_minio_adapter.download_file = AsyncMock(
+                return_value=Path("/tmp/test_file.parquet")
+            )
+            mock_minio.for_transform = Mock(return_value=mock_minio_adapter)
+            result = script_runner.run(['servicex', 'transforms', 'download',
+                                        '-c', 'tests/example_config.yaml',
+                                        'test-request-123'])
+            assert result.returncode == 0
+            result_rows = result.stdout.strip().split("\n")
+            assert len(result_rows) == 3
+            assert result_rows[1] == "/tmp/test_file.parquet"
+
+            mock_transform_status.assert_called_once_with('test-request-123')
+            mock_minio.for_transform.assert_called_once_with(transform_status)
+            mock_minio_adapter.list_bucket.assert_called_once()
+            assert mock_minio_adapter.download_file.call_count == 2
+            assert mock_minio_adapter.download_file.mock_calls[0].args[0] == 'test_file'
+
+
+def test_delete_transform(script_runner, transform_status):
+    with patch('servicex.app.transforms.ServiceXClient') as mock_servicex:
+        mock_delete_transform = AsyncMock(return_value=True)
+        mock_servicex.return_value.delete_transform = mock_delete_transform
+
+        mock_delete_local = Mock(return_value=True)
+        mock_servicex.return_value.delete_local_transform = mock_delete_local
+
+        result = script_runner.run(['servicex', 'transforms', 'delete',
+                                    '-c', 'tests/example_config.yaml',
+                                    'test-request-123'])
+        assert result.returncode == 0
+        assert result.stdout == "Transform test-request-123 deleted\n"
+        mock_delete_transform.assert_called_once_with('test-request-123')

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -91,7 +91,9 @@ async def test_get_transforms_wlcg_bearer_token(decode,
                                                 servicex,
                                                 transform_status_response):
     token_file = tempfile.NamedTemporaryFile(mode="w+t", delete=False)
-    token_file.write("luckycharms")
+    token_file.write(""""
+    eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
+    """)
     token_file.close()
 
     os.environ['BEARER_TOKEN_FILE'] = token_file.name

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -84,6 +84,12 @@ def test_delete_transform(mock_cache, servicex_adaptor):
     servicex_adaptor.delete_transform.assert_called_once_with("123-45-6789")
 
 
+def test_cancel_transform(mock_cache, servicex_adaptor):
+    sx = ServiceXClient(config_path="tests/example_config.yaml")
+    sx.cancel_transform("123-45-6789")
+    servicex_adaptor.cancel_transform.assert_called_once_with("123-45-6789")
+
+
 @pytest.fixture
 def transformed_results() -> TransformedResults:
     """


### PR DESCRIPTION
This pull request introduces several new features and improvements to the ServiceX CLI. The most notable changes include the addition of new commands, enhancements to the output formatting, and the implementation of new functionalities for managing transforms. Also completed the unit tests for the CLI code. Below is a summary of the most important changes:

### New CLI Commands
* Added `deliver` command to submit a YAML configuration file to the ServiceX backend and print the resulting file paths. (`docs/command_line.rst`, `servicex/app/main.py`) [[1]](diffhunk://#diff-c8aa0277057c29741b54e77dc385a622dcee6a8db3d16516eb4e1fb402becd99R23-R29) [[2]](diffhunk://#diff-45693d9f0af917dbdeafd6fb97e3f240a375ff3cc5e1b33b59f813e6131d196aR68-R81)
* Added `cancel` command to cancel a running transform. (`docs/command_line.rst`, `servicex/app/transforms.py`) [[1]](diffhunk://#diff-c8aa0277057c29741b54e77dc385a622dcee6a8db3d16516eb4e1fb402becd99R64-R68) [[2]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dR164-R192)

### Output Formatting Enhancements
* Introduced `pipeable_table` function to create tables that adapt based on the output destination (terminal or pipe). Applied this function to various commands to improve output formatting. (`servicex/app/__init__.py`, `servicex/app/cache.py`, `servicex/app/datasets.py`, `servicex/app/transforms.py`) [[1]](diffhunk://#diff-3f6a0bc9da5f3480c5e37ca50830193d16d677c29e3fe791958d8d1dde80cc55R28-R46) [[2]](diffhunk://#diff-e219046d73b35d5be17558b327e218b9472fe833f269930acf2c40f12b21ee65L33-R34) [[3]](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL33-R34) [[4]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dR36-R41)

### Transform Management Improvements
* Implemented `cancel_transform` method in `ServiceXClient` and `ServiceXAdapter` to support the new cancel command. (`servicex/servicex_adapter.py`, `servicex/servicex_client.py`) [[1]](diffhunk://#diff-6e75113f7810952525ce5c0fb5a657c867dea6b6a9d11b2a1474d2c7f767e739R214-R232) [[2]](diffhunk://#diff-1ffdb63d88e900f7b0a61d4db9e1c861e398749b5c0caa120ddf1f6234f05cb0R312-R318)

### Configuration File Support
* Added support for specifying a configuration file path (`config_path`) in various commands to allow more flexible configuration management. (`servicex/app/datasets.py`, `servicex/app/transforms.py`) [[1]](diffhunk://#diff-4f97c1a4760ccafd2e404f77ddeebe56a6b3ac23c937f5367bc7981a96af281eL43-R47) [[2]](diffhunk://#diff-b6290ab96e9a219037f44562c5e51a057ec665f192e7f84f436853e36759234dL56-R90)

### Tests
* Added tests for the new `deliver` command and version output. (`tests/app/test_app.py`)
* The local cache delete operation as part of transform delete was very hard to test as it was written. Moved the cache delete code into the ServiceX client and updated the CLI commands.  (`servicex/app/cache.py`, `servicex/servicex_client.py`) [[1]](diffhunk://#diff-e219046d73b35d5be17558b327e218b9472fe833f269930acf2c40f12b21ee65L93-L100) [[2]](diffhunk://#diff-1ffdb63d88e900f7b0a61d4db9e1c861e398749b5c0caa120ddf1f6234f05cb0R391-R400)

### Ignore Local Cache
* Added argument to `deliver` function to force IgnoreLocalCache setting. Accessible from the CLI too
