### PR TITLE
Extend fake token validity

### DIFF
--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -686,7 +686,7 @@ async def test_get_authorization_no_token_no_refresh(servicex, monkeypatch):
 
 
 @pytest.mark.asyncio
-@patch("servicex.servicex_adapter.jwt.decode", return_value={"exp": time.time() + 120})
+@patch("servicex.servicex_adapter.jwt.decode", return_value={"exp": time.time() + 600})
 async def test_get_authorization_with_valid_token(decode, servicex):
     servicex.token = "tok123"
     headers = await servicex._get_authorization()


### PR DESCRIPTION
One test would occasionally fail because the token "validity time" was set up when the module was imported, and by the time the test was actually executed the validity interval might have passed. Extend the interval so as to make this much less likely.