### PR TITLE
pin version of types-aiobotocore to <=2.26.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ test = [
     "fastparquet>=2024.11.0",
     "pre-commit>=4.0.1",
     "pytest-aioboto3>=0.6.0",
+    "types-aiobotocore>=2.7.0,<=2.26.0",
     "coverage>=7.0.0",
 ]
 docs = [


### PR DESCRIPTION
Pin version of `types-aiobotocore` to <=2.26.0 because the next version removes the `s3` subpackage.

This feature could be re-added with a new PyPI package (`types-aiobotocore-s3`), however compatibility with existing dependency `pytest-aioboto3` currently requires the `s3` subpackage: https://github.com/phillipuniverse/pytest-aioboto3/blob/main/pyproject.toml#L28