### PR TITLE
Adding section to analysis utils package

### DIFF
--- a/docs/analysis_tools.md
+++ b/docs/analysis_tools.md
@@ -12,4 +12,3 @@ $ pip install servicex-analysis-utils
 ## Analysis utils documentation
 
 A documentation of the available tools with example usages can be found in [readthedocs](https://servicex-analysis-utils.readthedocs.io/en/latest/index.html#)
-

--- a/docs/analysis_tools.md
+++ b/docs/analysis_tools.md
@@ -1,0 +1,15 @@
+# Analysis utilities
+
+An additional package provides tools interacting with the ServiceX client: [ServiceX Analysis Utils](https://github.com/ssl-hep/ServiceX_analysis_utils). The Analysis Utils package offers helper functions that streamline the usage of ServiceX and simplify its integration on workflows. It also contains specific use case tools that take advantage from the ServiceX data extraction system.
+
+## Instalation
+
+The extra package can be installed with:
+
+```bash
+$ pip install servicex-analysis-utils
+```
+## Analysis utils documentation
+
+A documentation of the available tools with example usages can be found in [readthedocs](https://servicex-analysis-utils.readthedocs.io/en/latest/index.html#)
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@ re-running queries that have already been executed.
    errors
    yaml
    command_line
+   analysis_tools
    contribute
    about
    modules


### PR DESCRIPTION
Added a section to the documentation about the parallel package with extra tools. 

The section does not go into details and points to the GH repo and the documentation.

I investigated the functionalities of the `intersphinx` extension. They could be useful if the second package grows and information has to be added more extensively to the client's doc. For now just pointing to links is enough. 

I placed this section after the CLI module. 