### PR TITLE
Avoid trying to interpret cached transformations in the SUBMITTED state

### DIFF
--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -197,7 +197,9 @@ class QueryCache:
         with self.lock:
             result = [
                 TransformedResults(**doc)
-                for doc in self.db.search(transforms.request_id.exists())
+                for doc in self.db.search(
+                    transforms.request_id.exists() & ~(transforms.status == "SUBMITTED")
+                )
             ]
         return result
 

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -325,6 +325,9 @@ def test_get_transform_request_id(transform_request, completed_status):
         request_id = cache.get_transform_request_id(hash_value)
         assert request_id == "123456"
 
+        # assert that in this state that cached_queries does NOT crash and returns nothing
+        assert len(cache.cached_queries()) == 0
+
         cache.close()
 
 


### PR DESCRIPTION
If `servicex cache list` is called while jobs are listed in the cache in the SUBMITTED state, it will crash since the stored documents are not proper `TransformedResults`. Exclude these requests from the list.