### PR TITLE
Better handoff to async code

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -41,6 +41,7 @@ from tenacity import (
     wait_fixed,
     retry_if_not_exception_type,
 )
+from make_it_sync import make_sync
 
 from servicex.models import (
     TransformRequest,
@@ -199,8 +200,10 @@ class ServiceXAdapter:
             statuses = [TransformStatus(**status) for status in o["requests"]]
             return statuses
 
-    async def get_code_generators(self) -> dict[str, str]:
+    async def get_code_generators_async(self) -> dict[str, str]:
         return (await self.get_servicex_info()).code_gen_image
+
+    get_code_generators = make_sync(get_code_generators_async)
 
     async def get_datasets(
         self, did_finder=None, show_deleted=False

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -276,7 +276,9 @@ async def deliver_async(
         for sample in config.Sample:
             sample.IgnoreLocalCache = True
 
-    datasets = await _build_datasets(config, config_path, servicex_name, fail_if_incomplete)
+    datasets = await _build_datasets(
+        config, config_path, servicex_name, fail_if_incomplete
+    )
 
     group = DatasetGroup(datasets)
 
@@ -291,14 +293,14 @@ async def deliver_async(
 
     if config.General.Delivery == General.DeliveryEnum.URLs:
         results = await group.as_signed_urls_async(
-                return_exceptions=return_exceptions, **progress_options
-            )
+            return_exceptions=return_exceptions, **progress_options
+        )
         return _output_handler(config, datasets, results)
 
     elif config.General.Delivery == General.DeliveryEnum.LocalCache:
         results = await group.as_files_async(
-                return_exceptions=return_exceptions, **progress_options
-            )
+            return_exceptions=return_exceptions, **progress_options
+        )
         return _output_handler(config, datasets, results)
 
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -123,10 +123,7 @@ class GuardList(Sequence):
 def _async_execute_and_wait(coro: Coroutine) -> Any:
     import asyncio
 
-    try:
-        return asyncio.create_task(coro).result()
-    except RuntimeError:
-        return asyncio.run(coro)
+    return asyncio.run(coro)
 
 
 def _load_ServiceXSpec(
@@ -170,7 +167,7 @@ def _load_ServiceXSpec(
     return config
 
 
-def _build_datasets(config, config_path, servicex_name, fail_if_incomplete):
+async def _build_datasets(config, config_path, servicex_name, fail_if_incomplete):
     def get_codegen(_sample: Sample, _general: General):
         if _sample.Codegen is not None:
             return _sample.Codegen
@@ -182,8 +179,8 @@ def _build_datasets(config, config_path, servicex_name, fail_if_incomplete):
             return _sample.Query.codegen
 
     sx = ServiceXClient(backend=servicex_name, config_path=config_path)
+    title_length_limit = await sx.servicex.get_servicex_sample_title_limit()
     datasets = []
-    title_length_limit = make_sync(sx.servicex.get_servicex_sample_title_limit)()
     for sample in config.Sample:
         sample.validate_title(title_length_limit)
         query = sx.generic_query(
@@ -236,7 +233,7 @@ def _output_handler(
     return out_dict
 
 
-def deliver(
+async def deliver_async(
     spec: Union[ServiceXSpec, Mapping[str, Any], str, Path],
     config_path: Optional[str] = None,
     servicex_name: Optional[str] = None,
@@ -279,7 +276,7 @@ def deliver(
         for sample in config.Sample:
             sample.IgnoreLocalCache = True
 
-    datasets = _build_datasets(config, config_path, servicex_name, fail_if_incomplete)
+    datasets = await _build_datasets(config, config_path, servicex_name, fail_if_incomplete)
 
     group = DatasetGroup(datasets)
 
@@ -293,16 +290,19 @@ def deliver(
         raise ValueError(f"Invalid value {progress_bar} for progress_bar provided")
 
     if config.General.Delivery == General.DeliveryEnum.URLs:
-        results = group.as_signed_urls(
-            return_exceptions=return_exceptions, **progress_options
-        )
+        results = await group.as_signed_urls_async(
+                return_exceptions=return_exceptions, **progress_options
+            )
         return _output_handler(config, datasets, results)
 
     elif config.General.Delivery == General.DeliveryEnum.LocalCache:
-        results = group.as_files(
-            return_exceptions=return_exceptions, **progress_options
-        )
+        results = await group.as_files_async(
+                return_exceptions=return_exceptions, **progress_options
+            )
         return _output_handler(config, datasets, results)
+
+
+deliver = make_sync(deliver_async)
 
 
 class ServiceXClient:
@@ -348,7 +348,7 @@ class ServiceXClient:
             )
 
         self.query_cache = QueryCache(self.config)
-        self.code_generators = set(self.get_code_generators().keys())
+        self.code_generators = self.get_code_generators()
 
     async def get_transforms_async(self) -> List[TransformStatus]:
         r"""
@@ -409,7 +409,7 @@ class ServiceXClient:
         Retrieve the code generators deployed with the serviceX instance
         :return:  The list of code generators as json dictionary
         """
-        return _async_execute_and_wait(self.servicex.get_code_generators())
+        return self.servicex.get_code_generators()
 
     def generic_query(
         self,

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -25,7 +25,13 @@ def network_patches(codegen_list):
         )
         _fixture.enter_context(
             patch(
-                "servicex.servicex_client.ServiceXClient.get_code_generators",
+                "servicex.servicex_adapter.ServiceXAdapter.get_code_generators_async",
+                return_value=codegen_list,
+            )
+        )
+        _fixture.enter_context(
+            patch(
+                "servicex.servicex_adapter.ServiceXAdapter.get_code_generators",
                 return_value=codegen_list,
             )
         )
@@ -341,7 +347,7 @@ def test_submit_mapping(transformed_result, network_patches, with_event_loop):
         ],
     }
     with patch(
-        "servicex.dataset_group.DatasetGroup.as_files",
+        "servicex.dataset_group.DatasetGroup.as_files_async",
         return_value=[transformed_result],
     ):
         results = deliver(spec, config_path="tests/example_config.yaml")
@@ -365,7 +371,7 @@ def test_submit_mapping_signed_urls(
         ],
     }
     with patch(
-        "servicex.dataset_group.DatasetGroup.as_signed_urls",
+        "servicex.dataset_group.DatasetGroup.as_signed_urls_async",
         return_value=[transformed_result_signed_url],
     ):
         results = deliver(spec, config_path="tests/example_config.yaml")
@@ -389,7 +395,7 @@ def test_submit_mapping_failure(transformed_result, network_patches, with_event_
         ]
     }
     with patch(
-        "servicex.dataset_group.DatasetGroup.as_files",
+        "servicex.dataset_group.DatasetGroup.as_files_async",
         return_value=[ServiceXException("dummy")],
     ):
         results = deliver(spec, config_path="tests/example_config.yaml")
@@ -415,7 +421,7 @@ def test_submit_mapping_failure_signed_urls(network_patches, with_event_loop):
         ],
     }
     with patch(
-        "servicex.dataset_group.DatasetGroup.as_signed_urls",
+        "servicex.dataset_group.DatasetGroup.as_signed_urls_async",
         return_value=[ServiceXException("dummy")],
     ):
         results = deliver(
@@ -849,7 +855,7 @@ def test_uproot_raw_query_rntuple(transformed_result, network_patches, with_even
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_generic_query(network_patches):
+async def test_generic_query(network_patches):
     from servicex.servicex_client import ServiceXClient
 
     spec = ServiceXSpec.model_validate(

--- a/tests/test_default_endpoint.py
+++ b/tests/test_default_endpoint.py
@@ -3,18 +3,18 @@ from unittest.mock import patch
 from servicex.servicex_client import ServiceXClient
 
 
-def test_default_endpoint(codegen_list):
+async def test_default_endpoint(codegen_list):
     with patch(
-        "servicex.servicex_client.ServiceXClient.get_code_generators",
+        "servicex.servicex_adapter.ServiceXAdapter.get_code_generators",
         return_value=codegen_list,
     ):
         sx = ServiceXClient(config_path="tests/example_config.yaml")
         assert sx.servicex.url == "http://localhost:5000"
 
 
-def test_first_endpoint(codegen_list):
+async def test_first_endpoint(codegen_list):
     with patch(
-        "servicex.servicex_client.ServiceXClient.get_code_generators",
+        "servicex.servicex_adapter.ServiceXAdapter.get_code_generators",
         return_value=codegen_list,
     ):
         sx = ServiceXClient(config_path="tests/example_config_default_endpoint.yaml")

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -175,7 +175,7 @@ async def test_get_codegens(get, servicex):
             "capabilities": [],
         },
     )
-    c = await servicex.get_code_generators()
+    c = await servicex.get_code_generators_async()
     assert len(c) == 2
     assert c["uproot"] == "http://uproot-codegen"
 

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -593,7 +593,7 @@ async def test_submit_generic(mocker, codegen_list):
     mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
     did = FileListDataset("/foo/bar/baz.root")
     with patch(
-        "servicex.servicex_client.ServiceXClient.get_code_generators",
+        "servicex.servicex_adapter.ServiceXAdapter.get_code_generators",
         return_value=codegen_list,
     ):
         client = ServiceXClient(
@@ -641,7 +641,7 @@ async def test_submit_cancelled(mocker, codegen_list):
     mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
     did = FileListDataset("/foo/bar/baz.root")
     with patch(
-        "servicex.servicex_client.ServiceXClient.get_code_generators",
+        "servicex.servicex_adapter.ServiceXAdapter.get_code_generators",
         return_value=codegen_list,
     ):
         client = ServiceXClient(


### PR DESCRIPTION
It seems that `make_sync` can have bad interactions with other code that sets up event loops and should really only be used for top-level interfaces. Change a couple of places to use async versions of functions, run via `asyncio`.

This is needed to fix the failures in the production tests.