### PR TITLE
Switch S3 client to boto3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "pydantic>=2.6.0",
     "aiohttp-retry>=2.8.3",
     "httpx>=0.24",
-    "miniopy-async>=1.20.1",
+    "aioboto3>=14.1.0",
     "tinydb>=4.7",
     "google-auth>=2.17",
     "typer>=0.12.1",
@@ -47,7 +47,6 @@ dependencies = [
     "importlib_metadata; python_version <= '3.9'",
     "typing_extensions; python_version <= '3.10'", # compatible versions controlled through pydantic
     "rich>=13.0.0",  # databinder
-    "aiofile",  # compatible versions controlled through miniopy-async
     "make-it-sync",  # compatible versions controlled through func_adl
     "ruamel.yaml>=0.18.7",
     "filelock>=3.12.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ test = [
     "pandas>=2.0.2",
     "pyarrow>=12.0.0",
     "pre-commit>=4.0.1",
+    "pytest-aioboto3>=0.6.0",
 ]
 docs = [
     "sphinx>=7.0.1, <8.2.0",

--- a/servicex/minio_adapter.py
+++ b/servicex/minio_adapter.py
@@ -135,7 +135,7 @@ class MinioAdapter:
     )
     async def get_signed_url(self, object_name: str) -> str:
         async with _semaphore:
-            async with self.minio.resource("s3", endpoint_url=self.endpoint_host) as s3:
+            async with self.minio.client("s3", endpoint_url=self.endpoint_host) as s3:
                 return await s3.generate_presigned_url(
                     "get_object", Params={"Bucket": self.bucket, "Key": object_name}
                 )

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, IRIS-HEP
+# Copyright (c) 2022-2025, IRIS-HEP
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -228,6 +228,7 @@ def deliver(
     fail_if_incomplete: bool = True,
     ignore_local_cache: bool = False,
     progress_bar: ProgressBarFormat = ProgressBarFormat.default,
+    concurrency: int = 8,
 ):
     r"""
     Execute a ServiceX query.
@@ -249,9 +250,13 @@ def deliver(
             will have its own progress bars; :py:const:`ProgressBarFormat.compact` gives one
             summary progress bar for all transformations; :py:const:`ProgressBarFormat.none`
             switches off progress bars completely.
+    :param concurrency: specify how many downloads to run in parallel (default is 8).
     :return: A dictionary mapping the name of each :py:class:`Sample` to a :py:class:`.GuardList`
             with the file names or URLs for the outputs.
     """
+    from .minio_adapter import init_download_semaphore
+
+    init_download_semaphore(concurrency)
     config = _load_ServiceXSpec(spec)
 
     if ignore_local_cache or config.General.IgnoreLocalCache:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,3 +222,9 @@ def codegen_list():
         "uproot": "http://servicex-code-gen-uproot:8000",
         "uproot-raw": "http://servicex-code-gen-uproot-raw:8000",
     }
+
+
+# This exists to force an async event loop to be created
+@fixture
+async def with_event_loop():
+    pass

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -286,7 +286,7 @@ def test_invalid_dataset_identifier():
         )
 
 
-def test_submit_mapping(transformed_result, codegen_list):
+def test_submit_mapping(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
 
     spec = {
@@ -316,7 +316,9 @@ def test_submit_mapping(transformed_result, codegen_list):
         assert list(results["sampleA"]) == ["1.parquet"]
 
 
-def test_submit_mapping_signed_urls(transformed_result_signed_url, codegen_list):
+def test_submit_mapping_signed_urls(
+    transformed_result_signed_url, codegen_list, with_event_loop
+):
     from servicex import deliver
 
     spec = {
@@ -347,7 +349,7 @@ def test_submit_mapping_signed_urls(transformed_result_signed_url, codegen_list)
         ]
 
 
-def test_submit_mapping_failure(transformed_result, codegen_list):
+def test_submit_mapping_failure(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
 
     spec = {
@@ -378,7 +380,7 @@ def test_submit_mapping_failure(transformed_result, codegen_list):
                 pass
 
 
-def test_submit_mapping_failure_signed_urls(codegen_list):
+def test_submit_mapping_failure_signed_urls(codegen_list, with_event_loop):
     from servicex import deliver
 
     spec = {
@@ -634,7 +636,7 @@ Sample:
         _load_ServiceXSpec(path2)
 
 
-def test_funcadl_query(transformed_result, codegen_list):
+def test_funcadl_query(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import FuncADL_Uproot  # type: ignore
 
@@ -664,7 +666,7 @@ def test_funcadl_query(transformed_result, codegen_list):
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_query_with_codegen_override(transformed_result, codegen_list):
+def test_query_with_codegen_override(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import FuncADL_Uproot  # type: ignore
 
@@ -748,7 +750,7 @@ def test_databinder_load_dict():
     )
 
 
-def test_python_query(transformed_result, codegen_list):
+def test_python_query(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import PythonFunction  # type: ignore
 
@@ -782,7 +784,7 @@ def test_python_query(transformed_result, codegen_list):
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_uproot_raw_query(transformed_result, codegen_list):
+def test_uproot_raw_query(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import UprootRaw  # type: ignore
 
@@ -810,7 +812,7 @@ def test_uproot_raw_query(transformed_result, codegen_list):
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_uproot_raw_query_parquet(transformed_result, codegen_list):
+def test_uproot_raw_query_parquet(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import UprootRaw  # type: ignore
 
@@ -897,7 +899,7 @@ def test_generic_query(codegen_list):
             )
 
 
-def test_deliver_progress_options(transformed_result, codegen_list):
+def test_deliver_progress_options(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver, ProgressBarFormat
     from servicex.query import UprootRaw  # type: ignore
 

--- a/tests/test_minio_adapter.py
+++ b/tests/test_minio_adapter.py
@@ -25,20 +25,56 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from pathlib import Path
 from unittest.mock import AsyncMock
+import urllib.parse
 
 import pytest
-from miniopy_async.datatypes import Object
 from pytest_asyncio import fixture
 
 from servicex.minio_adapter import MinioAdapter
 from servicex.models import ResultFile
 
+DOWNLOAD_PATCH_COUNTER = 0
+
+
+def mock_downloader(**args):
+    global DOWNLOAD_PATCH_COUNTER
+    DOWNLOAD_PATCH_COUNTER += 1
+    if DOWNLOAD_PATCH_COUNTER == 1:
+        raise Exception("lol")
+    elif DOWNLOAD_PATCH_COUNTER == 2:
+        open("/tmp/foo/test.txt", "wb").write(b"\x01" * 5)
+    elif DOWNLOAD_PATCH_COUNTER == 3:
+        open("/tmp/foo/test.txt", "wb").write(b"\x01" * 10)
+
 
 @fixture
-def minio_adapter() -> MinioAdapter:
-    return MinioAdapter("localhost", False, "access_key", "secret_key", "bucket")
+def download_patch():
+    import aioboto3.s3.inject
+
+    aioboto3.s3.inject.download_file = AsyncMock(side_effect=mock_downloader)
+    return aioboto3.s3.inject.download_file
+
+
+@fixture
+def minio_adapter(moto_services, moto_patch_session) -> MinioAdapter:
+    urlinfo = urllib.parse.urlparse(moto_services["s3"])
+    return MinioAdapter(
+        urlinfo.netloc, urlinfo.scheme == "https", "access_key", "secret_key", "bucket"
+    )
+
+
+@fixture
+async def populate_bucket(request, minio_adapter):
+    async with minio_adapter.minio.client(
+        "s3", endpoint_url=minio_adapter.endpoint_host
+    ) as s3:
+        await s3.create_bucket(Bucket=minio_adapter.bucket)
+        await s3.put_object(
+            Bucket=minio_adapter.bucket, Key=request.param, Body=b"\x01" * 10
+        )
+        yield
+        await s3.delete_object(Bucket=minio_adapter.bucket, Key=request.param)
 
 
 @fixture
@@ -52,75 +88,63 @@ def session(mocker):
 @pytest.mark.asyncio
 async def test_initialize_from_status(completed_status):
     minio = MinioAdapter.for_transform(completed_status)
-    assert minio.minio._base_url.host == "minio.org:9000"
-    assert minio.minio._provider._credentials.access_key == "miniouser"
-    assert minio.minio._provider._credentials.secret_key == "secret"
+    assert minio.endpoint_host == "http://minio.org:9000"
+    assert minio.minio._session._credentials.access_key == "miniouser"
+    assert minio.minio._session._credentials.secret_key == "secret"
     assert minio.bucket == "b8c508d0-ccf2-4deb-a1f7-65c839eebabf"
 
 
+@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
 @pytest.mark.asyncio
-async def test_list_bucket(minio_adapter):
+async def test_list_bucket(minio_adapter, populate_bucket):
     files = [ResultFile(filename="test.txt", size=10, extension="txt")]
-    minio_adapter.minio.list_objects = AsyncMock(
-        return_value=[
-            Object(object_name=file.filename, size=file.size, bucket_name="bucket")
-            for file in files
-        ]
-    )
     result = await minio_adapter.list_bucket()
     assert result == files
-    minio_adapter.minio.list_objects.assert_called_with("bucket")
 
 
+@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
 @pytest.mark.asyncio
-async def test_download_file(minio_adapter, session):
-    minio_adapter.minio.fget_object = AsyncMock(return_value="test.txt")
+async def test_download_file(minio_adapter, populate_bucket):
     result = await minio_adapter.download_file("test.txt", local_dir="/tmp/foo")
     assert str(result).endswith("test.txt")
-    assert session.call_args.kwargs["timeout"].total == 600
-    minio_adapter.minio.fget_object.assert_called_with(
-        bucket_name="bucket",
-        file_path="/tmp/foo/test.txt",
-        object_name="test.txt",
-        session=session.return_value.__aenter__.return_value,
-    )
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
 
 
+@pytest.mark.parametrize("populate_bucket", ["t::est.txt"], indirect=True)
 @pytest.mark.asyncio
-async def test_download_bad_filename(minio_adapter, session):
-    minio_adapter.minio.fget_object = AsyncMock(return_value="t::est.txt")
+async def test_download_bad_filename(minio_adapter, populate_bucket):
     result = await minio_adapter.download_file("t::est.txt", local_dir="/tmp/foo")
     assert str(result).endswith("t__est.txt")
-    minio_adapter.minio.fget_object.assert_called_with(
-        bucket_name="bucket",
-        file_path="/tmp/foo/t__est.txt",
-        object_name="t::est.txt",
-        session=session.return_value.__aenter__.return_value,
-    )
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
 
 
+@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
 @pytest.mark.asyncio
-async def test_download_short_filename_no_change(minio_adapter, session):
-    minio_adapter.minio.fget_object = AsyncMock(return_value="test.txt")
+async def test_download_short_filename_no_change(minio_adapter, populate_bucket):
     result = await minio_adapter.download_file(
         "test.txt", local_dir="/tmp/foo", shorten_filename=True
     )
     assert str(result).endswith("test.txt")
-    minio_adapter.minio.fget_object.assert_called_with(
-        bucket_name="bucket",
-        file_path="/tmp/foo/test.txt",
-        object_name="test.txt",
-        session=session.return_value.__aenter__.return_value,
-    )
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
 
 
+@pytest.mark.parametrize(
+    "populate_bucket",
+    [
+        "test12345678901234567890123456789012345678901234567898012345678901234567890.txt"  # noqa: E501
+    ],
+    indirect=True,
+)
 @pytest.mark.asyncio
-async def test_download_short_filename_change(minio_adapter, session):
-    minio_adapter.minio.fget_object = AsyncMock(
-        return_value="test12345678901234567890123456789012345678901234567898012345678901234567890.txt"  # noqa: E501
-    )
+async def test_download_short_filename_change(minio_adapter, populate_bucket):
     result = await minio_adapter.download_file(
-        "test123456789012345678901234567890k12345678901234567898012345678901234567890.txt",
+        "test12345678901234567890123456789012345678901234567898012345678901234567890.txt",
         local_dir="/tmp/foo",
         shorten_filename=True,
     )
@@ -129,39 +153,24 @@ async def test_download_short_filename_change(minio_adapter, session):
     assert str(result).endswith("01234567890.txt")
 
     # Make sure the length is right
-    assert len(Path(result).name) == 60
+    assert len(result.name) == 60
 
-    # Make sure we did the right call
-    minio_adapter.minio.fget_object.assert_called_with(
-        bucket_name="bucket",
-        file_path="/tmp/foo/_7405534c58a3f71e5d01cdd2f59356bda6f50a06678901234567890.txt",
-        object_name="test123456789012345678901234567890k12345678901234567898012345678901234567890.txt",  # noqa: E501
-        session=session.return_value.__aenter__.return_value,
-    )
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
 
 
+@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
 @pytest.mark.asyncio
-async def test_download_file_retry(minio_adapter, session):
-    minio_adapter.minio.fget_object = AsyncMock(side_effect=[None, "test.txt"])
+async def test_download_file_retry(download_patch, minio_adapter, populate_bucket):
     result = await minio_adapter.download_file("test.txt", local_dir="/tmp/foo")
     assert str(result).endswith("test.txt")
-    assert session.call_args.kwargs["timeout"].total == 600
-    assert len(minio_adapter.minio.fget_object.call_args_list) == 2
-    minio_adapter.minio.fget_object.assert_called_with(
-        bucket_name="bucket",
-        file_path="/tmp/foo/test.txt",
-        object_name="test.txt",
-        session=session.return_value.__aenter__.return_value,
-    )
+    assert result.exists()
+    assert len(download_patch.call_args_list) == 3
+    result.unlink()
 
 
 @pytest.mark.asyncio
-async def test_get_signed_url(minio_adapter):
-    minio_adapter.minio.get_presigned_url = AsyncMock(
-        return_value="https://pre-signed.me"
-    )
+async def test_get_signed_url(minio_adapter, moto_services):
     result = await minio_adapter.get_signed_url("test.txt")
-    assert result == "https://pre-signed.me"
-    minio_adapter.minio.get_presigned_url.assert_called_with(
-        bucket_name="bucket", method="GET", object_name="test.txt"
-    )
+    assert result.startswith(moto_services["s3"])


### PR DESCRIPTION
Fixes #571 . `aioboto3` has better built-in error detection and retry support than `minio`.
Merge after #573 