### PR TITLE
Determine sample name length limit from server capability

### DIFF
--- a/servicex/databinder_models.py
+++ b/servicex/databinder_models.py
@@ -143,17 +143,22 @@ class Sample(DocStringBaseModel):
             raise ValueError("NFiles cannot be set to zero for a dataset.")
         return self
 
-    @field_validator("Name", mode="before")
-    @classmethod
-    def truncate_long_sample_name(cls, v):
+    def validate_title(self, length: int) -> None:
         """
-        Truncate sample name to 512 characters if exceed
-        Print warning message
+        Logic for adjusting length of the title
         """
-        if len(v) > 512:
-            logger.warning(f"Truncating Sample name to 512 characters for {v}")
-            v = v[0:512]
-        return v
+        if length is None:
+            # we adopt pre-3.2.0 behavior: truncate to 128 characters
+            if len(self.Name) > 128:
+                logger.warning(
+                    f"Truncating Sample name to 128 characters for {self.Name}"
+                )
+                self.Name = self.Name[:128]
+                logger.warning(f"New name is {self.Name}")
+        else:
+            if len(self.Name) > length:
+                logger.error(f"Sample name {self.Name} over the limit ({length})")
+                raise ValueError(f"Sample name {self.Name} length too long")
 
     @property
     def hash(self):

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -79,6 +79,7 @@ class ServiceXAdapter:
 
         # interact with _servicex_info via get_servicex_info
         self._servicex_info: Optional[ServiceXInfo] = None
+        self._sample_title_limit: Optional[int] = None
 
     async def _get_token(self):
         url = f"{self.url}/token/refresh"
@@ -161,6 +162,22 @@ class ServiceXAdapter:
 
     async def get_servicex_capabilities(self) -> List[str]:
         return (await self.get_servicex_info()).capabilities
+
+    async def get_servicex_sample_title_limit(self) -> Optional[int]:
+        # check if the capability is defined
+        capabilities = await self.get_servicex_capabilities()
+        for capability in capabilities:
+            if capability.startswith("long_sample_titles_"):
+                try:
+                    # hope capability is of the form long_sample_titles_NNNN
+                    return int(capability[19:])
+                except ValueError:
+                    raise RuntimeError(
+                        "Unable to determine allowed sample title length\n"
+                        f"Server capability is: {capability}"
+                    )
+
+        return None
 
     async def get_transforms(self) -> List[TransformStatus]:
         headers = await self._get_authorization()

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -183,7 +183,9 @@ def _build_datasets(config, config_path, servicex_name, fail_if_incomplete):
 
     sx = ServiceXClient(backend=servicex_name, config_path=config_path)
     datasets = []
+    title_length_limit = make_sync(sx.servicex.get_servicex_sample_title_limit)()
     for sample in config.Sample:
+        sample.validate_title(title_length_limit)
         query = sx.generic_query(
             dataset_identifier=sample.dataset_identifier,
             title=sample.Name,


### PR DESCRIPTION
Release 3.2.0 will not protect against submissions of too long sample names to pre-1.7.0 servers. Use a proper mechanism to determine whether the server should be able to handle long names.