### PR TITLE
Fix devcontainer python image base

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,7 @@
 
 # [Choice] Python version
 ARG VARIANT="3.13"
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/python:1-${VARIANT}
 
 # [Option] Install Node.js
 ARG INSTALL_NODE="false"


### PR DESCRIPTION
Previous PR #549 unintentionally changed the devcontainer `Dockerfile` to pull from a non-existent tag (0-3.13). I have changed it to 1-3.13 .