### PR TITLE
Pass `display_progress` to query core

### DIFF
--- a/servicex/dataset_group.py
+++ b/servicex/dataset_group.py
@@ -74,7 +74,8 @@ class DatasetGroup:
             display_progress, provided_progress, overall_progress=overall_progress
         ) as progress:
             self.tasks = [
-                d.as_signed_urls_async(provided_progress=progress, dataset_group=True)
+                d.as_signed_urls_async(provided_progress=progress, dataset_group=True,
+                                       display_progress=display_progress)
                 for d in self.datasets
             ]
             return await asyncio.gather(
@@ -97,7 +98,8 @@ class DatasetGroup:
             display_progress, provided_progress, overall_progress=overall_progress
         ) as progress:
             self.tasks = [
-                d.as_files_async(provided_progress=progress) for d in self.datasets
+                d.as_files_async(provided_progress=progress, display_progress=display_progress)
+                for d in self.datasets
             ]
             return await asyncio.gather(
                 *self.tasks, return_exceptions=return_exceptions

--- a/servicex/dataset_group.py
+++ b/servicex/dataset_group.py
@@ -74,8 +74,11 @@ class DatasetGroup:
             display_progress, provided_progress, overall_progress=overall_progress
         ) as progress:
             self.tasks = [
-                d.as_signed_urls_async(provided_progress=progress, dataset_group=True,
-                                       display_progress=display_progress)
+                d.as_signed_urls_async(
+                    provided_progress=progress,
+                    dataset_group=True,
+                    display_progress=display_progress,
+                )
                 for d in self.datasets
             ]
             return await asyncio.gather(
@@ -98,7 +101,9 @@ class DatasetGroup:
             display_progress, provided_progress, overall_progress=overall_progress
         ) as progress:
             self.tasks = [
-                d.as_files_async(provided_progress=progress, display_progress=display_progress)
+                d.as_files_async(
+                    provided_progress=progress, display_progress=display_progress
+                )
                 for d in self.datasets
             ]
             return await asyncio.gather(

--- a/tests/test_dataset_group.py
+++ b/tests/test_dataset_group.py
@@ -60,6 +60,27 @@ async def test_as_signed_urls(mocker, transformed_result):
     assert len(results) == 2
     assert results[0].request_id == "123-45-6789"
     assert results[1].request_id == "98-765-432"
+    assert "display_progress" in ds1.as_signed_urls_async.call_args_list[0].kwargs
+    assert ds1.as_signed_urls_async.call_args_list[0].kwargs["display_progress"]
+
+
+@pytest.mark.asyncio
+async def test_as_signed_urls_no_progress(mocker, transformed_result):
+    ds1 = mocker.Mock()
+    ds1.as_signed_urls_async = AsyncMock(return_value=transformed_result)
+    ds1.servicex._get_authorization = AsyncMock()
+
+    ds2 = mocker.Mock()
+    ds2.as_signed_urls_async = AsyncMock(
+        return_value=transformed_result.model_copy(update={"request_id": "98-765-432"})
+    )
+
+    group = DatasetGroup([ds1, ds2])
+    await group.as_signed_urls_async(display_progress=False)
+
+    ds1.as_signed_urls_async.assert_called_once()
+    assert "display_progress" in ds1.as_signed_urls_async.call_args_list[0].kwargs
+    assert not ds1.as_signed_urls_async.call_args_list[0].kwargs["display_progress"]
 
 
 @pytest.mark.asyncio
@@ -79,6 +100,27 @@ async def test_as_files(mocker, transformed_result):
     assert len(results) == 2
     assert results[0].request_id == "123-45-6789"
     assert results[1].request_id == "98-765-432"
+    assert "display_progress" in ds1.as_files_async.call_args_list[0].kwargs
+    assert ds1.as_files_async.call_args_list[0].kwargs["display_progress"]
+
+
+@pytest.mark.asyncio
+async def test_as_files_no_progress(mocker, transformed_result):
+    ds1 = mocker.Mock()
+    ds1.as_files_async = AsyncMock(return_value=transformed_result)
+    ds1.servicex._get_authorization = AsyncMock()
+
+    ds2 = mocker.Mock()
+    ds2.as_files_async = AsyncMock(
+        return_value=transformed_result.model_copy(update={"request_id": "98-765-432"})
+    )
+
+    group = DatasetGroup([ds1, ds2])
+    await group.as_files_async(display_progress=False)
+
+    ds1.as_files_async.assert_called_once()
+    assert 'display_progress' in ds1.as_files_async.call_args_list[0].kwargs
+    assert not ds1.as_files_async.call_args_list[0].kwargs['display_progress']
 
 
 @pytest.mark.asyncio

--- a/tests/test_dataset_group.py
+++ b/tests/test_dataset_group.py
@@ -119,8 +119,8 @@ async def test_as_files_no_progress(mocker, transformed_result):
     await group.as_files_async(display_progress=False)
 
     ds1.as_files_async.assert_called_once()
-    assert 'display_progress' in ds1.as_files_async.call_args_list[0].kwargs
-    assert not ds1.as_files_async.call_args_list[0].kwargs['display_progress']
+    assert "display_progress" in ds1.as_files_async.call_args_list[0].kwargs
+    assert not ds1.as_files_async.call_args_list[0].kwargs["display_progress"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
* We were not passing `display_progress` from the `data_group` to `query` for file downloads or URL downloads.

Fixes #567