### PR TITLE
build:  Restrict ruamel-yaml to v0.18.6 or older

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "rich>=13.0.0",  # databinder
     "aiofile",  # compatible versions controlled through miniopy-async
     "make-it-sync",  # compatible versions controlled through func_adl
-    "ruamel.yaml>=0.18",
+    "ruamel.yaml>=0.18,<0.18.7",  # FIXME: ruamel-yaml v0.18.7 has a breaking API change relative to v0.18.6
     "ccorp-yaml-include-relative-path>=0.0.4",
     "filelock>=3.12.0",
     "tenacity >= 9.0.0"


### PR DESCRIPTION
Resolves #540 

* ruamel-yaml v0.18.7 has a breaking API change relative to v0.18.6. Until this can be fixed, introduce a short lived version cap.
   - c.f. https://pypi.org/project/ruamel.yaml/0.18.7/ c.f. https://sourceforge.net/p/ruamel-yaml/code/ci/0.18.7/tree/