### PR TITLE
Document codegen CLI options

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -30,7 +30,17 @@ Provide the path to the configuration file as an argument to the command.
 codegens
 ~~~~~~~~
 
-This command will list the code generators deployed.
+Commands that interact with code generators deployed on a backend.
+
+list
+^^^^
+
+List the available code generators for the selected backend.
+
+flush
+^^^^^
+
+Clear any cached code generator information for the selected backend.
 
 transforms
 ~~~~~~~~~~


### PR DESCRIPTION
## Summary
- document both `list` and `flush` subcommands in CLI docs
- explain that `flush` clears cached code generator data

## Testing
- `make -C docs html`

------
https://chatgpt.com/codex/tasks/task_e_6872679b43788320a7379247937197a5