### PR TITLE
Fix CI for astral-sh/setup-uv 6

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --system --upgrade '.[test,docs]'
+          uv venv
+          uv pip install --upgrade '.[test,docs]'
           uv pip list
 
       - name: Test with pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,8 @@ jobs:
 
       - name: Test with pytest
         run: |
-          coverage run --source servicex/ -m pytest tests
-          coverage xml
+          uv run coverage run --source servicex/ -m pytest tests
+          uv run coverage xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv pip install --upgrade '.[test,docs]'
+          uv pip install --system --upgrade '.[test,docs]'
           uv pip list
 
       - name: Test with pytest


### PR DESCRIPTION
Use a venv for uv package installation instead of using the system installation.