### PR TITLE
Adding steps to pypi workflow - bot commit version bump

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -43,8 +43,8 @@ jobs:
 
     - name: Update Version
       run: |
-        sed -i '/version =/ s/= "[^"][^"]*"/ = "${{ env.RELEASE_VERSION }}"/' pyproject.toml
-
+        sed -i "/version =/ s/= \"[^\"]*\"/= \"${{ env.RELEASE_VERSION }}\"/" pyproject.toml
+        
     - name: commit version-bump
       run: |
         git config --local user.name "github-actions[bot]"

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -14,7 +14,7 @@ jobs:
       contents: write # required to push with GITHUB_TOKEN
     env:
       BRANCH: ${{ github.event.release.target_commitish }}
-      
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -44,7 +44,7 @@ jobs:
     - name: Update Version
       run: |
         sed -i "/version =/ s/= \"[^\"]*\"/= \"${{ env.RELEASE_VERSION }}\"/" pyproject.toml
-        
+
     - name: commit version-bump
       run: |
         git config --local user.name "github-actions[bot]"

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -11,6 +11,7 @@ jobs:
     # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
     permissions:
       id-token: write
+      contents: write # required to push with GITHUB_TOKEN
 
     steps:
     - uses: actions/checkout@v4
@@ -41,6 +42,26 @@ jobs:
     - name: Update Version
       run: |
         sed -i '/version =/ s/= "[^"][^"]*"/ = "${{ env.RELEASE_VERSION }}"/' pyproject.toml
+
+    - name: commit version-bump
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git add ./pyproject.toml
+
+        # Check if there are changes to commit
+        if ! git diff --cached --quiet; then
+          echo "Changes detected, committing..."
+          git commit -m "Update version to ${{ env.RELEASE_VERSION }}" --no-verify
+        else
+          echo "No changes to commit"
+        fi
+
+    - name: Push commit
+      # GITHUB_TOKEN is automatically provided
+      run: |
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        git push origin HEAD:$BRANCH
 
     - name: Build a sdist and wheel
       run: |

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -12,7 +12,9 @@ jobs:
     permissions:
       id-token: write
       contents: write # required to push with GITHUB_TOKEN
-
+    env:
+      BRANCH: ${{ github.event.release.target_commitish }}
+      
     steps:
     - uses: actions/checkout@v4
       with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version  = "3.0.1-alpha-1"
+version = "3.0.1-alpha-1"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.1.1-alpha.1"
+version  = "3.0.1-alpha-1"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.1.0.alpha.001"
+version = "3.1.1"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.0.1-alpha-1"
+version = "3.1.0.alpha.001"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier


### PR DESCRIPTION
I added a couple of steps in `pypi.yml` to commit the version bump when a release is created.

I also changed the version tag replacement using `sed`. 
There was an extra white space being introduced. This would cause the reggex search to fail on the next release event.

This should fix the doc building issue (currently showing the wrong release tag) automaticaly for next releases. 
This garantees `pyproject.toml` in master is consistent with the distributed package tag. 

I also manualy set the version to 3.1.1 since that release is published. 

--------------------------------------------------------------------------------

Tested with pre-releases on the feat/version-bump-gha branch, and the github bot correctly comits the version bump. 