### PR TITLE
Documentation and client support for changes to the uproot-raw axis default

### DIFF
--- a/servicex/uproot_raw/uproot_raw.py
+++ b/servicex/uproot_raw/uproot_raw.py
@@ -56,6 +56,8 @@ class TreeSubQuery(DocStringBaseModel):
     """Define aliases to use in computation and expressions"""
     fail_on_missing_trees: Optional[bool] = None
     """Make queries fail if input trees are missing (default False)"""
+    use_standard_awkward_axis: Optional[bool] = None
+    """Do not override standard axis default arguments in awkward expressions (default False)"""
 
 
 class CopyHistogramSubQuery(DocStringBaseModel):


### PR DESCRIPTION
Documentation and a smal tweak for client support for https://github.com/ssl-hep/ServiceX/pull/1054 .