### PR TITLE
Search home dir for ServiceX config

### DIFF
--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -143,4 +143,18 @@ class Configuration(BaseModel):
 
             dir = dir.parent
 
+        # If nothing was found walking up the directory tree, look in the user's
+        # home directory as a final fallback. This mirrors the behaviour
+        # documented for the search path.
+        if config is None and not path:
+            home = Path.home()
+            # Look first for `.servicex` and then for `servicex.yaml` just as we
+            # did in the directory walk above.
+            for cfg_name in [name, alt_name] if alt_name else [name]:
+                f = home / cfg_name
+                if f.exists():
+                    with open(f) as config_file:
+                        config = yaml.safe_load(config_file)
+                    break
+
         return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
+from pathlib import Path
 from unittest.mock import patch
 import pytest
 
@@ -66,3 +67,28 @@ def test_default_cache_path(tempdir):
     c = Configuration.read(config_path="tests/example_config_no_cache_path.yaml")
     assert c.cache_path == "mytemp/servicex_p_higgs"
     del os.environ["USER"]
+
+
+def test_read_from_home(monkeypatch, tmp_path):
+    """Ensure configuration can be located in the user's home directory."""
+
+    # Create a fake home directory with a servicex.yaml file
+    home = tmp_path / "home"
+    home.mkdir()
+    cfg = home / "servicex.yaml"
+    cfg.write_text(
+        """
+api_endpoints:
+  - endpoint: http://localhost:5000
+    name: localhost
+"""
+    )
+
+    # Patch Path.home to point to our fake home and move cwd elsewhere
+    monkeypatch.setattr(Path, "home", lambda: home)
+    work = tmp_path / "work"
+    work.mkdir()
+    monkeypatch.chdir(work)
+
+    c = Configuration.read()
+    assert c.api_endpoints[0].endpoint == "http://localhost:5000"


### PR DESCRIPTION
## Summary
- fall back to user home directory when loading `servicex.yaml`
- test that configuration is found in the home directory

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_6874520d4f608320bc733590ccf62e5c