### PR TITLE
Patch for cases where the bearer token has no expiration

### DIFF
--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -106,16 +106,16 @@ async def test_get_transforms_wlcg_bearer_token(
     )
     token_file.close()
 
-    os.environ["BEARER_TOKEN_FILE"] = token_file.name
+    with patch.dict(os.environ, {"BEARER_TOKEN_FILE": token_file.name}, clear=True):
+        print(os.environ)
 
-    # Try with an expired token
-    with pytest.raises(AuthorizationError) as err:
-        decode.return_value = {"exp": 0.0}
-        await servicex.get_transforms()
-        assert "ServiceX access token request rejected:" in str(err.value)
+        # Try with an expired token
+        with pytest.raises(AuthorizationError) as err:
+            decode.return_value = {"exp": 0.0}
+            await servicex.get_transforms()
+            assert "ServiceX access token request rejected:" in str(err.value)
 
     os.remove(token_file.name)
-    del os.environ["BEARER_TOKEN_FILE"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -107,7 +107,6 @@ async def test_get_transforms_wlcg_bearer_token(
     token_file.close()
 
     with patch.dict(os.environ, {"BEARER_TOKEN_FILE": token_file.name}, clear=True):
-        print(os.environ)
 
         # Try with an expired token
         with pytest.raises(AuthorizationError) as err:


### PR DESCRIPTION
Code assumed an "exp" field was available in JWT bearer tokens. While this is good practice it is not mandatory. Handle this edge case.