### PR TITLE
Improve query argument type error message

### DIFF
--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -442,6 +442,9 @@ class ServiceXClient:
 
         """
 
+        if query is None:
+            raise ValueError("query argument cannot be None")
+
         if isinstance(query, str):
             if codegen is None:
                 raise RuntimeError(
@@ -449,7 +452,10 @@ class ServiceXClient:
                 )
             query = GenericQueryStringGenerator(query, codegen)
         if not isinstance(query, QueryStringGenerator):
-            raise ValueError("query argument must be string or QueryStringGenerator")
+            raise ValueError(
+                "query argument must be string or QueryStringGenerator, not "
+                f"{type(query).__name__}"
+            )
 
         real_codegen = codegen if codegen is not None else query.default_codegen
         if real_codegen is None:

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -889,11 +889,17 @@ async def test_generic_query(network_patches):
     query.query_string_generator = None
     with pytest.raises(RuntimeError):
         query.generate_selection_string()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="not int"):
         query = sx.generic_query(
             dataset_identifier=spec.Sample[0].RucioDID,
             codegen=spec.General.Codegen,
             query=5,
+        )
+    with pytest.raises(ValueError, match="cannot be None"):
+        query = sx.generic_query(
+            dataset_identifier=spec.Sample[0].RucioDID,
+            codegen=spec.General.Codegen,
+            query=None,
         )
     with pytest.raises(NameError):
         query = sx.generic_query(


### PR DESCRIPTION
Very minor error message update - clarifies what has gone wrong when a `query` isn't in an expected format to give the user a little more information to understand what mistake they made.

## Summary
- clarify query argument type errors by including the received type in the message
- test generic_query error output
- explicitly reject `None` for query arguments

------
https://chatgpt.com/codex/tasks/task_e_689ba4c36e3c8320941bca450427fb4f