### PR TITLE
ci: Add Dependabot updates for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns:
+          - "*"
+    labels:
+      - "github-actions"
+      - "dependencies"
+    reviewers:
+      - "BenGalewsky"
+      - "ponyisi"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.x"
 
@@ -35,15 +35,15 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
 
       - name: Install dependencies
         run: |
@@ -55,7 +55,7 @@ jobs:
           coverage run -m pytest tests --cov=./servicex/ --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3.1.4
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/reports/

--- a/.github/workflows/ci_production.yaml
+++ b/.github/workflows/ci_production.yaml
@@ -11,12 +11,12 @@ jobs:
     environment: production-service
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.12
+          python-version: "3.12"
 
       - name: Save secret
         run: 'echo "$SERVICEX_YAML" > servicex.yaml'
@@ -25,7 +25,7 @@ jobs:
           SERVICEX_YAML: ${{ secrets.SERVICEX_YAML }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v5
 
       - name: Install package
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - 3.0_develop
   pull_request:
   workflow_dispatch:
 
@@ -31,7 +30,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v5
 
     - name: Install Python dependencies
       run: |

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -23,7 +23,7 @@ jobs:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v3
+      uses: astral-sh/setup-uv@v5
 
     - name: Install python-build and twine
       run: |


### PR DESCRIPTION
* Enable weekly checks for updates to GitHub Actions in use with Dependabot. Group the updates into a single PR to avoid PR noise.
* Update GitHub Actions to latest versions:
   - actions/checkout v3 -> v4
   - actions/setup-python v4 -> v5
   - astral-sh/setup-uv v3 -> v5
   - codecov/codecov-action v3 -> v5
* Remove '3.0_develop' branch as trigger for docs workflow, as it no longer exists.