### PR TITLE
Upgrade local download concurrency control to use aioboto3's built-in handling

### DIFF
--- a/servicex/minio_adapter.py
+++ b/servicex/minio_adapter.py
@@ -40,7 +40,7 @@ from servicex.models import ResultFile, TransformStatus
 _transferconfig = TransferConfig(max_concurrency=10)
 
 
-def init_download_semaphore(concurrency: int = 10):
+def init_s3_config(concurrency: int = 10):
     "Update the number of concurrent connections"
     global _transferconfig
     _transferconfig = TransferConfig(max_concurrency=concurrency)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -228,7 +228,7 @@ def deliver(
     fail_if_incomplete: bool = True,
     ignore_local_cache: bool = False,
     progress_bar: ProgressBarFormat = ProgressBarFormat.default,
-    concurrency: int = 8,
+    concurrency: int = 10,
 ):
     r"""
     Execute a ServiceX query.

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -254,9 +254,9 @@ def deliver(
     :return: A dictionary mapping the name of each :py:class:`Sample` to a :py:class:`.GuardList`
             with the file names or URLs for the outputs.
     """
-    from .minio_adapter import init_download_semaphore
+    from .minio_adapter import init_s3_config
 
-    init_download_semaphore(concurrency)
+    init_s3_config(concurrency)
     config = _load_ServiceXSpec(spec)
 
     if ignore_local_cache or config.General.IgnoreLocalCache:

--- a/tests/test_minio_adapter.py
+++ b/tests/test_minio_adapter.py
@@ -162,6 +162,25 @@ async def test_download_short_filename_change(minio_adapter, populate_bucket):
 
 @pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
 @pytest.mark.asyncio
+async def test_download_repeat(minio_adapter, populate_bucket):
+    import asyncio
+
+    print(await minio_adapter.list_bucket())
+    result = await minio_adapter.download_file("test.txt", local_dir="/tmp/foo")
+    assert str(result).endswith("test.txt")
+    assert result.exists()
+    t0 = result.stat().st_mtime_ns
+    await asyncio.sleep(4)  # hopefully long enough for Windows/FAT32 ... ?
+
+    result2 = await minio_adapter.download_file("test.txt", local_dir="/tmp/foo")
+    assert result2.exists()
+    assert result2 == result
+    assert t0 == result2.stat().st_mtime_ns
+    result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
+@pytest.mark.asyncio
 async def test_download_file_retry(download_patch, minio_adapter, populate_bucket):
     result = await minio_adapter.download_file("test.txt", local_dir="/tmp/foo")
     assert str(result).endswith("test.txt")
@@ -174,25 +193,3 @@ async def test_download_file_retry(download_patch, minio_adapter, populate_bucke
 async def test_get_signed_url(minio_adapter, moto_services):
     result = await minio_adapter.get_signed_url("test.txt")
     assert result.startswith(moto_services["s3"])
-
-
-@pytest.mark.parametrize("populate_bucket", ["testn.txt"], indirect=True)
-@pytest.mark.asyncio
-async def test_download_repeat(minio_adapter, populate_bucket):
-    import asyncio
-
-    result = await minio_adapter.download_file(
-        "testn.txt", local_dir="/tmp/foo", shorten_filename=True
-    )
-    assert str(result).endswith("testn.txt")
-    assert result.exists()
-    t0 = result.stat().st_mtime_ns
-    await asyncio.sleep(4)  # hopefully long enough for Windows/FAT32 ... ?
-
-    result2 = await minio_adapter.download_file(
-        "testn.txt", local_dir="/tmp/foo", shorten_filename=True
-    )
-    assert result2.exists()
-    assert result2 == result
-    assert t0 == result2.stat().st_mtime_ns
-    result.unlink()  # it should exist, from above ...

--- a/tests/test_minio_adapter.py
+++ b/tests/test_minio_adapter.py
@@ -174,3 +174,25 @@ async def test_download_file_retry(download_patch, minio_adapter, populate_bucke
 async def test_get_signed_url(minio_adapter, moto_services):
     result = await minio_adapter.get_signed_url("test.txt")
     assert result.startswith(moto_services["s3"])
+
+
+@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
+@pytest.mark.asyncio
+async def test_download_repeat(minio_adapter, populate_bucket):
+    import asyncio
+
+    result = await minio_adapter.download_file(
+        "test.txt", local_dir="/tmp/foo", shorten_filename=True
+    )
+    assert str(result).endswith("test.txt")
+    assert result.exists()
+    t0 = result.stat().st_mtime_ns
+    await asyncio.sleep(4)  # hopefully long enough for Windows/FAT32 ... ?
+
+    result2 = await minio_adapter.download_file(
+        "test.txt", local_dir="/tmp/foo", shorten_filename=True
+    )
+    assert result2.exists()
+    assert result2 == result
+    assert t0 == result2.stat().st_mtime_ns
+    result.unlink()  # it should exist, from above ...

--- a/tests/test_minio_adapter.py
+++ b/tests/test_minio_adapter.py
@@ -176,21 +176,21 @@ async def test_get_signed_url(minio_adapter, moto_services):
     assert result.startswith(moto_services["s3"])
 
 
-@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
+@pytest.mark.parametrize("populate_bucket", ["testn.txt"], indirect=True)
 @pytest.mark.asyncio
 async def test_download_repeat(minio_adapter, populate_bucket):
     import asyncio
 
     result = await minio_adapter.download_file(
-        "test.txt", local_dir="/tmp/foo", shorten_filename=True
+        "testn.txt", local_dir="/tmp/foo", shorten_filename=True
     )
-    assert str(result).endswith("test.txt")
+    assert str(result).endswith("testn.txt")
     assert result.exists()
     t0 = result.stat().st_mtime_ns
     await asyncio.sleep(4)  # hopefully long enough for Windows/FAT32 ... ?
 
     result2 = await minio_adapter.download_file(
-        "test.txt", local_dir="/tmp/foo", shorten_filename=True
+        "testn.txt", local_dir="/tmp/foo", shorten_filename=True
     )
     assert result2.exists()
     assert result2 == result


### PR DESCRIPTION
Replace #573 by using the native concurrency handling of the boto3 libraries. Up the default concurrency to 10 (matches the default in the library).