### PR TITLE
Fix codegen flush uses resolved backend

### DIFF
--- a/servicex/app/codegen.py
+++ b/servicex/app/codegen.py
@@ -46,7 +46,9 @@ def flush(
     """
     sx = ServiceXClient(backend=backend, config_path=config_path)
     cache = sx.query_cache
-    cache.delete_codegen_by_backend(backend)
+    # Use the backend resolved by the ServiceXClient so that the
+    # configured default is respected when no backend option is given.
+    cache.delete_codegen_by_backend(sx.backend)
     rich.print("Deleted cached code generators.")
 
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -334,6 +334,10 @@ class ServiceXClient:
                 # Take the first endpoint from servicex.yaml if default_endpoint is not set
                 backend = self.config.api_endpoints[0].name
 
+        # Record the backend that will actually be used so callers can
+        # determine it even when not explicitly specified.
+        self.backend = backend
+
         if bool(url) == bool(backend):
             raise ValueError("Only specify backend or url... not both")
 

--- a/tests/app/test_codegen.py
+++ b/tests/app/test_codegen.py
@@ -58,3 +58,24 @@ def test_codegen_flush(script_runner):
         )
         assert result.returncode == 0
         p.assert_called_once_with("localhost")
+
+
+def test_codegen_flush_default_backend(script_runner, codegen_list):
+    """Ensure the flush command uses the configured default backend when
+    none is specified on the command line."""
+    with patch(
+        "servicex.servicex_client.ServiceXClient.get_code_generators",
+        return_value=codegen_list,
+    ):
+        with patch("servicex.query_cache.QueryCache.delete_codegen_by_backend") as p:
+            result = script_runner.run(
+                [
+                    "servicex",
+                    "codegen",
+                    "flush",
+                    "-c",
+                    "tests/example_config_default_endpoint.yaml",
+                ]
+            )
+            assert result.returncode == 0
+            p.assert_called_once_with("servicex-uc-af")


### PR DESCRIPTION
Update so that `servicex codegetn flush` uses the default backend name resolution used by the rest of `servicex`. This also prevents the silent behavior of command previously if you left off `-b <backend`.

## Summary
- maintain resolved backend name inside `ServiceXClient`
- use that backend for `servicex codegen flush`
- add regression test for default backend flush

## Notes

- The `backend` uses the internal client backend resolution - but if a `url` is specified instead, this might still be `None`. I'm not familiar enough with how the `url` is used to know what to do there.
- Anothe option is to require `-b` in the command line.
- And print an INFO message what backend's codegen was actually flushed.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687268c2b26083209d70544ae44ddb70