### PR TITLE
Allow deleting multiple datasets via CLI

### DIFF
--- a/servicex/app/datasets.py
+++ b/servicex/app/datasets.py
@@ -25,7 +25,7 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-from typing import Optional
+from typing import Optional, List
 
 import rich
 
@@ -49,7 +49,7 @@ show_deleted_opt = typer.Option(
     show_default=True,
 )
 dataset_id_get_arg = typer.Argument(..., help="The ID of the dataset to get")
-dataset_id_delete_arg = typer.Argument(..., help="The ID of the dataset to delete")
+dataset_ids_delete_arg = typer.Argument(..., help="IDs of the datasets to delete")
 
 
 @datasets_app.command(no_args_is_help=False)
@@ -145,12 +145,16 @@ def get(
 def delete(
     backend: Optional[str] = backend_cli_option,
     config_path: Optional[str] = config_file_option,
-    dataset_id: int = dataset_id_delete_arg,
+    dataset_ids: List[int] = dataset_ids_delete_arg,
 ):
     sx = ServiceXClient(backend=backend, config_path=config_path)
-    result = sx.delete_dataset(dataset_id)
-    if result:
-        typer.echo(f"Dataset {dataset_id} deleted")
-    else:
-        typer.echo(f"Dataset {dataset_id} not found")
+    any_missing: bool = False  # Track if any dataset ID is not found
+    for dataset_id in dataset_ids:
+        result = sx.delete_dataset(dataset_id)
+        if result:
+            typer.echo(f"Dataset {dataset_id} deleted")
+        else:
+            typer.echo(f"Dataset {dataset_id} not found")
+            any_missing = True
+    if any_missing:
         raise typer.Abort()


### PR DESCRIPTION
## Summary
- enable deleting multiple datasets in one command
- test dataset delete with multiple IDs

## Testing
- `flake8 servicex/app/datasets.py tests/app/test_datasets.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b489a8323c8320b6d6a1adb885798a