### PR TITLE
Use semaphore to limit concurrent downloads in non-CLI client

### DIFF
--- a/servicex/minio_adapter.py
+++ b/servicex/minio_adapter.py
@@ -127,7 +127,6 @@ class MinioAdapter:
                     # maybe move to a better verification mechanism with e-tags in the future
                     localsize = path.stat().st_size
                     if localsize == remotesize:
-                        print(f"skipping {localsize} {remotesize}")
                         return path.resolve()
                 _ = await self.minio.fget_object(
                     bucket_name=self.bucket,

--- a/servicex/minio_adapter.py
+++ b/servicex/minio_adapter.py
@@ -135,7 +135,7 @@ class MinioAdapter:
                     file_path=path.as_posix(),
                     session=session,
                 )
-                localsize = path.stat().st_size
+                localsize = path.stat().st_size if _ is not None else 0
                 if _ is None or localsize != remotesize:
                     raise RuntimeError(f"Download of {object_name} failed")
         return path.resolve()

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, IRIS-HEP
+# Copyright (c) 2022-2025, IRIS-HEP
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -228,6 +228,7 @@ def deliver(
     fail_if_incomplete: bool = True,
     ignore_local_cache: bool = False,
     progress_bar: ProgressBarFormat = ProgressBarFormat.default,
+    concurrency: int = 8,
 ):
     r"""
     Execute a ServiceX query.
@@ -249,9 +250,13 @@ def deliver(
             will have its own progress bars; :py:const:`ProgressBarFormat.compact` gives one
             summary progress bar for all transformations; :py:const:`ProgressBarFormat.none`
             switches off progress bars completely.
+    :param concurrency: specify how many downloads to run in parallel (default is 8).
     :return: A dictionary mapping the name of each :py:class:`Sample` to a :py:class:`.GuardList`
             with the file names or URLs for the outputs.
     """
+    from .minio_adapter import init_download_semaphore
+
+    init_download_semaphore(concurrency)
     config = _load_ServiceXSpec(spec)
 
     if ignore_local_cache or config.General.IgnoreLocalCache:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -222,3 +222,9 @@ def codegen_list():
         "uproot": "http://servicex-code-gen-uproot:8000",
         "uproot-raw": "http://servicex-code-gen-uproot-raw:8000",
     }
+
+
+# This exists to force an async event loop to be created
+@fixture
+async def with_event_loop():
+    pass

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -286,7 +286,7 @@ def test_invalid_dataset_identifier():
         )
 
 
-def test_submit_mapping(transformed_result, codegen_list):
+def test_submit_mapping(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
 
     spec = {
@@ -316,7 +316,9 @@ def test_submit_mapping(transformed_result, codegen_list):
         assert list(results["sampleA"]) == ["1.parquet"]
 
 
-def test_submit_mapping_signed_urls(transformed_result_signed_url, codegen_list):
+def test_submit_mapping_signed_urls(
+    transformed_result_signed_url, codegen_list, with_event_loop
+):
     from servicex import deliver
 
     spec = {
@@ -347,7 +349,7 @@ def test_submit_mapping_signed_urls(transformed_result_signed_url, codegen_list)
         ]
 
 
-def test_submit_mapping_failure(transformed_result, codegen_list):
+def test_submit_mapping_failure(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
 
     spec = {
@@ -378,7 +380,7 @@ def test_submit_mapping_failure(transformed_result, codegen_list):
                 pass
 
 
-def test_submit_mapping_failure_signed_urls(codegen_list):
+def test_submit_mapping_failure_signed_urls(codegen_list, with_event_loop):
     from servicex import deliver
 
     spec = {
@@ -634,7 +636,7 @@ Sample:
         _load_ServiceXSpec(path2)
 
 
-def test_funcadl_query(transformed_result, codegen_list):
+def test_funcadl_query(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import FuncADL_Uproot  # type: ignore
 
@@ -664,7 +666,7 @@ def test_funcadl_query(transformed_result, codegen_list):
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_query_with_codegen_override(transformed_result, codegen_list):
+def test_query_with_codegen_override(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import FuncADL_Uproot  # type: ignore
 
@@ -748,7 +750,7 @@ def test_databinder_load_dict():
     )
 
 
-def test_python_query(transformed_result, codegen_list):
+def test_python_query(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import PythonFunction  # type: ignore
 
@@ -782,7 +784,7 @@ def test_python_query(transformed_result, codegen_list):
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_uproot_raw_query(transformed_result, codegen_list):
+def test_uproot_raw_query(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import UprootRaw  # type: ignore
 
@@ -810,7 +812,7 @@ def test_uproot_raw_query(transformed_result, codegen_list):
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_uproot_raw_query_parquet(transformed_result, codegen_list):
+def test_uproot_raw_query_parquet(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver
     from servicex.query import UprootRaw  # type: ignore
 
@@ -897,7 +899,7 @@ def test_generic_query(codegen_list):
             )
 
 
-def test_deliver_progress_options(transformed_result, codegen_list):
+def test_deliver_progress_options(transformed_result, codegen_list, with_event_loop):
     from servicex import deliver, ProgressBarFormat
     from servicex.query import UprootRaw  # type: ignore
 


### PR DESCRIPTION
By default, only run 8 downloads at once in a session (can be overridden with an argument to `deliver`).