### PR TITLE
Add config file info to backend errors

### DIFF
--- a/servicex/configuration.py
+++ b/servicex/configuration.py
@@ -100,7 +100,9 @@ class Configuration(BaseModel):
         :return: Populated configuration object
         """
         if config_path:
-            yaml_config, cfg_path = cls._add_from_path(Path(config_path), walk_up_tree=False)
+            yaml_config, cfg_path = cls._add_from_path(
+                Path(config_path), walk_up_tree=False
+            )
         else:
             yaml_config, cfg_path = cls._add_from_path(walk_up_tree=True)
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -342,8 +342,9 @@ class ServiceXClient:
         elif backend:
             if backend not in self.endpoints:
                 valid_backends = ", ".join(self.endpoints.keys())
+                cfg_file = self.config.config_file or ".servicex"
                 raise ValueError(
-                    f"Backend {backend} not defined in .servicex file. "
+                    f"Backend {backend} not defined in {cfg_file} file. "
                     f"Valid backend names: {valid_backends}"
                 )
             self.servicex = ServiceXAdapter(

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -138,3 +139,13 @@ def test_delete_transform_from_cache(mock_cache, servicex_adaptor, transformed_r
             mock_cache.return_value.delete_record_by_request_id.assert_called_once_with(
                 "servicex-request-789"
             )
+
+
+def test_invalid_backend_raises_error_with_filename():
+    config_file = "tests/example_config.yaml"
+    expected = Path(config_file).resolve()
+
+    with pytest.raises(ValueError) as err:
+        ServiceXClient(backend="badname", config_path=config_file)
+
+    assert f"Backend badname not defined in {expected} file" in str(err.value)


### PR DESCRIPTION
## Summary
- track which config file was loaded
- include the used config file in backend error messages
- test backend error message shows the correct file

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877ecf578bc8320b88307c5788a5094