### PR TITLE
Fail on authentication tokens without expiration

### DIFF
--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -106,16 +106,18 @@ async def test_get_transforms_wlcg_bearer_token(
     )
     token_file.close()
 
-    os.environ["BEARER_TOKEN_FILE"] = token_file.name
+    with patch.dict(os.environ, {"BEARER_TOKEN_FILE": token_file.name}, clear=True):
+        # Try with no expiration at all
+        with pytest.raises(RuntimeError):
+            await servicex.get_transforms()
 
-    # Try with an expired token
-    with pytest.raises(AuthorizationError) as err:
-        decode.return_value = {"exp": 0.0}
-        await servicex.get_transforms()
-        assert "ServiceX access token request rejected:" in str(err.value)
+        # Try with an expired token
+        with pytest.raises(AuthorizationError) as err:
+            decode.return_value = {"exp": 0.0}
+            await servicex.get_transforms()
+            assert "ServiceX access token request rejected:" in str(err.value)
 
     os.remove(token_file.name)
-    del os.environ["BEARER_TOKEN_FILE"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
After consulting some site experts, we do not expect anyone to deploy tokens with no expiration. Raise an error if such a token is encountered.