### PR TITLE
add pyproject hatch test environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,10 @@ dynamic_context = "test_function"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+
+[tool.hatch.envs.test]
+features = ["test"]
+
+[tool.hatch.envs.test.scripts]
+test = "pytest {args}"
+cov = "pytest --cov=servicex {args}"


### PR DESCRIPTION
We are currently using `hatch` as a build system.

This change allows the user to execute tests in an isolated environment directly from the command line:
```
hatch run test:test
```

The old way, where test packages are only set as optional dependencies, requires the user to manually set the environments packages prior to executing tests:
```
# install test dependencies
pip install -e ".[test]"
hatch run python -m pytest
# uninstall test dependencies
pip install -e .
```