### PR TITLE
Updated xaod_usage documentation URL in ServiceX_frontend docs.

### DIFF
--- a/docs/query_types.rst
+++ b/docs/query_types.rst
@@ -139,7 +139,7 @@ is applied to each event in the input sequence, and the result is a sequence of 
 The dictionary defines the columns of the output file (e.g. the leaves in a ``TTree``). In each case, the three ``lambda`` functions are applied
 to each jet, transforming the sequence of jets into a sequence of :math:`p_T` values, a sequence of :math:`\eta` values, and a sequence of EM fractions.
 
-Full documentation on the func-adl query language can be found at this `JupyterBook <https://gordonwatts.github.io/xaod_usage/intro.html>`_.
+Full documentation on the func-adl query language can be found at this `JupyterBook <https://iris-hep.github.io/xaod_usage/intro.html>`_.
 
 Python Function Query Type
 --------------------------


### PR DESCRIPTION
Moved xaod_usage docs over to iris-hep from Gordon's git hub. Needed to update the link in the service x frontend docs to reflect these changes.