### PR TITLE
Feat/auto bump deploy key

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -19,6 +19,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ssh-key: ${{ secrets.DEPLOY_KEY }}
 
     - name: Set up Python 3.12
       uses: actions/setup-python@v5
@@ -62,7 +63,6 @@ jobs:
     - name: Push commit
       # GITHUB_TOKEN is automatically provided
       run: |
-        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
         git push origin HEAD:$BRANCH
 
     - name: Build a sdist and wheel

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -45,6 +45,26 @@ jobs:
       run: |
         sed -i "/version =/ s/= \"[^\"]*\"/= \"${{ env.RELEASE_VERSION }}\"/" pyproject.toml
 
+    - name: commit version-bump
+      run: |
+        git config --local user.name "github-actions[bot]"
+        git config --local user.email "github-actions[bot]@users.noreply.github.com"
+        git add ./pyproject.toml
+
+        # Check if there are changes to commit
+        if ! git diff --cached --quiet; then
+          echo "Changes detected, committing..."
+          git commit -m "Update version to ${{ env.RELEASE_VERSION }}" --no-verify
+        else
+          echo "No changes to commit"
+        fi
+
+    - name: Push commit
+      # GITHUB_TOKEN is automatically provided
+      run: |
+        git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
+        git push origin HEAD:$BRANCH
+
     - name: Build a sdist and wheel
       run: |
         python -m build .

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -11,7 +11,6 @@ jobs:
     # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
     permissions:
       id-token: write
-      contents: write # required to push with GITHUB_TOKEN
     env:
       BRANCH: ${{ github.event.release.target_commitish }}
 
@@ -61,7 +60,6 @@ jobs:
         fi
 
     - name: Push commit
-      # GITHUB_TOKEN is automatically provided
       run: |
         git push origin HEAD:$BRANCH
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.2.2"
+version = "0.0.1b"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.2.2"
+version = "3.2.2b"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.2.2b"
+version = "3.2.2"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "0.0.1b"
+version = "3.2.2"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier


### PR DESCRIPTION
Follow up on PR #588 and solution to #649 

This workflow updates the `pyproject.toml` version to the new Github release tag and pushes it to the repo. 
Also, it builds and publishes the PyPI distribution associated with the release version. 

To bypass the push protection on master, I added:
- Deploy key: **Github Actions - protection bypass** with write permits
   - Public key built with `ssh-keygen -t ed25519 -C "deploy-key-to-front-end" -N ""`  
-  Secret: **DEPLOY_KEY**
   - Contains the private key
- Added "Deploy Keys" to the Bypass list of the ProtectMaster ruleset 

The workflow imports the ssh key from the `secrets.DEPLOY_KEY ` and was tested on dev branches

The rule bypass was not tested yet on master