### PR TITLE
Raise error when transform yields no files

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install --upgrade '.[test]'
+          uv pip install --upgrade '.[test,docs]'
           uv pip list
 
       - name: Test with pytest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv venv
-          uv pip install --upgrade '.[test,docs]'
+          uv pip install --upgrade '.[test]'
           uv pip list
 
       - name: Test with pytest

--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -59,10 +59,7 @@ class DataSetIdentifier:
     def describe(self) -> str:
         """Return a human readable description of this dataset."""
 
-        did_value = self.did
-        if did_value is not None:
-            return did_value
-        return str(self.dataset)
+        return self.did
 
 
 class RucioDatasetIdentifier(DataSetIdentifier):

--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -92,11 +92,6 @@ class RucioDatasetIdentifier(DataSetIdentifier):
     def from_yaml(cls, _, node):
         return cls(node.value)
 
-    def describe(self) -> str:
-        """Return a human readable description of the configured Rucio dataset."""
-
-        return super().describe()
-
 
 class FileListDataset(DataSetIdentifier):
     def __init__(self, files: Union[List[str], str]):
@@ -163,11 +158,6 @@ class CERNOpenDataDatasetIdentifier(DataSetIdentifier):
     def from_yaml(cls, _, node):
         return cls(int(node.value))
 
-    def describe(self) -> str:
-        """Return a human readable description of the CERN Open Data dataset."""
-
-        return super().describe()
-
 
 class XRootDDatasetIdentifier(DataSetIdentifier):
     def __init__(self, pattern: str, num_files: Optional[int] = None):
@@ -187,8 +177,3 @@ class XRootDDatasetIdentifier(DataSetIdentifier):
     @classmethod
     def from_yaml(cls, _, node):
         return cls(node.value)
-
-    def describe(self) -> str:
-        """Return a human readable description of the XRootD dataset pattern."""
-
-        return super().describe()

--- a/servicex/dataset_identifier.py
+++ b/servicex/dataset_identifier.py
@@ -56,6 +56,14 @@ class DataSetIdentifier:
         sha = hashlib.sha256(str([self.dataset]).encode("utf-8"))
         return sha.hexdigest()
 
+    def describe(self) -> str:
+        """Return a human readable description of this dataset."""
+
+        did_value = self.did
+        if did_value is not None:
+            return did_value
+        return str(self.dataset)
+
 
 class RucioDatasetIdentifier(DataSetIdentifier):
     def __init__(self, dataset: str, num_files: Optional[int] = None):
@@ -84,6 +92,11 @@ class RucioDatasetIdentifier(DataSetIdentifier):
     def from_yaml(cls, _, node):
         return cls(node.value)
 
+    def describe(self) -> str:
+        """Return a human readable description of the configured Rucio dataset."""
+
+        return super().describe()
+
 
 class FileListDataset(DataSetIdentifier):
     def __init__(self, files: Union[List[str], str]):
@@ -106,6 +119,17 @@ class FileListDataset(DataSetIdentifier):
     @property
     def did(self):
         return None
+
+    def describe(self) -> str:
+        """Return a human readable description of the configured file list."""
+
+        file_count: int = len(self.files)
+        file_word: str = "file" if file_count == 1 else "files"
+        preview_count: int = min(3, file_count)
+        preview: str = ", ".join(self.files[:preview_count])
+        suffix: str = ", ..." if file_count > preview_count else ""
+
+        return f"{file_count} {file_word}: {preview}{suffix}"
 
     yaml_tag = "!FileList"
 
@@ -139,6 +163,11 @@ class CERNOpenDataDatasetIdentifier(DataSetIdentifier):
     def from_yaml(cls, _, node):
         return cls(int(node.value))
 
+    def describe(self) -> str:
+        """Return a human readable description of the CERN Open Data dataset."""
+
+        return super().describe()
+
 
 class XRootDDatasetIdentifier(DataSetIdentifier):
     def __init__(self, pattern: str, num_files: Optional[int] = None):
@@ -158,3 +187,8 @@ class XRootDDatasetIdentifier(DataSetIdentifier):
     @classmethod
     def from_yaml(cls, _, node):
         return cls(node.value)
+
+    def describe(self) -> str:
+        """Return a human readable description of the XRootD dataset pattern."""
+
+        return super().describe()

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -134,11 +134,7 @@ class Query:
     def _describe_dataset(self) -> str:
         """Return a human-readable description of the dataset for error messages."""
 
-        descriptor = getattr(self.dataset_identifier, "describe", None)
-        if callable(descriptor):
-            return descriptor()
-
-        return str(self.dataset_identifier)
+        return self.dataset_identifier.describe()
 
     @property
     def transform_request(self):

--- a/tests/test_dataset_identifier.py
+++ b/tests/test_dataset_identifier.py
@@ -26,9 +26,11 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from servicex.dataset_identifier import (
+    CERNOpenDataDatasetIdentifier,
     DataSetIdentifier,
-    RucioDatasetIdentifier,
     FileListDataset,
+    RucioDatasetIdentifier,
+    XRootDDatasetIdentifier,
 )
 import pytest
 
@@ -41,6 +43,12 @@ def test_did():
 def test_rucio():
     did = RucioDatasetIdentifier("abc:123-456")
     assert did.did == "rucio://abc:123-456"
+    assert did.describe() == "rucio://abc:123-456"
+
+
+def test_rucio_with_file_limit():
+    did = RucioDatasetIdentifier("abc:123-456", num_files=10)
+    assert did.describe() == "rucio://abc:123-456?files=10"
 
 
 def test_rucio_no_namespace():
@@ -51,11 +59,26 @@ def test_rucio_no_namespace():
 def test_file_list():
     did = FileListDataset(["c:/foo.bar"])
     assert did.files == ["c:/foo.bar"]
+    assert did.describe() == "1 file: c:/foo.bar"
 
 
 def test_single_file():
     did = FileListDataset("c:/foo.bar")
     assert did.files == ["c:/foo.bar"]
+    assert did.describe() == "1 file: c:/foo.bar"
+
+
+def test_file_list_multiple_preview():
+    did = FileListDataset(["file1.root", "file2.root", "file3.root"])
+
+    assert did.describe() == "3 files: file1.root, file2.root, file3.root"
+
+
+def test_file_list_ellipsis_for_many_files():
+    files = ["file1.root", "file2.root", "file3.root", "file4.root"]
+    did = FileListDataset(files)
+
+    assert did.describe() == "4 files: file1.root, file2.root, file3.root, ..."
 
 
 def test_populate_transform_request(transform_request):
@@ -66,3 +89,23 @@ def test_populate_transform_request(transform_request):
     did2 = RucioDatasetIdentifier("abc:123-456")
     did2.populate_transform_request(transform_request)
     assert transform_request.did == "rucio://abc:123-456"
+
+
+def test_cern_open_data_description():
+    did = CERNOpenDataDatasetIdentifier(12345)
+    assert did.describe() == "cernopendata://12345"
+
+
+def test_cern_open_data_description_with_file_limit():
+    did = CERNOpenDataDatasetIdentifier(12345, num_files=2)
+    assert did.describe() == "cernopendata://12345?files=2"
+
+
+def test_xrootd_description():
+    did = XRootDDatasetIdentifier("root://server//data/*.root")
+    assert did.describe() == "xrootd://root://server//data/*.root"
+
+
+def test_xrootd_description_with_file_limit():
+    did = XRootDDatasetIdentifier("root://server//data/*.root", num_files=1)
+    assert did.describe() == "xrootd://root://server//data/*.root?files=1"


### PR DESCRIPTION
## Summary
- raise a ServiceXException when a transform completes successfully but returns no files and provide a dataset identifier in the message
- extend dataset identifier classes to describe themselves so Query reuses those descriptions when building error messages, including file count previews for FileList datasets, and ensure every identifier subclass overrides the helper
- add coverage for the new behaviour and adjust existing dataset tests to avoid empty mocked downloads, including description coverage for CERN Open Data and XRootD identifiers

## Testing
- black servicex/query_core.py tests/test_dataset.py servicex/dataset_identifier.py tests/test_dataset_identifier.py
- flake8
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5601c52648320850716e40a72cf75