### PR TITLE
make AuthorizationError inherit from Exception (not BaseException)

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -51,7 +51,7 @@ from servicex.models import (
 )
 
 
-class AuthorizationError(BaseException):
+class AuthorizationError(Exception):
     pass
 
 


### PR DESCRIPTION
Make `AuthorizationError` inherit from `Exception` (rather than `BaseException`) so it is caught by our error guard.

This is recommended by Python's documentation https://docs.python.org/3/library/exceptions.html#built-in-exceptions: "The built-in exception classes can be subclassed to define new exceptions; programmers are encouraged to derive new exceptions from the [Exception](https://docs.python.org/3/library/exceptions.html#Exception) class or one of its subclasses, and not from [BaseException](https://docs.python.org/3/library/exceptions.html#BaseException)."


Before:
```
(local) mattshirley@matts-mbp ServiceX_frontend % hatch run python examples/FuncADL_Uproot_Dict.py
FuncADL_Uproot_Dict: Transform ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0/?
                      Download ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0/?
Traceback (most recent call last):
  File "/Users/mattshirley/work/ServiceX_frontend/examples/FuncADL_Uproot_Dict.py", line 22, in <module>
    print(f"Files: {deliver(spec)}")
                    ~~~~~~~^^^^^^
  File "/Users/mattshirley/Library/Application Support/hatch/env/virtual/servicex/17737ykL/servicex/lib/python3.13/site-packages/make_it_sync/func_wrapper.py", line 63, in wrapped_call
    return _sync_version_of_function(fn, *args, **kwargs)
  File "/Users/mattshirley/Library/Application Support/hatch/env/virtual/servicex/17737ykL/servicex/lib/python3.13/site-packages/make_it_sync/func_wrapper.py", line 14, in _sync_version_of_function
    return loop.run_until_complete(r)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.3_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 719, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/mattshirley/work/ServiceX_frontend/servicex/servicex_client.py", line 328, in deliver_async
    output_dict = _output_handler(config, datasets, results)
  File "/Users/mattshirley/work/ServiceX_frontend/servicex/servicex_client.py", line 226, in _output_handler
    obj[1].file_list if not isinstance(obj[1], Exception) else obj[1]
    ^^^^^^^^^^^^^^^^
AttributeError: 'AuthorizationError' object has no attribute 'file_list'
```
After:
```
(local) mattshirley@matts-mbp ServiceX_frontend % hatch run python examples/FuncADL_Uproot_Dict.py
FuncADL_Uproot_Dict: Transform ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0/?
                      Download ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0/?
Files: {'FuncADL_Uproot_Dict': Invalid GuardList: AuthorizationError('Not authorized to access serviceX at https://servicex.af.uchicago.edu/')}
```