### PR TITLE
Shift tag after doing version bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "servicex"
-version = "3.2.3b"
+version = "3.2.3"
 description = "Python SDK and CLI Client for ServiceX"
 readme = "README.md"
 license = { text = "BSD-3-Clause" }  # SPDX short identifier


### PR DESCRIPTION
The release tags were created before the version bump was done, meaning that the tags still had the old release name in `pyproject.toml`. This meant the documentation had an off-by-one error in release numbers. Hopefully this fixes this.