### PR TITLE
Revert the commit of version to pyproject.toml

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -45,26 +45,6 @@ jobs:
       run: |
         sed -i "/version =/ s/= \"[^\"]*\"/= \"${{ env.RELEASE_VERSION }}\"/" pyproject.toml
 
-    - name: commit version-bump
-      run: |
-        git config --local user.name "github-actions[bot]"
-        git config --local user.email "github-actions[bot]@users.noreply.github.com"
-        git add ./pyproject.toml
-
-        # Check if there are changes to commit
-        if ! git diff --cached --quiet; then
-          echo "Changes detected, committing..."
-          git commit -m "Update version to ${{ env.RELEASE_VERSION }}" --no-verify
-        else
-          echo "No changes to commit"
-        fi
-
-    - name: Push commit
-      # GITHUB_TOKEN is automatically provided
-      run: |
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-        git push origin HEAD:$BRANCH
-
     - name: Build a sdist and wheel
       run: |
         python -m build .


### PR DESCRIPTION
This is causing a failure in the build since branch protection rules prevent a direct push to master branch.

Reverting this for now and need to investigate a way to make this work with the branch protection bypass rules