### PR TITLE
Add tracking of submitted transforms

### DIFF
--- a/docs/command_line.rst
+++ b/docs/command_line.rst
@@ -77,7 +77,8 @@ list
 ^^^^
 
 Show all of the cached transforms along with the run time, code
-generator, and number of resulting files
+generator, and number of resulting files. Pending submissions are
+also listed with the run date and file count shown as ``Pending``.
 
 delete
 ^^^^^^

--- a/servicex/app/cache.py
+++ b/servicex/app/cache.py
@@ -62,6 +62,7 @@ def list():
     table.add_column("Files")
     table.add_column("Format")
     runs = cache.cached_queries()
+    pending = cache.submitted_queries()
     for r in runs:
         table.add_row(
             r.title,
@@ -70,6 +71,15 @@ def list():
             r.submit_time.astimezone().strftime("%a, %Y-%m-%d %H:%M"),
             str(r.files),
             r.result_format,
+        )
+    for r in pending:
+        table.add_row(
+            r.get("title", ""),
+            r.get("codegen", ""),
+            r.get("request_id", ""),
+            "Pending",
+            "Pending",
+            str(r.get("result_format", "")),
         )
     rich.print(table)
 

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -325,8 +325,7 @@ class Query:
                 self.request_id = self.cache.get_transform_request_id(sx_request_hash)
             else:
                 self.request_id = await self.servicex.submit_transform(sx_request)
-                self.cache.update_transform_request_id(sx_request_hash, self.request_id)
-                self.cache.update_transform_status(sx_request_hash, "SUBMITTED")
+                self.cache.cache_submitted_transform(sx_request, self.request_id)
 
             monitor_task = loop.create_task(
                 self.transform_status_listener(

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -321,7 +321,7 @@ async def test_submit_and_download_cache_miss(python_dataset, completed_status):
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
-        python_dataset.cache.update_transform_request_id = Mock()
+        python_dataset.cache.cache_submitted_transform = Mock()
 
         signed_urls_only = False
         expandable_progress = ExpandableProgress()
@@ -354,7 +354,7 @@ async def test_submit_and_download_cache_miss_overall_progress(
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
-        python_dataset.cache.update_transform_request_id = Mock()
+        python_dataset.cache.cache_submitted_transform = Mock()
 
         signed_urls_only = False
         expandable_progress = ExpandableProgress(overall_progress=True)
@@ -423,7 +423,7 @@ async def test_submit_and_download_cache_miss_signed_urls_only(
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
         python_dataset.download_files.return_value = []
-        python_dataset.cache.update_transform_request_id = Mock()
+        python_dataset.cache.cache_submitted_transform = Mock()
 
         signed_urls_only = True
         expandable_progress = ExpandableProgress()


### PR DESCRIPTION
## Summary
- record submitted transform metadata with `cache_submitted_transform`
- return submitted queries from `submitted_queries`
- use new cache API when submitting transforms
- list pending requests in the CLI cache table
- document that `cache list` shows submitted queries

## Testing
- `flake8 servicex/query_cache.py servicex/query_core.py servicex/app/cache.py tests/test_dataset.py tests/test_query_cache.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791d01353483208e71471198f5c3ca