### PR TITLE
Remove obsolete fields in transform requests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ test = [
     "pre-commit>=4.0.1",
 ]
 docs = [
-    "sphinx>=7.0.1",
+    "sphinx>=7.0.1, <8.2.0",
     "furo>=2023.5.20",
     "sphinx-code-include>=1.4.0",
     "myst-parser>=3.0.1",

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -104,9 +104,7 @@ class TransformRequest(DocStringBaseModel):
     did: Optional[str] = None
     file_list: Optional[List[str]] = Field(default=None, alias="file-list")
     selection: str
-    image: Optional[str] = None
     codegen: str
-    tree_name: Optional[str] = Field(default=None, alias="tree-name")
     result_destination: ResultDestination = Field(
         serialization_alias="result-destination"
     )
@@ -126,9 +124,9 @@ class TransformRequest(DocStringBaseModel):
                 [
                     self.did,
                     self.selection,
-                    self.tree_name,
+                    None,  # was tree_name
                     self.codegen,
-                    self.image,
+                    None,  # was image
                     self.result_format.name,
                     sorted(self.file_list) if self.file_list else None,
                 ]


### PR DESCRIPTION
Neither `tree-name` nor `image` should be specified in ServiceX requests. The former does nothing anyway and the latter is a security risk. In any case the frontend v3 API doesn't provide any way for users to set them.