### PR TITLE
Update pyproject.toml back to 3.2.2 after GHA test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "0.0.1a"
+version = "3.2.2"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier


### PR DESCRIPTION
Following the test for #652 this is a manual version reset to 3.2.2 in `pyproject.toml` 