### PR TITLE
Add back concurrency semaphore

### DIFF
--- a/servicex/minio_adapter.py
+++ b/servicex/minio_adapter.py
@@ -99,7 +99,7 @@ class MinioAdapter:
                         size=_["Size"],
                         extension=_["Key"].split(".")[-1],
                     )
-                    for _ in listing["Contents"]
+                    for _ in listing.get("Contents", [])
                     if not _["Key"].endswith("/")
                 ]
                 return rv

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -533,9 +533,13 @@ class Query:
             progress: Progress,
             download_progress: TaskID,
             shorten_filename: bool = False,
+            expected_size: Optional[int] = None,
         ):
             downloaded_filename = await minio.download_file(
-                filename, self.download_path, shorten_filename=shorten_filename
+                filename,
+                self.download_path,
+                shorten_filename=shorten_filename,
+                expected_size=expected_size,
             )
             result_uris.append(downloaded_filename.as_posix())
             progress.advance(task_id=download_progress, task_type="Download")
@@ -580,6 +584,7 @@ class Query:
                                             progress,
                                             download_progress,
                                             shorten_filename=self.configuration.shortened_downloaded_filename,  # NOQA: E501
+                                            expected_size=file.size,
                                         )
                                     )
                                 )  # NOQA 501

--- a/tests/app/test_datasets.py
+++ b/tests/app/test_datasets.py
@@ -64,7 +64,6 @@ def dataset():
     return cached_dataset
 
 
-@pytest.mark.asyncio
 def test_datasets_list(script_runner, dataset):
     with patch("servicex.app.datasets.ServiceXClient") as mock_servicex:
         mock_get_datasets = AsyncMock(return_value=[dataset])

--- a/tests/test_minio_adapter.py
+++ b/tests/test_minio_adapter.py
@@ -112,6 +112,19 @@ async def test_download_file(minio_adapter, populate_bucket):
     result.unlink()  # it should exist, from above ...
 
 
+@pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
+@pytest.mark.asyncio
+async def test_download_file_with_expected_size(minio_adapter, populate_bucket):
+    info = await minio_adapter.list_bucket()
+    result = await minio_adapter.download_file(
+        "test.txt", local_dir="/tmp/foo", expected_size=info[0].size
+    )
+    assert str(result).endswith("test.txt")
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
+
+
 @pytest.mark.parametrize("populate_bucket", ["t::est.txt"], indirect=True)
 @pytest.mark.asyncio
 async def test_download_bad_filename(minio_adapter, populate_bucket):

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -216,7 +216,7 @@ async def test_submit(mocker):
     mock_minio = AsyncMock()
     mock_minio.list_bucket = AsyncMock(side_effect=[[file1], [file1, file2]])
     mock_minio.download_file = AsyncMock(
-        side_effect=lambda a, _, shorten_filename: PurePath(a)
+        side_effect=lambda a, _, shorten_filename, expected_size: PurePath(a)
     )
 
     mock_cache = mocker.MagicMock(QueryCache)
@@ -260,7 +260,7 @@ async def test_submit_partial_success(mocker):
     mock_minio = AsyncMock()
     mock_minio.list_bucket = AsyncMock(side_effect=[[file1], [file1]])
     mock_minio.download_file = AsyncMock(
-        side_effect=lambda a, _, shorten_filename: PurePath(a)
+        side_effect=lambda a, _, shorten_filename, expected_size: PurePath(a)
     )
 
     mock_cache = mocker.MagicMock(QueryCache)
@@ -303,7 +303,7 @@ async def test_use_of_cache(mocker):
     mock_minio = AsyncMock()
     mock_minio.list_bucket = AsyncMock(return_value=[file1, file2])
     mock_minio.download_file = AsyncMock(
-        side_effect=lambda a, _, shorten_filename: PurePath(a)
+        side_effect=lambda a, _, shorten_filename, expected_size: PurePath(a)
     )
     mock_minio.get_signed_url = AsyncMock(side_effect=["http://file1", "http://file2"])
 


### PR DESCRIPTION
I had misunderstood the concurrency limit in the boto3 configuration as a global limit, but it is only a limit on the number of parallel downloads for each individual download request. Therefore we could still be spawning a huge number of simultaneous S3 connections.

This PR puts semaphores back to limit the number of distinct simultaneous connections. It also tries to reduce the total number of connections made:
* it reuses metadata obtained in the bucket listing,
* it uses a lower level part of the library that means that fewer requests are made.

The new magic numbers are
* maximum 5 simultaneous bucket listings
* maximum 10 distinct files being downloaded simultaneously (configurable)
* maximum 5 download streams per file (internal boto configuration)