### PR TITLE
Defer code generator validation until transform submission

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/ci_production.yaml
+++ b/.github/workflows/ci_production.yaml
@@ -11,10 +11,10 @@ jobs:
     environment: production-service
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,12 +20,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -49,7 +49,7 @@ jobs:
         done
 
     - name: Upload artifact
-      uses: actions/upload-pages-artifact@v3
+      uses: actions/upload-pages-artifact@v4
       with:
         path: 'docs/_build/html'
 

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -84,6 +84,6 @@ jobs:
 
     - name: Publish distribution 📦 to PyPI
       if: github.repository == 'ssl-hep/ServiceX_frontend'
-      uses: pypa/gh-action-pypi-publish@v1.12.4
+      uses: pypa/gh-action-pypi-publish@v1.13.0
       with:
         print-hash: true

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -15,13 +15,13 @@ jobs:
       BRANCH: ${{ github.event.release.target_commitish }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
         ssh-key: ${{ secrets.DEPLOY_KEY }}
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: "v5.0.0"
+    rev: "v6.0.0"
     hooks:
       - id: check-case-conflict
       - id: check-merge-conflict
@@ -15,7 +15,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 25.9.0
     hooks:
       -   id: black
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.2.2test"
+version = "0.0.1a"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.2.2"
+version = "3.2.2test"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ test = [
     "pyarrow>=12.0.0",
     "pre-commit>=4.0.1",
     "pytest-aioboto3>=0.6.0",
+    "coverage>=7.0.0",
 ]
 docs = [
     "sphinx>=7.0.1, <8.2.0",
@@ -124,14 +125,20 @@ include = [
 packages = ["servicex"]
 
 [tool.coverage.run]
-dynamic_context = "test_function"
+source = ["servicex"]
+omit = [
+    "*/tests/*",
+    "*/test_*",
+]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+testpaths = ["tests"]
 
 [tool.hatch.envs.test]
 features = ["test"]
 
 [tool.hatch.envs.test.scripts]
 test = "pytest {args}"
-cov = "pytest --cov=servicex {args}"
+cov = "coverage run --source servicex/ -m pytest tests && coverage report"
+cov-html = "coverage run --source servicex/ -m pytest tests && coverage html"

--- a/servicex/app/cache.py
+++ b/servicex/app/cache.py
@@ -29,10 +29,28 @@ import shutil
 
 import rich
 import typer
+from pathlib import Path
 from rich.prompt import Confirm
+from typing import List
 
 from servicex.app import pipeable_table
+from servicex.models import TransformedResults
 from servicex.servicex_client import ServiceXClient
+
+
+def _format_size(size_bytes: int) -> str:
+    """Return human readable string for size in bytes."""
+    if size_bytes >= 1024**4:
+        size = size_bytes / (1024**4)
+        unit = "TB"
+    elif size_bytes >= 1024**3:
+        size = size_bytes / (1024**3)
+        unit = "GB"
+    else:
+        size = size_bytes / (1024**2)
+        unit = "MB"
+    return f"{size:,.2f} {unit}"
+
 
 cache_app = typer.Typer(name="cache", no_args_is_help=True)
 force_opt = typer.Option(False, "-y", help="Force, don't ask for permission")
@@ -48,7 +66,9 @@ def cache():
 
 
 @cache_app.command()
-def list():
+def list(
+    show_size: bool = typer.Option(False, "--size", help="Include size of cached files")
+) -> None:
     """
     List the cached queries
     """
@@ -61,16 +81,26 @@ def list():
     table.add_column("Run Date")
     table.add_column("Files")
     table.add_column("Format")
-    runs = cache.cached_queries()
+    if show_size:
+        table.add_column("Size")
+
+    runs: List[TransformedResults] = cache.cached_queries()
     for r in runs:
-        table.add_row(
+        row = [
             r.title,
             r.codegen,
             r.request_id,
             r.submit_time.astimezone().strftime("%a, %Y-%m-%d %H:%M"),
             str(r.files),
             r.result_format,
-        )
+        ]
+        if show_size:
+            total_size: int = sum(
+                Path(f).stat().st_size for f in r.file_list if Path(f).exists()
+            )
+            # Convert to human readable string, keeping two decimal places
+            row.append(_format_size(total_size))
+        table.add_row(*row)
     rich.print(table)
 
 

--- a/servicex/app/codegen.py
+++ b/servicex/app/codegen.py
@@ -36,6 +36,12 @@ from typing import Optional
 codegen_app = typer.Typer(name="codegen", no_args_is_help=True)
 
 
+@codegen_app.callback()
+def codegen() -> None:
+    """Sub-commands for interacting with available backend code generators."""
+    pass
+
+
 @codegen_app.command(no_args_is_help=False)
 def list(
     backend: Optional[str] = backend_cli_option,

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -40,6 +40,14 @@ from servicex.models import CachedDataset
 from rich.table import Table
 
 datasets_app = typer.Typer(name="datasets", no_args_is_help=True)
+
+
+@datasets_app.callback()
+def datasets() -> None:
+    """Sub-commands for interacting with the list of looked-up datasets on the server."""
+    pass
+
+
 did_finder_opt = typer.Option(
     None,
     help="Filter datasets by DID finder. Some useful values are 'rucio' or 'user'",
@@ -66,7 +74,9 @@ def list(
     show_deleted: Optional[bool] = show_deleted_opt,
 ) -> None:
     """
-    List the datasets. Use fancy formatting if printing to a terminal.
+    List the datasets on the server.
+
+    Use fancy formatting if printing to a terminal.
     Output as plain text if redirected.
     """
     sx = ServiceXClient(backend=backend, config_path=config_path)
@@ -97,6 +107,7 @@ def list(
             )
 
         datasets = [dataset for dataset in datasets if matches_pattern(dataset)]
+    assert show_deleted is not None
 
     for d in datasets:
         # Format the CachedDataset object into a table row
@@ -140,7 +151,11 @@ def get(
     dataset_id: int = dataset_id_get_arg,
 ):
     """
-    Get the details of a dataset. Output as a pretty, nested table if printing to a terminal.
+    List the files in a dataset.
+
+    Known replicas on the GRID are listed.
+
+    Output as a pretty, nested table if printing to a terminal.
     Output as json if redirected.
     """
     sx = ServiceXClient(backend=backend, config_path=config_path)
@@ -183,6 +198,12 @@ def delete(
     config_path: Optional[str] = config_file_option,
     dataset_ids: List[int] = dataset_ids_delete_arg,
 ):
+    """
+    Remove a dataset from the ServiceX.
+
+    The next time it is queried, it will have to be looked up again. This command should only be
+    used when debugging.
+    """
     sx = ServiceXClient(backend=backend, config_path=config_path)
     any_missing: bool = False  # Track if any dataset ID is not found
     for dataset_id in dataset_ids:

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -107,11 +107,25 @@ def list(
         d_name = d.name if d.did_finder != "user" else "File list"
         is_stale = "Yes" if d.is_stale else ""
         last_used = d.last_used.strftime("%Y-%m-%dT%H:%M:%S")
+
+        # Convert byte size into a human-readable string with appropriate units
+        size_in_bytes = d.size
+        if size_in_bytes >= 1e12:
+            size_value = size_in_bytes / 1e12
+            unit = "TB"
+        elif size_in_bytes >= 1e9:
+            size_value = size_in_bytes / 1e9
+            unit = "GB"
+        else:
+            size_value = size_in_bytes / 1e6
+            unit = "MB"
+        size_str = f"{size_value:,.2f} {unit}"
+
         table.add_row(
             str(d.id),
             d_name,
-            "%d" % d.n_files,
-            "{:,}MB".format(round(d.size / 1e6)),
+            f"{d.n_files}",
+            size_str,
             d.lookup_status,
             last_used,
             is_stale,

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -25,7 +25,8 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from typing import Optional
+from fnmatch import fnmatch
+from typing import List, Optional
 
 import rich
 
@@ -35,6 +36,7 @@ from servicex.app.cli_options import backend_cli_option, config_file_option
 import typer
 
 from servicex.servicex_client import ServiceXClient
+from servicex.models import CachedDataset
 from rich.table import Table
 
 datasets_app = typer.Typer(name="datasets", no_args_is_help=True)
@@ -54,11 +56,15 @@ dataset_id_delete_arg = typer.Argument(..., help="The ID of the dataset to delet
 
 @datasets_app.command(no_args_is_help=False)
 def list(
+    name_pattern: Optional[str] = typer.Argument(
+        None,
+        help="Filter datasets by name. Use '*' as a wildcard for any number of characters.",
+    ),
     backend: Optional[str] = backend_cli_option,
     config_path: Optional[str] = config_file_option,
     did_finder: Optional[str] = did_finder_opt,
     show_deleted: Optional[bool] = show_deleted_opt,
-):
+) -> None:
     """
     List the datasets. Use fancy formatting if printing to a terminal.
     Output as plain text if redirected.
@@ -74,7 +80,23 @@ def list(
     if show_deleted:
         table.add_column("Deleted")
 
-    datasets = sx.get_datasets(did_finder=did_finder, show_deleted=show_deleted)
+    datasets: List[CachedDataset] = sx.get_datasets(
+        did_finder=did_finder, show_deleted=show_deleted
+    )
+
+    if name_pattern:
+        # Allow substring matching when no wildcard is provided by surrounding the pattern
+        # with '*' characters. Users can still provide wildcards explicitly to narrow the match.
+        effective_pattern = name_pattern if "*" in name_pattern else f"*{name_pattern}*"
+
+        def matches_pattern(dataset: CachedDataset) -> bool:
+            display_name = dataset.name if dataset.did_finder != "user" else "File list"
+            return any(
+                fnmatch(candidate, effective_pattern)
+                for candidate in {dataset.name, display_name}
+            )
+
+        datasets = [dataset for dataset in datasets if matches_pattern(dataset)]
 
     for d in datasets:
         # Format the CachedDataset object into a table row

--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -51,7 +51,7 @@ show_deleted_opt = typer.Option(
     show_default=True,
 )
 dataset_id_get_arg = typer.Argument(..., help="The ID of the dataset to get")
-dataset_id_delete_arg = typer.Argument(..., help="The ID of the dataset to delete")
+dataset_ids_delete_arg = typer.Argument(..., help="IDs of the datasets to delete")
 
 
 @datasets_app.command(no_args_is_help=False)
@@ -181,12 +181,16 @@ def get(
 def delete(
     backend: Optional[str] = backend_cli_option,
     config_path: Optional[str] = config_file_option,
-    dataset_id: int = dataset_id_delete_arg,
+    dataset_ids: List[int] = dataset_ids_delete_arg,
 ):
     sx = ServiceXClient(backend=backend, config_path=config_path)
-    result = sx.delete_dataset(dataset_id)
-    if result:
-        typer.echo(f"Dataset {dataset_id} deleted")
-    else:
-        typer.echo(f"Dataset {dataset_id} not found")
+    any_missing: bool = False  # Track if any dataset ID is not found
+    for dataset_id in dataset_ids:
+        result = sx.delete_dataset(dataset_id)
+        if result:
+            typer.echo(f"Dataset {dataset_id} deleted")
+        else:
+            typer.echo(f"Dataset {dataset_id} not found")
+            any_missing = True
+    if any_missing:
         raise typer.Abort()

--- a/servicex/app/main.py
+++ b/servicex/app/main.py
@@ -49,6 +49,11 @@ spec_file_arg = typer.Argument(..., help="Spec file to submit to serviceX")
 ignore_cache_opt = typer.Option(
     None, "--ignore-cache", help="Ignore local cache and always submit to ServiceX"
 )
+hide_results_opt = typer.Option(
+    False,
+    "--hide-results",
+    help="Exclude printing results to the console",
+)
 
 
 def show_version(show: bool):
@@ -75,19 +80,20 @@ def deliver(
     config_path: Optional[str] = config_file_option,
     spec_file: str = spec_file_arg,
     ignore_cache: Optional[bool] = ignore_cache_opt,
+    hide_results: bool = hide_results_opt,
 ):
     """
     Deliver a file to the ServiceX cache.
     """
 
     print(f"Delivering {spec_file} to ServiceX cache")
-    results = servicex_client.deliver(
+    servicex_client.deliver(
         spec_file,
         servicex_name=backend,
         config_path=config_path,
         ignore_local_cache=ignore_cache,
+        display_results=not hide_results,
     )
-    rich.print(results)
 
 
 if __name__ == "__main__":

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -320,6 +320,19 @@ class Query:
         )
 
         if not cached_record:
+            # Validate the requested code generator only when we are about to
+            # submit a new transform. This avoids a network call when a cached
+            # transform is used.
+            supported_codegens = await self.servicex.get_code_generators_async()
+            if self.codegen not in supported_codegens:
+                # Include available code generators to guide user when an
+                # unsupported one is requested.
+                available_codegens = ", ".join(sorted(supported_codegens))
+                raise NameError(
+                    f"{self.codegen} code generator not supported by serviceX "
+                    f"deployment at {self.servicex.url}. Supported code generators are: "
+                    f"{available_codegens}"
+                )
 
             if self.cache.is_transform_request_submitted(sx_request_hash):
                 self.request_id = self.cache.get_transform_request_id(sx_request_hash)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -52,6 +52,7 @@ from servicex.databinder_models import ServiceXSpec, General, Sample
 from collections.abc import Sequence, Coroutine
 from enum import Enum
 import traceback
+from rich.table import Table
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
@@ -233,6 +234,58 @@ def _output_handler(
     return out_dict
 
 
+def _get_progress_options(progress_bar: ProgressBarFormat) -> dict:
+    """Get progress options based on progress bar format."""
+    if progress_bar == ProgressBarFormat.expanded:
+        return {}
+    elif progress_bar == ProgressBarFormat.compact:
+        return {"overall_progress": True}
+    elif progress_bar == ProgressBarFormat.none:
+        return {"display_progress": False}
+    else:
+        raise ValueError(f"Invalid value {progress_bar} for progress_bar provided")
+
+
+def _display_results(out_dict):
+    """Display the delivery results using rich styling."""
+    from rich import get_console
+
+    console = get_console()
+
+    console.print("\n[bold green]✓ ServiceX Delivery Complete![/bold green]\n")
+
+    table = Table(
+        title="Delivered Files", show_header=True, header_style="bold magenta"
+    )
+    table.add_column("Sample", style="cyan", no_wrap=True)
+    table.add_column("File Count", justify="right", style="green")
+    table.add_column("Files", style="dim")
+
+    total_files = 0
+    for sample_name, files in out_dict.items():
+        if isinstance(files, GuardList) and files.valid():
+            file_list = list(files)
+            file_count = len(file_list)
+            total_files += file_count
+
+            # Show first few files with ellipsis if many
+            if file_count <= 3:
+                files_display = "\n".join(str(f) for f in file_list)
+            else:
+                files_display = "\n".join(str(f) for f in file_list[:2])
+                files_display += f"\n... and {file_count - 2} more files"
+
+            table.add_row(sample_name, str(file_count), files_display)
+        else:
+            # Handle error case
+            table.add_row(
+                sample_name, "[red]Error[/red]", "[red]Failed to retrieve files[/red]"
+            )
+
+    console.print(table)
+    console.print(f"\n[bold blue]Total files delivered: {total_files}[/bold blue]\n")
+
+
 async def deliver_async(
     spec: Union[ServiceXSpec, Mapping[str, Any], str, Path],
     config_path: Optional[str] = None,
@@ -241,6 +294,7 @@ async def deliver_async(
     fail_if_incomplete: bool = True,
     ignore_local_cache: bool = False,
     progress_bar: ProgressBarFormat = ProgressBarFormat.default,
+    display_results: bool = True,
     concurrency: int = 10,
 ):
     r"""
@@ -263,6 +317,8 @@ async def deliver_async(
             will have its own progress bars; :py:const:`ProgressBarFormat.compact` gives one
             summary progress bar for all transformations; :py:const:`ProgressBarFormat.none`
             switches off progress bars completely.
+    :param display_results: Specifies whether the results should be displayed to the console.
+            Defaults to True.
     :param concurrency: specify how many downloads to run in parallel (default is 8).
     :return: A dictionary mapping the name of each :py:class:`Sample` to a :py:class:`.GuardList`
             with the file names or URLs for the outputs.
@@ -282,26 +338,32 @@ async def deliver_async(
 
     group = DatasetGroup(datasets)
 
-    if progress_bar == ProgressBarFormat.expanded:
-        progress_options = {}
-    elif progress_bar == ProgressBarFormat.compact:
-        progress_options = {"overall_progress": True}
-    elif progress_bar == ProgressBarFormat.none:
-        progress_options = {"display_progress": False}
-    else:
-        raise ValueError(f"Invalid value {progress_bar} for progress_bar provided")
+    progress_options = _get_progress_options(progress_bar)
+
+    if config.General.Delivery not in [
+        General.DeliveryEnum.URLs,
+        General.DeliveryEnum.LocalCache,
+    ]:
+        raise ValueError(
+            f"unexpected value for config.general.Delivery: {config.General.Delivery}"
+        )
 
     if config.General.Delivery == General.DeliveryEnum.URLs:
         results = await group.as_signed_urls_async(
             return_exceptions=return_exceptions, **progress_options
         )
-        return _output_handler(config, datasets, results)
 
-    elif config.General.Delivery == General.DeliveryEnum.LocalCache:
+    else:
         results = await group.as_files_async(
             return_exceptions=return_exceptions, **progress_options
         )
-        return _output_handler(config, datasets, results)
+
+    output_dict = _output_handler(config, datasets, results)
+
+    if display_results:
+        _display_results(output_dict)
+
+    return output_dict
 
 
 deliver = make_sync(deliver_async)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -442,6 +442,9 @@ class ServiceXClient:
 
         """
 
+        if query is None:
+            raise ValueError("query argument cannot be None")
+
         if isinstance(query, str):
             if codegen is None:
                 raise RuntimeError(
@@ -449,7 +452,10 @@ class ServiceXClient:
                 )
             query = GenericQueryStringGenerator(query, codegen)
         if not isinstance(query, QueryStringGenerator):
-            raise ValueError("query argument must be string or QueryStringGenerator")
+            raise ValueError(
+                "query argument must be string or QueryStringGenerator, not "
+                f"{type(query).__name__}"
+            )
 
         real_codegen = codegen if codegen is not None else query.default_codegen
         if real_codegen is None:

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -25,6 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
 from unittest.mock import Mock, patch
 
 
@@ -45,6 +46,31 @@ def test_deliver(script_runner):
         assert result.returncode == 0
         result_rows = result.stdout.split("\n")
         assert result_rows[0] == "Delivering foo.yaml to ServiceX cache"
-        assert (
-            result_rows[1] == "{'UprootRaw_YAML': ['/tmp/foo.root', '/tmp/bar.root']}"
+        mock_servicex_client.deliver.assert_called_once_with(
+            "foo.yaml",
+            servicex_name=None,
+            config_path=None,
+            ignore_local_cache=None,
+            display_results=True,
+        )
+
+
+def test_deliver_hide_results(script_runner):
+    with patch("servicex.app.main.servicex_client") as mock_servicex_client:
+        mock_servicex_client.deliver = Mock(
+            return_value={"UprootRaw_YAML": ["/tmp/foo.root", "/tmp/bar.root"]}
+        )
+        result = script_runner.run(
+            ["servicex", "deliver", "foo.yaml", "--hide-results"]
+        )
+        assert result.returncode == 0
+        result_rows = result.stdout.split("\n")
+        assert result_rows[0] == "Delivering foo.yaml to ServiceX cache"
+        # Verify that servicex_client.deliver was called with display_results=False
+        mock_servicex_client.deliver.assert_called_once_with(
+            "foo.yaml",
+            servicex_name=None,
+            config_path=None,
+            ignore_local_cache=None,
+            display_results=False,
         )

--- a/tests/app/test_cache.py
+++ b/tests/app/test_cache.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2022, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from datetime import datetime, timezone
+import os
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from servicex.models import ResultFormat, TransformedResults
+
+
+def test_cache_list_size(script_runner, tmp_path) -> None:
+    dummy_file: Path = tmp_path / "data.parquet"
+    dummy_file.write_bytes(b"0" * (5 * 1024 * 1024))
+
+    record = TransformedResults(
+        hash="hash",
+        title="Test",
+        codegen="code",
+        request_id="id",
+        submit_time=datetime.now(timezone.utc),
+        data_dir=str(tmp_path),
+        file_list=[str(dummy_file)],
+        signed_url_list=[],
+        files=1,
+        result_format=ResultFormat.parquet,
+    )
+
+    with patch("servicex.app.cache.ServiceXClient") as mock_servicex:
+        cache_mock = Mock()
+        cache_mock.cached_queries.return_value = [record]
+        mock_servicex.return_value.query_cache = cache_mock
+        result = script_runner.run(["servicex", "cache", "list", "--size"])
+
+    assert result.returncode == 0
+    expected_size: float = os.path.getsize(dummy_file) / (1024 * 1024)
+    result_row = result.stdout.split("  ")
+    assert len(result_row) == 7
+    assert result_row[-1].strip() == f"{expected_size:,.2f} MB"
+
+
+def test_cache_list_without_size(script_runner, tmp_path) -> None:
+    dummy_file: Path = tmp_path / "data.parquet"
+    dummy_file.write_bytes(b"0" * (5 * 1024 * 1024))
+
+    record = TransformedResults(
+        hash="hash",
+        title="Test",
+        codegen="code",
+        request_id="id",
+        submit_time=datetime.now(timezone.utc),
+        data_dir=str(tmp_path),
+        file_list=[str(dummy_file)],
+        signed_url_list=[],
+        files=1,
+        result_format=ResultFormat.parquet,
+    )
+
+    with patch("servicex.app.cache.ServiceXClient") as mock_servicex:
+        cache_mock = Mock()
+        cache_mock.cached_queries.return_value = [record]
+        mock_servicex.return_value.query_cache = cache_mock
+        result = script_runner.run(["servicex", "cache", "list"])
+
+    assert result.returncode == 0
+    result_row = result.stdout.split("  ")
+    # Without the --size option, the output should have only six columns
+    assert len(result_row) == 6
+
+
+def test_cache_list_size_gb(script_runner, tmp_path) -> None:
+    dummy_file: Path = tmp_path / "data.parquet"
+    dummy_file.write_bytes(b"0")
+
+    record = TransformedResults(
+        hash="hash",
+        title="Test",
+        codegen="code",
+        request_id="id",
+        submit_time=datetime.now(timezone.utc),
+        data_dir=str(tmp_path),
+        file_list=[str(dummy_file)],
+        signed_url_list=[],
+        files=1,
+        result_format=ResultFormat.parquet,
+    )
+
+    size_bytes: int = 2 * 1024**3
+    with (
+        patch("servicex.app.cache.ServiceXClient") as mock_servicex,
+        patch(
+            "servicex.app.cache.Path.stat",
+            return_value=Mock(st_size=size_bytes),
+        ),
+    ):
+        cache_mock = Mock()
+        cache_mock.cached_queries.return_value = [record]
+        mock_servicex.return_value.query_cache = cache_mock
+        result = script_runner.run(["servicex", "cache", "list", "--size"])
+
+    assert result.returncode == 0
+    result_row = result.stdout.split("  ")
+    assert result_row[-1].strip() == "2.00 GB"
+
+
+def test_cache_list_size_tb(script_runner, tmp_path) -> None:
+    dummy_file: Path = tmp_path / "data.parquet"
+    dummy_file.write_bytes(b"0")
+
+    record = TransformedResults(
+        hash="hash",
+        title="Test",
+        codegen="code",
+        request_id="id",
+        submit_time=datetime.now(timezone.utc),
+        data_dir=str(tmp_path),
+        file_list=[str(dummy_file)],
+        signed_url_list=[],
+        files=1,
+        result_format=ResultFormat.parquet,
+    )
+
+    size_bytes: int = 3 * 1024**4
+    with (
+        patch("servicex.app.cache.ServiceXClient") as mock_servicex,
+        patch(
+            "servicex.app.cache.Path.stat",
+            return_value=Mock(st_size=size_bytes),
+        ),
+    ):
+        cache_mock = Mock()
+        cache_mock.cached_queries.return_value = [record]
+        mock_servicex.return_value.query_cache = cache_mock
+        result = script_runner.run(["servicex", "cache", "list", "--size"])
+
+    assert result.returncode == 0
+    result_row = result.stdout.split("  ")
+    assert result_row[-1].strip() == "3.00 TB"

--- a/tests/app/test_datasets.py
+++ b/tests/app/test_datasets.py
@@ -100,7 +100,7 @@ def test_datasets_list(script_runner, dataset) -> None:
         assert result_row[0].strip() == "42"
         assert result_row[1] == "test_dataset"
         assert result_row[2] == "2"
-        assert result_row[3] == "0MB"
+        assert result_row[3] == "0.00 MB"
         assert result_row[4] == "completed"
 
         mock_get_datasets.assert_called_once_with(did_finder=None, show_deleted=False)
@@ -122,6 +122,28 @@ def test_datasets_list(script_runner, dataset) -> None:
         mock_get_datasets.assert_called_once_with(
             did_finder="some_finder", show_deleted=True
         )
+
+
+@pytest.mark.parametrize(
+    "size,expected",
+    [
+        (int(5e7), "50.00 MB"),
+        (int(1.5e9), "1.50 GB"),
+        (int(2.5e12), "2.50 TB"),
+    ],
+)
+def test_datasets_list_size_units(script_runner, dataset, size, expected):
+    dataset.size = size
+    with patch("servicex.app.datasets.ServiceXClient") as mock_servicex:
+        mock_get_datasets = MagicMock(return_value=[dataset])
+        mock_servicex.return_value.get_datasets = mock_get_datasets
+
+        result = script_runner.run(
+            ["servicex", "datasets", "list", "-c", "tests/example_config.yaml"]
+        )
+        assert result.returncode == 0
+        result_row = result.stdout.split("  ")
+        assert result_row[3] == expected
 
 
 def test_dataset_get(script_runner, dataset) -> None:

--- a/tests/app/test_datasets.py
+++ b/tests/app/test_datasets.py
@@ -22,7 +22,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import json
 from datetime import datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch, MagicMock, call
 
 import pytest
 
@@ -165,24 +165,40 @@ def test_dataset_get(script_runner, dataset) -> None:
 
 def test_dataset_delete(script_runner) -> None:
     with patch("servicex.app.datasets.ServiceXClient") as mock_servicex:
-        mock_delete_dataset = MagicMock(return_value=True)
+        mock_delete_dataset = MagicMock(side_effect=[True, True])
         mock_servicex.return_value.delete_dataset = mock_delete_dataset
 
         result = script_runner.run(
-            ["servicex", "datasets", "delete", "-c", "tests/example_config.yaml", "42"]
+            [
+                "servicex",
+                "datasets",
+                "delete",
+                "-c",
+                "tests/example_config.yaml",
+                "42",
+                "43",
+            ]
         )
         assert result.returncode == 0
-        assert result.stdout == "Dataset 42 deleted\n"
-        mock_delete_dataset.assert_called_once_with(42)
+        assert result.stdout == "Dataset 42 deleted\nDataset 43 deleted\n"
+        assert mock_delete_dataset.call_args_list == [call(42), call(43)]
 
-        mock_delete_dataset_not_found = MagicMock(return_value=False)
+        mock_delete_dataset_not_found = MagicMock(side_effect=[True, False])
         mock_servicex.return_value.delete_dataset = mock_delete_dataset_not_found
         result = script_runner.run(
-            ["servicex", "datasets", "delete", "-c", "tests/example_config.yaml", "42"]
+            [
+                "servicex",
+                "datasets",
+                "delete",
+                "-c",
+                "tests/example_config.yaml",
+                "42",
+                "43",
+            ]
         )
         assert result.returncode == 1
-        mock_delete_dataset.assert_called_once_with(42)
-        assert result.stdout == "Dataset 42 not found\n"
+        assert mock_delete_dataset_not_found.call_args_list == [call(42), call(43)]
+        assert result.stdout == "Dataset 42 deleted\nDataset 43 not found\n"
 
 
 def test_datasets_list_with_search_pattern(script_runner) -> None:

--- a/tests/test_code_generator_fetch.py
+++ b/tests/test_code_generator_fetch.py
@@ -1,0 +1,70 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from pathlib import Path
+from servicex.dataset_identifier import FileListDataset
+from servicex.query_cache import QueryCache
+from servicex.query_core import GenericQueryStringGenerator, Query
+from servicex.servicex_client import ServiceXClient
+from servicex.servicex_adapter import ServiceXAdapter
+from tests.test_servicex_dataset import transform_status1, transform_status3
+
+
+@pytest.mark.asyncio
+async def test_codegen_list_fetched_when_not_cached(mocker):
+    """Ensure we validate code generators only when submitting a new transform."""
+    sx_adapter = AsyncMock(spec=ServiceXAdapter)
+    sx_adapter.submit_transform.return_value = "123-456"
+    sx_adapter.get_transform_status.side_effect = [transform_status1, transform_status3]
+    sx_adapter.get_code_generators_async = AsyncMock(return_value={"uproot": "img"})
+    sx_adapter.url = "http://example.com"
+
+    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=AsyncMock())
+
+    cache = MagicMock(spec=QueryCache)
+    cache.get_transform_by_hash.return_value = None
+    cache.is_transform_request_submitted.return_value = False
+    cache.cache_path_for_transform.return_value = Path("/tmp")
+    cache.transformed_results.return_value = MagicMock()
+
+    client = ServiceXClient(config_path="tests/example_config.yaml")
+    client.servicex = sx_adapter
+    client.query_cache = cache
+
+    q = client.generic_query(
+        dataset_identifier=FileListDataset("file.root"),
+        query=GenericQueryStringGenerator("1", "uproot"),
+    )
+
+    mocker.patch.object(Query, "download_files", AsyncMock(return_value=[]))
+
+    await q.as_files_async(display_progress=False)
+
+    sx_adapter.get_code_generators_async.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_codegen_list_skipped_when_cached(mocker):
+    """No validation network call should happen when using cached results."""
+    sx_adapter = AsyncMock(spec=ServiceXAdapter)
+    sx_adapter.get_code_generators_async = AsyncMock()
+
+    cache = MagicMock(spec=QueryCache)
+    cached = MagicMock()
+    cached.file_list = ["/tmp/data.parquet"]
+    cache.get_transform_by_hash.return_value = cached
+
+    client = ServiceXClient(config_path="tests/example_config.yaml")
+    client.servicex = sx_adapter
+    client.query_cache = cache
+
+    q = client.generic_query(
+        dataset_identifier=FileListDataset("file.root"),
+        query=GenericQueryStringGenerator("1", "uproot"),
+    )
+
+    result = await q.as_files_async(display_progress=False)
+
+    sx_adapter.get_code_generators_async.assert_not_called()
+    assert result is cached

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -889,11 +889,17 @@ async def test_generic_query(network_patches):
     query.query_string_generator = None
     with pytest.raises(RuntimeError):
         query.generate_selection_string()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="not int"):
         query = sx.generic_query(
             dataset_identifier=spec.Sample[0].RucioDID,
             codegen=spec.General.Codegen,
             query=5,
+        )
+    with pytest.raises(ValueError, match="cannot be None"):
+        query = sx.generic_query(
+            dataset_identifier=spec.Sample[0].RucioDID,
+            codegen=spec.General.Codegen,
+            query=None,
         )
     with pytest.raises(NameError):
         query = sx.generic_query(

--- a/tests/test_databinder.py
+++ b/tests/test_databinder.py
@@ -5,8 +5,9 @@ from pydantic import ValidationError
 
 from servicex import ServiceXSpec, dataset, OutputFormat
 from servicex.query_core import ServiceXException
-from servicex.servicex_client import ReturnValueException
+from servicex.servicex_client import ProgressBarFormat, ReturnValueException
 from servicex.dataset import FileList, Rucio
+from servicex.dataset_identifier import FileListDataset
 
 
 @fixture
@@ -684,9 +685,7 @@ def test_funcadl_query(transformed_result, network_patches, with_event_loop):
         deliver(spec, config_path="tests/example_config.yaml")
 
 
-def test_query_with_codegen_override(
-    transformed_result, network_patches, with_event_loop
-):
+def test_query_with_codegen_override(network_patches, with_event_loop, codegen_list):
     from servicex import deliver
     from servicex.query import FuncADL_Uproot  # type: ignore
 
@@ -705,14 +704,18 @@ def test_query_with_codegen_override(
             ],
         }
     )
-    with patch(
-        "servicex.dataset_group.DatasetGroup.as_files",
-        return_value=[transformed_result],
-    ):
-        with pytest.raises(NameError) as excinfo:
-            deliver(spec, config_path="tests/example_config.yaml")
-        # if this has propagated correctly, the override worked
-        assert excinfo.value.args[0].startswith("does-not-exist")
+    with pytest.raises(NameError) as excinfo:
+        deliver(
+            spec,
+            config_path="tests/example_config.yaml",
+            progress_bar=ProgressBarFormat.none,
+            return_exceptions=False,
+        )
+    # if this has propagated correctly, the override worked and lists supported
+    # code generators.
+    assert excinfo.value.args[0].startswith("does-not-exist")
+    for cg_name in codegen_list:
+        assert cg_name in excinfo.value.args[0]
 
     # second, with sample-level override
     spec = ServiceXSpec.model_validate(
@@ -729,14 +732,18 @@ def test_query_with_codegen_override(
             ]
         }
     )
-    with patch(
-        "servicex.dataset_group.DatasetGroup.as_files",
-        return_value=[transformed_result],
-    ):
-        with pytest.raises(NameError) as excinfo:
-            deliver(spec, config_path="tests/example_config.yaml")
-        # if this has propagated correctly, the override worked
-        assert excinfo.value.args[0].startswith("does-not-exist")
+    with pytest.raises(NameError) as excinfo:
+        deliver(
+            spec,
+            config_path="tests/example_config.yaml",
+            progress_bar=ProgressBarFormat.none,
+            return_exceptions=False,
+        )
+    # if this has propagated correctly, the override worked and lists supported
+    # code generators.
+    assert excinfo.value.args[0].startswith("does-not-exist")
+    for cg_name in codegen_list:
+        assert cg_name in excinfo.value.args[0]
 
 
 def test_databinder_load_dict():
@@ -874,13 +881,13 @@ async def test_generic_query(network_patches):
     )
     sx = ServiceXClient(config_path="tests/example_config.yaml")
     query = sx.generic_query(
-        dataset_identifier=spec.Sample[0].RucioDID,
+        dataset_identifier=FileListDataset("/foo.root"),
         codegen=spec.General.Codegen,
         query=spec.Sample[0].Query,
     )
     assert query.generate_selection_string() == "[{'treename': 'nominal'}]"
     query = sx.generic_query(
-        dataset_identifier=spec.Sample[0].RucioDID,
+        dataset_identifier=FileListDataset("/foo.root"),
         result_format=spec.General.OutputFormat.to_ResultFormat(),
         codegen=spec.General.Codegen,
         query=spec.Sample[0].Query,
@@ -901,16 +908,18 @@ async def test_generic_query(network_patches):
             codegen=spec.General.Codegen,
             query=None,
         )
+    query = sx.generic_query(
+        dataset_identifier=FileListDataset("/foo.root"),
+        codegen="nonsense",
+        query=spec.Sample[0].Query,
+    )
     with pytest.raises(NameError):
-        query = sx.generic_query(
-            dataset_identifier=spec.Sample[0].RucioDID,
-            codegen="nonsense",
-            query=spec.Sample[0].Query,
-        )
+        await query.as_files_async(display_progress=False)
     with pytest.raises(RuntimeError):
         # no codegen specified by generic class
         query = sx.generic_query(
-            dataset_identifier=spec.Sample[0].RucioDID, query=spec.Sample[0].Query
+            dataset_identifier=FileListDataset("/foo.root"),
+            query=spec.Sample[0].Query,
         )
 
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -48,6 +48,13 @@ from rich.progress import Progress
 from servicex.servicex_adapter import ServiceXFile
 
 
+def _sx_mock() -> AsyncMock:
+    """Create a ServiceX adapter mock with code generators configured."""
+    mock = AsyncMock()
+    mock.get_code_generators_async = AsyncMock(return_value={"uproot": "img"})
+    return mock
+
+
 @pytest.mark.asyncio
 async def test_as_signed_urls_happy(transformed_result):
     # Test when display_progress is True and provided_progress is None
@@ -127,7 +134,7 @@ async def test_download_files(python_dataset):
     minio_mock = AsyncMock()
     config = Configuration(cache_path="temp_dir", api_endpoints=[])
     python_dataset.configuration = config
-    python_dataset.servicex = AsyncMock()
+    python_dataset.servicex = _sx_mock()
     python_dataset.servicex.get_servicex_capabilities = AsyncMock(
         return_value=["poll_local_transformation_results"]
     )
@@ -174,7 +181,7 @@ async def test_download_files_with_signed_urls(python_dataset):
     minio_mock.get_signed_url.return_value = "http://example.com/signed_url"
     progress_mock = Mock()
 
-    python_dataset.servicex = AsyncMock()
+    python_dataset.servicex = _sx_mock()
     python_dataset.servicex.get_servicex_capabilities = AsyncMock(
         return_value=["poll_local_transformation_results"]
     )
@@ -256,7 +263,7 @@ async def test_retrieve_current_transform_status_status_none(
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
@@ -282,7 +289,7 @@ async def test_retrieve_current_transform_status_status_not(
     python_dataset, completed_status
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         python_dataset.servicex.get_transform_status.return_value = completed_status
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
@@ -307,13 +314,13 @@ async def test_retrieve_current_transform_status_status_not(
 async def test_submit_and_download_cache_miss(python_dataset, completed_status):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
         python_dataset.configuration = config
 
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         python_dataset.cache.get_transform_by_hash = Mock()
         python_dataset.cache.get_transform_by_hash.return_value = None
         python_dataset.servicex.get_transform_status = AsyncMock(id="12345")
@@ -340,13 +347,13 @@ async def test_submit_and_download_cache_miss_overall_progress(
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
         python_dataset.configuration = config
 
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         python_dataset.cache.get_transform_by_hash = Mock()
         python_dataset.cache.get_transform_by_hash.return_value = None
         python_dataset.servicex.get_transform_status = AsyncMock(id="12345")
@@ -372,7 +379,7 @@ async def test_submit_and_download_cache_miss_overall_progress(
 async def test_submit_and_download_no_result_format(python_dataset, completed_status):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
@@ -383,7 +390,7 @@ async def test_submit_and_download_no_result_format(python_dataset, completed_st
             r"Use set_result_format method",
         ):
             python_dataset.result_format = None
-            python_dataset.servicex = AsyncMock()
+            python_dataset.servicex = _sx_mock()
             python_dataset.cache.get_transform_by_hash = Mock()
             python_dataset.cache.get_transform_by_hash.return_value = None
             python_dataset.servicex.get_transform_status = AsyncMock(id="12345")
@@ -410,12 +417,12 @@ async def test_submit_and_download_cache_miss_signed_urls_only(
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
         python_dataset.configuration = config
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         python_dataset.cache.get_transform_by_hash = Mock()
         python_dataset.cache.get_transform_by_hash.return_value = None
         python_dataset.servicex.get_transform_status = AsyncMock(id="12345")
@@ -442,12 +449,12 @@ async def test_submit_and_download_cache_files_request_urls(
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
         python_dataset.configuration = config
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         python_dataset.cache.get_transform_by_hash = Mock()
         python_dataset.cache.get_transform_by_hash.return_value = transformed_result
         status = Mock(
@@ -474,12 +481,12 @@ async def test_submit_and_download_cache_urls_request_files(
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
         python_dataset.configuration = config
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         python_dataset.cache.get_transform_by_hash = Mock()
         transformed_result.signed_url_list = ["a.b.c.com"]
         transformed_result.file_list = []
@@ -506,14 +513,14 @@ async def test_submit_and_download_cache_urls_request_files(
 async def test_network_loss(python_dataset, transformed_result):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
         python_dataset.configuration = config
         python_dataset.download_path = Path("www.a.b.com")
 
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         status = Mock(files=10, files_completed=5, files_failed=1, status=Status.fatal)
         python_dataset.current_status = status
 
@@ -544,12 +551,12 @@ async def test_submit_and_download_get_request_id_from_previous_submitted_reques
 ):
     with tempfile.TemporaryDirectory() as temp_dir:
         python_dataset.current_status = None
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         config = Configuration(cache_path=temp_dir, api_endpoints=[])
         cache = QueryCache(config)
         python_dataset.cache = cache
         python_dataset.configuration = config
-        python_dataset.servicex = AsyncMock()
+        python_dataset.servicex = _sx_mock()
         python_dataset.cache.get_transform_by_hash = Mock()
         python_dataset.cache.get_transform_by_hash.return_value = None
         python_dataset.servicex.get_transform_status = AsyncMock(id="12345")

--- a/tests/test_display_results.py
+++ b/tests/test_display_results.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2022, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from unittest.mock import Mock, patch
+import pytest
+
+from servicex.servicex_client import (
+    GuardList,
+    _display_results,
+    _get_progress_options,
+    ProgressBarFormat,
+    ServiceXClient,
+)
+
+
+def test_display_results_basic():
+    """Test _display_results basic functionality - covers most code paths."""
+    # Test with valid files (covers main path)
+    valid_files = GuardList(["/tmp/file1.root", "/tmp/file2.root"])
+    # Test with error case (covers error path)
+    error_files = GuardList(ValueError("Test error"))
+
+    out_dict = {"ValidSample": valid_files, "ErrorSample": error_files}
+
+    with patch("rich.get_console") as mock_get_console:
+        mock_console = Mock()
+        mock_get_console.return_value = mock_console
+
+        with patch("servicex.servicex_client.Table"):
+            _display_results(out_dict)
+
+            # Just verify it was called - don't over-test internal details
+            mock_get_console.assert_called_once()
+            assert mock_console.print.call_count >= 2  # At least completion + total
+
+
+def test_essential_valueerrors():
+    """Test the most important ValueError cases in one simple test."""
+    # Test progress options
+    assert _get_progress_options(ProgressBarFormat.expanded) == {}
+    with pytest.raises(ValueError, match="Invalid value"):
+        _get_progress_options("invalid")
+
+    # Test ServiceX client errors - simplest possible
+    with pytest.raises(ValueError, match="Only specify backend or url"):
+        with patch("servicex.servicex_client.Configuration") as mock_config_class:
+            mock_config = Mock()
+            mock_config.endpoint_dict.return_value = {}
+            mock_config.default_endpoint = None
+            mock_config_class.read.return_value = mock_config
+            ServiceXClient(backend="test", url="http://test.com")
+
+
+def test_guardlist_basics():
+    """Test GuardList basic functionality."""
+    # Valid case
+    valid_list = GuardList([1, 2, 3])
+    assert len(valid_list) == 3
+    assert valid_list[0] == 1
+    assert valid_list.valid()
+
+    # Error case
+    from servicex.servicex_client import ReturnValueException
+
+    error_list = GuardList(ValueError("error"))
+    assert not error_list.valid()
+    with pytest.raises(ReturnValueException):
+        _ = error_list[0]

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -149,3 +149,67 @@ def test_invalid_backend_raises_error_with_filename():
         ServiceXClient(backend="badname", config_path=config_file)
 
     assert f"Backend badname not defined in {expected} file" in str(err.value)
+
+
+def test_display_results_with_many_files():
+    from servicex.servicex_client import _display_results, GuardList
+    from unittest.mock import patch, MagicMock
+
+    # Mock GuardList with more than 3 files to trigger lines 275-276
+    mock_guard_list = MagicMock(spec=GuardList)
+    mock_guard_list.valid.return_value = True
+    mock_guard_list.__iter__.return_value = iter(
+        [
+            "file1.parquet",
+            "file2.parquet",
+            "file3.parquet",
+            "file4.parquet",
+            "file5.parquet",
+        ]
+    )
+
+    out_dict = {"sample1": mock_guard_list}
+
+    with patch("rich.get_console") as mock_get_console:
+        mock_console = MagicMock()
+        mock_get_console.return_value = mock_console
+
+        with patch("servicex.servicex_client.Table") as mock_table:
+            mock_table_instance = MagicMock()
+            mock_table.return_value = mock_table_instance
+
+            _display_results(out_dict)
+
+            # Verify that add_row was called with the truncated file list
+            mock_table_instance.add_row.assert_called_once()
+            call_args = mock_table_instance.add_row.call_args[0]
+            assert call_args[0] == "sample1"
+            assert call_args[1] == "5"
+            assert "... and 3 more files" in call_args[2]
+
+
+@pytest.mark.asyncio
+async def test_deliver_async_invalid_delivery_config():
+    from servicex.servicex_client import deliver_async
+    from unittest.mock import patch, MagicMock
+
+    # Mock the config loading to return invalid delivery type
+    with patch("servicex.servicex_client._load_ServiceXSpec") as mock_load_spec:
+        with patch("servicex.servicex_client._build_datasets") as mock_build_datasets:
+            with patch("servicex.minio_adapter.init_s3_config"):
+                mock_config = MagicMock()
+                mock_config.General.Delivery = (
+                    "INVALID_DELIVERY"  # Invalid delivery type
+                )
+                mock_config.General.IgnoreLocalCache = False
+                mock_config.Sample = []
+                mock_load_spec.return_value = mock_config
+                mock_build_datasets.return_value = []
+
+                with pytest.raises(ValueError) as exc_info:
+                    await deliver_async("test_spec.yaml")
+
+                assert (
+                    "unexpected value for config.general.Delivery: INVALID_DELIVERY"
+                    in str(exc_info.value)
+                )


### PR DESCRIPTION
Goal: make sure no internet is needed for a cached query

## Summary
- lazily fetch and cache ServiceX code generators
- validate code generators only when submitting uncached transforms
- provide list of supported code generators when an unsupported one is requested
- add tests covering cached vs uncached transform paths

## Testing
- `black tests/test_databinder.py servicex/query_core.py`
- `flake8 tests/test_databinder.py servicex/query_core.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689df04bede4832088ce0db7ccf3044b