### PR TITLE
[WIP] Turn local cache into catalog

### DIFF
--- a/examples/TopCP_input_marc.yaml
+++ b/examples/TopCP_input_marc.yaml
@@ -1,0 +1,31 @@
+Query: &my_query !UprootRaw |
+  [
+    {
+      "treename": "reco",
+      "filter_name": [
+        "mu_phi", "mu_eta", "mu_charge", "mu_e*", "mu_pt*", "mu_select*", "mu*SF*",
+        "el_phi", "el_eta", "el_charge", "el_e*", "el_pt*", "el_select*", "el*SF*",
+        "jet_phi", "jet_eta", "jet_e*", "jet_pt*", "jet_GN2*", "jet_select*", "jet_TruthFlavour",
+        "met_met*", "met_phi*",
+        "PL*", "NNLO*", "weight*", "globalTrigger*", "run*", "event*", "mcChannel*"
+      ],
+      "cut": "((any(log(jet_GN2v01_pc / (jet_GN2v01_pb*0.3 + jet_GN2v01_pu*0.7)) > 0.828, axis=1)) | (sum(log(jet_GN2v01_pb / (jet_GN2v01_pc*0.2 + jet_GN2v01_pu*0.8)) > 2.09, axis=1) > 1)) & (met_met_NOSYS > 45000)"
+    },
+    {
+      "copy_histograms": ["CutBookkeeper*", "cflow*", "metadata", "listOfSystematics"]
+    }
+  ]
+
+Sample:
+  - Name: singletop
+    Dataset: !Rucio user.mtost:user.mtost.700604.Sh_2212_lvvv.DAOD_PHYS.e8433_s3681_r13144_r13146_p6490.Jul2_final_submit
+    Query: *my_query
+  - Name: zjets_3
+    Dataset: !Rucio user.mtost:user.mtost.700794.Sh.DAOD_PHYS.e8527_e7400_s3681_r13167_r13146_p6490.Feb5_zjets_tautau
+    Query: *my_query
+  - Name: zjets_1
+    Dataset: !Rucio user.mtost:user.mtost.700792.Sh.DAOD_PHYS.e8527_e7400_s3681_r13144_r13146_p6490.Feb5_zjets_tautau
+    Query: *my_query
+  - Name: zjets_2
+    Dataset: !Rucio user.mtost:user.mtost.700793.Sh.DAOD_PHYS.e8527_e7400_s3681_r13144_r13146_p6490.Feb5_zjets_tautau
+    Query: *my_query

--- a/examples/cat_demo.py
+++ b/examples/cat_demo.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from servicex.catalog import Catalog
+
+cat = Catalog(Path("/Users/bengal1/dev/IRIS-HEP/ServiceX_Client/cache-dir"))
+print(cat.samples)
+
+print(cat.db.all())
+uproot_cat = cat["UprootRaw_YAML"]
+print(uproot_cat.get_runs())
+
+for sha in uproot_cat.get_runs():
+    print(sha, uproot_cat.get_run(sha).submit_time)
+
+
+print(uproot_cat.latest.submit_time)
+print(uproot_cat.latest.file_list)

--- a/examples/cat_demo.py
+++ b/examples/cat_demo.py
@@ -1,16 +1,26 @@
 from pathlib import Path
+from rich.console import Console
+from rich.table import Table
+
 
 from servicex.catalog import Catalog
 
 cat = Catalog(Path("/Users/bengal1/dev/IRIS-HEP/ServiceX_Client/cache-dir"))
-print(cat.samples)
+table = Table(title="Catalog")
+table.add_column("Sample Name", style="cyan")
+for sample in cat.samples:
+    table.add_row(sample)
+console = Console()
+console.print(table)
 
 uproot_cat = cat["UprootRaw_YAML"]
-print(uproot_cat.get_versions())
+table = Table(title="UprootRaw_YAML", width=25)
+table.add_column("Version", style="cyan")
+for v in uproot_cat.versions:
+    table.add_row(v)
+console = Console()
+console.print(table)
 
-
-from rich.console import Console
-from rich.table import Table
 
 table = Table(title="Uproot Catalog Runs")
 table.add_column("SHA", style="cyan")
@@ -26,5 +36,13 @@ console = Console()
 console.print(table)
 
 
-print(uproot_cat.latest.submit_time)
-print(uproot_cat.get_version("1.0").file_list)
+table = Table(title="Latest Run Timestamp")
+table.add_column("Submit Time", style="magenta")
+table.add_row(str(uproot_cat.latest.submit_time))
+console.print(table)
+
+table = Table(title="Files for Version 1.0")
+table.add_column("File Path", style="cyan")
+for file_path in uproot_cat.get_version("1.0").file_list:
+    table.add_row(str(file_path))
+console.print(table)

--- a/examples/cat_demo.py
+++ b/examples/cat_demo.py
@@ -5,13 +5,26 @@ from servicex.catalog import Catalog
 cat = Catalog(Path("/Users/bengal1/dev/IRIS-HEP/ServiceX_Client/cache-dir"))
 print(cat.samples)
 
-print(cat.db.all())
 uproot_cat = cat["UprootRaw_YAML"]
-print(uproot_cat.get_runs())
+print(uproot_cat.get_versions())
+
+
+from rich.console import Console
+from rich.table import Table
+
+table = Table(title="Uproot Catalog Runs")
+table.add_column("SHA", style="cyan")
+table.add_column("RequestID", style="yellow")
+table.add_column("Submit Time", style="magenta")
+table.add_column("Version", style="green")
 
 for sha in uproot_cat.get_runs():
-    print(sha, uproot_cat.get_run(sha).submit_time)
+    run = uproot_cat.get_run(sha)
+    table.add_row(sha, run.request_id, str(run.submit_time), run.version)
+
+console = Console()
+console.print(table)
 
 
 print(uproot_cat.latest.submit_time)
-print(uproot_cat.latest.file_list)
+print(uproot_cat.get_version("1.0").file_list)

--- a/examples/cat_demo.py
+++ b/examples/cat_demo.py
@@ -5,44 +5,30 @@ from rich.table import Table
 
 from servicex.catalog import Catalog
 
-cat = Catalog(Path("/Users/bengal1/dev/IRIS-HEP/ServiceX_Client/cache-dir"))
-table = Table(title="Catalog")
-table.add_column("Sample Name", style="cyan")
-for sample in cat.samples:
-    table.add_row(sample)
+cat = Catalog(Path("/data/tost/sx_versioning_cache"))
 console = Console()
-console.print(table)
 
-uproot_cat = cat["UprootRaw_YAML"]
-table = Table(title="UprootRaw_YAML", width=25)
+table = Table(title="Catalog Versions")
 table.add_column("Version", style="cyan")
-for v in uproot_cat.versions:
-    table.add_row(v)
-console = Console()
+for version in cat.versions:
+    table.add_row(version)
 console.print(table)
 
+v1 = cat["1.0"]
 
-table = Table(title="Uproot Catalog Runs")
+table = Table(title="Samples in Version 1.0")
+table.add_column("Sample Name", style="cyan")
+for sample in v1.samples:
+    table.add_row(sample)
+console.print(table)
+
+table = Table(title="Runs in Version 1.0")
 table.add_column("SHA", style="cyan")
 table.add_column("RequestID", style="yellow")
 table.add_column("Submit Time", style="magenta")
 table.add_column("Version", style="green")
-
-for sha in uproot_cat.get_runs():
-    run = uproot_cat.get_run(sha)
-    table.add_row(sha, run.request_id, str(run.submit_time), run.version)
-
-console = Console()
-console.print(table)
-
-
-table = Table(title="Latest Run Timestamp")
-table.add_column("Submit Time", style="magenta")
-table.add_row(str(uproot_cat.latest.submit_time))
-console.print(table)
-
-table = Table(title="Files for Version 1.0")
-table.add_column("File Path", style="cyan")
-for file_path in uproot_cat.get_version("1.0").file_list:
-    table.add_row(str(file_path))
+table.add_column("Sample Name", style="blue")
+for sha in v1.run_ids():
+    run = v1.get_run(sha)
+    table.add_row(sha, run.request_id, str(run.submit_time), run.version, run.title)
 console.print(table)

--- a/servicex/app/main.py
+++ b/servicex/app/main.py
@@ -128,6 +128,11 @@ def deliver(
     ignore_cache: Optional[bool] = ignore_cache_opt,
     hide_results: bool = hide_results_opt,
     cache_dir: Optional[str] = cache_dir_option,
+    version_string: Optional[str] = typer.Option(
+        None,
+        "--version",
+        help="Version string to record with the transform",
+    ),
 ):
     """
     Deliver a file to the ServiceX cache.
@@ -140,6 +145,7 @@ def deliver(
         config_path=config_path,
         ignore_local_cache=ignore_cache,
         cache_dir=cache_dir,
+        version=version_string,
     )
     if not hide_results:
         _display_results(results)

--- a/servicex/catalog.py
+++ b/servicex/catalog.py
@@ -10,15 +10,11 @@ from servicex.models import TransformedResults
 class Catalog:
     def __init__(self, path: Path):
         self.path = path
-        self.db = TinyDB(
-                os.path.join(self.path, ".servicex", "db.json")
-            )
-
-
+        self.db = TinyDB(os.path.join(self.path, ".servicex", "db.json"))
 
     @property
     def samples(self) -> list[str]:
-        distinct_titles = {doc['title'] for doc in self.db.all()}
+        distinct_titles = {doc["title"] for doc in self.db.all()}
         return list(distinct_titles)
 
     def get_sample(self, title: str) -> list[TransformedResults]:
@@ -29,15 +25,22 @@ class Catalog:
         """
         transforms = Query()
 
-        sample_recs = self.db.search((transforms.title == title) & (transforms.status == 'COMPLETE'))
-        sample_recs.sort(key=lambda x: datetime.fromisoformat(x['submit_time'].replace('Z', '+00:00')))
+        sample_recs = self.db.search(
+            (transforms.title == title) & (transforms.status == "COMPLETE")
+        )
+        sample_recs.sort(
+            key=lambda x: datetime.fromisoformat(
+                x["submit_time"].replace("Z", "+00:00")
+            )
+        )
 
-        return [ TransformedResults(**rec) for rec in sample_recs]
+        return [TransformedResults(**rec) for rec in sample_recs]
 
     def __getitem__(self, item):
         """
         Allow the catalog to be indexed by sample title."""
         return Sample(self.get_sample(item))
+
 
 class Sample:
     def __init__(self, results: list[TransformedResults]):
@@ -46,8 +49,14 @@ class Sample:
     def get_runs(self) -> list[str]:
         return [run.short_hash for run in self.results]
 
+    def get_versions(self) -> list[str]:
+        return [run.version for run in self.results if run.version is not None]
+
     def get_run(self, sha: str) -> TransformedResults:
         return next(filter(lambda x: x.short_hash == sha, self.results))
+
+    def get_version(self, version: str) -> TransformedResults:
+        return next(filter(lambda x: x.version == version, self.results))
 
     @property
     def latest(self) -> TransformedResults:

--- a/servicex/catalog.py
+++ b/servicex/catalog.py
@@ -49,7 +49,8 @@ class Sample:
     def get_runs(self) -> list[str]:
         return [run.short_hash for run in self.results]
 
-    def get_versions(self) -> list[str]:
+    @property
+    def versions(self) -> list[str]:
         return [run.version for run in self.results if run.version is not None]
 
     def get_run(self, sha: str) -> TransformedResults:

--- a/servicex/catalog.py
+++ b/servicex/catalog.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from pathlib import Path
+
+from tinydb import TinyDB, Query
+import os
+
+from servicex.models import TransformedResults
+
+
+class Catalog:
+    def __init__(self, path: Path):
+        self.path = path
+        self.db = TinyDB(
+                os.path.join(self.path, ".servicex", "db.json")
+            )
+
+
+
+    @property
+    def samples(self) -> list[str]:
+        distinct_titles = {doc['title'] for doc in self.db.all()}
+        return list(distinct_titles)
+
+    def get_sample(self, title: str) -> list[TransformedResults]:
+        """
+        Get a sample from the database and sort the runs by submission time. Decode
+        the JSON into TransformedResults objects.
+        Return a list of TransformedResults, sorted by submission time
+        """
+        transforms = Query()
+
+        sample_recs = self.db.search((transforms.title == title) & (transforms.status == 'COMPLETE'))
+        sample_recs.sort(key=lambda x: datetime.fromisoformat(x['submit_time'].replace('Z', '+00:00')))
+
+        return [ TransformedResults(**rec) for rec in sample_recs]
+
+    def __getitem__(self, item):
+        """
+        Allow the catalog to be indexed by sample title."""
+        return Sample(self.get_sample(item))
+
+class Sample:
+    def __init__(self, results: list[TransformedResults]):
+        self.results = results
+
+    def get_runs(self) -> list[str]:
+        return [run.short_hash for run in self.results]
+
+    def get_run(self, sha: str) -> TransformedResults:
+        return next(filter(lambda x: x.short_hash == sha, self.results))
+
+    @property
+    def latest(self) -> TransformedResults:
+        return self.results[-1]

--- a/servicex/catalog.py
+++ b/servicex/catalog.py
@@ -84,7 +84,6 @@ class Version:
         return f"Version({self.version!r}, {len(self.results)} run(s))"
 
 
-
 def build_symlink_forest(catalog: Catalog, output_dir: Path) -> None:
     """
     Build a symlink forest from *catalog* under *output_dir*, organized by version.
@@ -114,7 +113,9 @@ def build_symlink_forest(catalog: Catalog, output_dir: Path) -> None:
         for sample_title in sorted(version.samples):
             result = version.get_sample(sample_title)
             if not result.file_list:
-                print(f"  [{version_tag}] {sample_title}: No files found in catalog, skipping symlink.")
+                print(
+                    f"  [{version_tag}] {sample_title}: No files found in catalog, skipping symlink."
+                )
                 continue
 
             cached_path = Path(result.file_list[0]).parent

--- a/servicex/catalog.py
+++ b/servicex/catalog.py
@@ -13,52 +13,71 @@ class Catalog:
         self.db = TinyDB(os.path.join(self.path, ".servicex", "db.json"))
 
     @property
-    def samples(self) -> list[str]:
-        distinct_titles = {doc["title"] for doc in self.db.all()}
-        return list(distinct_titles)
+    def versions(self) -> list[str]:
+        distinct_versions = {doc["version"] for doc in self.db.all()}
+        return list(distinct_versions)
 
-    def get_sample(self, title: str) -> list[TransformedResults]:
+    def get_version(self, version: str) -> "Version":
         """
-        Get a sample from the database and sort the runs by submission time. Decode
-        the JSON into TransformedResults objects.
-        Return a list of TransformedResults, sorted by submission time
+        Return all completed runs sharing the given version tag, sorted by submission time.
         """
         transforms = Query()
-
-        sample_recs = self.db.search(
-            (transforms.title == title) & (transforms.status == "COMPLETE")
+        return Version(
+            version,
+            self._sorted_results(
+                self.db.search(
+                    (transforms.version == version) & (transforms.status == "COMPLETE")
+                )
+            ),
         )
-        sample_recs.sort(
+
+    def _sorted_results(self, records: list[dict]) -> list[TransformedResults]:
+        records.sort(
             key=lambda x: datetime.fromisoformat(
                 x["submit_time"].replace("Z", "+00:00")
             )
         )
+        return [TransformedResults(**rec) for rec in records]
 
-        return [TransformedResults(**rec) for rec in sample_recs]
-
-    def __getitem__(self, item):
-        """
-        Allow the catalog to be indexed by sample title."""
-        return Sample(self.get_sample(item))
+    def __getitem__(self, item: str) -> "Version":
+        """Index the catalog by version tag: cat['v1.0']"""
+        return self.get_version(item)
 
 
-class Sample:
-    def __init__(self, results: list[TransformedResults]):
-        self.results = results
+class Version:
+    def __init__(self, version: str, results: list[TransformedResults]):
+        self.version = version
 
-    def get_runs(self) -> list[str]:
-        return [run.short_hash for run in self.results]
+        # this is where the latest feature now gets enforced
+        # only the most recent sample gets added to the catalog if the version/sample pair
+        # is not unique
+        latest_by_title: dict[str, TransformedResults] = {}
+        for r in results:
+            latest_by_title[r.title] = r
+        self.results = list(latest_by_title.values())
 
     @property
-    def versions(self) -> list[str]:
-        return [run.version for run in self.results if run.version is not None]
+    def samples(self) -> list[str]:
+        return list({r.title for r in self.results})
+
+    def get_sample(self, title: str) -> TransformedResults:
+        """Return the latest run for the given sample title within this version."""
+        runs = [r for r in self.results if r.title == title]
+        if not runs:
+            raise KeyError(f"Sample {title!r} not found in version {self.version!r}")
+        return runs[-1]
+
+    def __getitem__(self, title: str) -> TransformedResults:
+        """Index by sample title: cat['v1.0']['my_sample']"""
+        return self.get_sample(title)
+
+    def run_ids(self) -> list[str]:
+        return [run.short_hash for run in self.results]
 
     def get_run(self, sha: str) -> TransformedResults:
         return next(filter(lambda x: x.short_hash == sha, self.results))
 
-    def get_version(self, version: str) -> TransformedResults:
-        return next(filter(lambda x: x.version == version, self.results))
+    # Note: removed the "latest" feature since it could get confusing when mixed w/ versioning
 
-    @property
-    def latest(self) -> TransformedResults:
-        return self.results[-1]
+    def __repr__(self) -> str:
+        return f"Version({self.version!r}, {len(self.results)} run(s))"

--- a/servicex/catalog.py
+++ b/servicex/catalog.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from pathlib import Path
+import os
+import shutil
 
 from tinydb import TinyDB, Query
-import os
 
 from servicex.models import TransformedResults
 
@@ -81,3 +82,54 @@ class Version:
 
     def __repr__(self) -> str:
         return f"Version({self.version!r}, {len(self.results)} run(s))"
+
+
+
+def build_symlink_forest(catalog: Catalog, output_dir: Path) -> None:
+    """
+    Build a symlink forest from *catalog* under *output_dir*, organized by version.
+    The forest gets re-made completely each call, so it should always perfectly match the catalog.
+
+    For every version creates:
+        <output_dir>/<version>/<sample>  ->  <absolute cache directory>
+
+    Also writes an ``ff_helper.txt`` file to help with fastframes integration. Can be commented out if this should not be part core SX funmctionality.
+    """
+    versions = catalog.versions
+
+    if not versions:
+        print("No versions found in catalog.")
+        return
+
+    if output_dir.exists():
+        # Note: this wipes the forest and starts over again. But should be careful if this gets pointed to a place other than the "symlink" directory in the cache
+        shutil.rmtree(output_dir)
+    output_dir.mkdir(parents=True)
+
+    for version_tag in sorted(versions):
+        version = catalog.get_version(version_tag)
+        version_dir = output_dir / version_tag
+        version_dir.mkdir(parents=True, exist_ok=True)
+
+        for sample_title in sorted(version.samples):
+            result = version.get_sample(sample_title)
+            if not result.file_list:
+                print(f"  [{version_tag}] {sample_title}: No files found in catalog, skipping symlink.")
+                continue
+
+            cached_path = Path(result.file_list[0]).parent
+            sample_symlink_path = version_dir / sample_title
+            os.symlink(cached_path, sample_symlink_path)
+
+            print(f"  [{version_tag}] {sample_title}: symlink -> {cached_path}")
+
+        ff_helper_file = version_dir / "ff_helper.txt"
+        version_abs_path = version_dir.resolve()
+        with open(ff_helper_file, "w") as f:
+            f.write(
+                "Hello intrepid serviceX user! Please run this command in the appropriate "
+                "directory to generate input metadata files for fastframe consumption:\n\n"
+            )
+            f.write(
+                f"python3 fastframes/python/produce_metadata_files.py --root_files_folder {version_abs_path}\n"
+            )

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -111,6 +111,7 @@ class TransformRequest(DocStringBaseModel):
         serialization_alias="result-destination"
     )
     result_format: ResultFormat = Field(serialization_alias="result-format")
+    version: Optional[str] = None
 
     model_config = {"populate_by_name": True, "use_attribute_docstrings": True}
 
@@ -131,6 +132,7 @@ class TransformRequest(DocStringBaseModel):
                     None,  # was image
                     self.result_format.name,
                     sorted(self.file_list) if self.file_list else None,
+                    self.version,
                 ]
             ).encode("utf-8")
         )
@@ -230,6 +232,9 @@ class TransformedResults(DocStringBaseModel):
     """File format for results"""
     log_url: Optional[str] = None
     """URL for looking up logs on the ServiceX server"""
+
+    version: Optional[str] = None
+    """Version of the sample. """
 
     @property
     def short_hash(self):

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -231,6 +231,10 @@ class TransformedResults(DocStringBaseModel):
     log_url: Optional[str] = None
     """URL for looking up logs on the ServiceX server"""
 
+    @property
+    def short_hash(self):
+        return self.hash[:8]
+
 
 class ServiceXInfo(DocStringBaseModel):
     r"""

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -79,6 +79,7 @@ class QueryCache:
             files=completed_status.files,
             result_format=transform.result_format,
             log_url=completed_status.log_url,
+            version=transform.version,
         )
 
     def cache_transform(self, record: TransformedResults):
@@ -167,6 +168,7 @@ class QueryCache:
             "title": transform.title,
             "codegen": transform.codegen,
             "result_format": transform.result_format,
+            "version": transform.version,
             "request_id": request_id,
             "status": "SUBMITTED",
             "submit_time": datetime.now(timezone.utc).isoformat(),

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -81,6 +81,7 @@ class Query:
         ignore_cache: bool = False,
         query_string_generator: Optional[QueryStringGenerator] = None,
         fail_if_incomplete: bool = True,
+        version: Optional[str] = None,
     ):
         r"""
         This is the main class for constructing transform requests and receiving the
@@ -121,6 +122,7 @@ class Query:
         self.ignore_cache = ignore_cache
         self.fail_if_incomplete = fail_if_incomplete
         self.query_string_generator = query_string_generator
+        self.version = version
 
         # Number of seconds in between ServiceX status polls
         self.servicex_polling_interval = servicex_polling_interval
@@ -144,6 +146,7 @@ class Query:
             result_destination=ResultDestination.object_store,  # type: ignore
             result_format=self.result_format,  # type: ignore
             selection=self.generate_selection_string(),
+            version=self.version,
         )  # type: ignore
         # Transfer the DID into the transform request
         self.dataset_identifier.populate_transform_request(sx_request)

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -173,6 +173,7 @@ async def _build_datasets(
     servicex_name,
     fail_if_incomplete,
     cache_dir: Optional[str] = None,
+    version: Optional[str] = None,
 ):
     def get_codegen(_sample: Sample, _general: General):
         if _sample.Codegen is not None:
@@ -199,6 +200,7 @@ async def _build_datasets(
             ignore_cache=sample.IgnoreLocalCache,
             query=sample.Query,
             fail_if_incomplete=fail_if_incomplete,
+            version=version,
         )
         logger.debug(f"Query string: {query.generate_selection_string()}")
         query.ignore_cache = sample.IgnoreLocalCache
@@ -263,6 +265,7 @@ async def deliver_async(
     progress_bar: ProgressBarFormat = ProgressBarFormat.default,
     concurrency: int = 10,
     cache_dir: Optional[str] = None,
+    version: Optional[str] = None,
 ):
     r"""
     Execute a ServiceX query.
@@ -300,7 +303,7 @@ async def deliver_async(
             sample.IgnoreLocalCache = True
 
     datasets = await _build_datasets(
-        config, config_path, servicex_name, fail_if_incomplete, cache_dir
+        config, config_path, servicex_name, fail_if_incomplete, cache_dir, version
     )
 
     group = DatasetGroup(datasets)
@@ -474,6 +477,7 @@ class ServiceXClient:
         result_format: ResultFormat = ResultFormat.parquet,
         ignore_cache: bool = False,
         fail_if_incomplete: bool = True,
+        version: Optional[str] = None,
     ) -> Query:
         r"""
         Generate a Query object for a generic codegen specification
@@ -521,6 +525,7 @@ class ServiceXClient:
             ignore_cache=ignore_cache,
             query_string_generator=query,
             fail_if_incomplete=fail_if_incomplete,
+            version=version,
         )
         return qobj
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -30,6 +30,7 @@ import shutil
 from typing import Optional, List, TypeVar, Any, Mapping, Union, cast
 from pathlib import Path
 
+from servicex.catalog import Catalog, build_symlink_forest
 from servicex.configuration import Configuration
 from servicex.models import (
     ResultFormat,
@@ -55,7 +56,6 @@ import traceback
 
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
-
 
 class ProgressBarFormat(str, Enum):
     """Specify the way progress bars are displayed."""
@@ -329,6 +329,12 @@ async def deliver_async(
         )
 
     output_dict = _output_handler(config, datasets, results)
+
+    if config.General.Delivery == General.DeliveryEnum.LocalCache and datasets:
+        cache_path = Path(datasets[0].configuration.cache_path)
+        #The symlinks automatically go in a directory within the cache, for now.
+        build_symlink_forest(Catalog(cache_path), cache_path / "symlinks")
+   
 
     return output_dict
 

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -57,6 +57,7 @@ import traceback
 T = TypeVar("T")
 logger = logging.getLogger(__name__)
 
+
 class ProgressBarFormat(str, Enum):
     """Specify the way progress bars are displayed."""
 
@@ -332,9 +333,8 @@ async def deliver_async(
 
     if config.General.Delivery == General.DeliveryEnum.LocalCache and datasets:
         cache_path = Path(datasets[0].configuration.cache_path)
-        #The symlinks automatically go in a directory within the cache, for now.
+        # The symlinks automatically go in a directory within the cache, for now.
         build_symlink_forest(Catalog(cache_path), cache_path / "symlinks")
-   
 
     return output_dict
 

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -58,6 +58,7 @@ def test_deliver(script_runner):
             config_path=None,
             ignore_local_cache=None,
             cache_dir=None,
+            version=None,
         )
         assert result_rows[-3] == "Total files delivered: 2"
 


### PR DESCRIPTION
This PR represents a sketch of how we might implement a results catalog feature for local caches of ServiceX results.

## Concepts:
1. Catalog - this represents an output directory from ServiceX client. It contains downloaded results in subdirectories named after the requestID along with a json db in a hidden `.servicex` directory that provides the metadata for each run
2. Sample - This is a specific transform query and dataset with the Sample's title being the primary key. There can be multiple runs of this sample, which may be identified by an optional version string. 

## Sample Versions
In order to facilitate working with multiple runs of a sample, we introduce a version property for each sample run. This optional property can be set with the new `--version` CLI option for the `deliver` command. This string is also now an argument for the `deliver` function in `servicex_client`.

## Notes:
1. I added version number to the hash so you can always force a new sample run to be remembered by incrementing the version.
2. I did think about the version being part of the `General` section of the spec so it can be tied to source code control

## Example
I created [cat_demo.py](https://github.com/ssl-hep/ServiceX_frontend/blob/catalog/examples/cat_demo.py) in examples directory to show how this works:

```
        Catalog        
┏━━━━━━━━━━━━━━━━━━━━━┓
┃ Sample Name         ┃
┡━━━━━━━━━━━━━━━━━━━━━┩
│ Uproot_FuncADL_YAML │
│ UprootRaw_YAML      │
└─────────────────────┘
     UprootRaw_YAML      
┏━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Version               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━┩
│ 1.0                   │
│ 1.1                   │
└───────────────────────┘
                                      Uproot Catalog Runs                                       
┏━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━┓
┃ SHA      ┃ RequestID                            ┃ Submit Time                      ┃ Version ┃
┡━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━┩
│ 210065e3 │ de99473f-2300-4094-85f3-badf03c8d3a1 │ 2026-02-12 19:07:25.319945+00:00 │ 1.0     │
│ b7c48b86 │ d38d002a-d8a9-4a5a-b9c3-010d9e0a7d11 │ 2026-02-12 21:33:36.406181+00:00 │ 1.1     │
│ 042f69c9 │ 2316760d-75b8-49ea-a253-4a031a5d28a7 │ 2026-02-12 21:38:40.028354+00:00 │         │
└──────────┴──────────────────────────────────────┴──────────────────────────────────┴─────────┘
        Latest Run Timestamp        
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Submit Time                      ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 2026-02-12 21:38:40.028354+00:00 │
└──────────────────────────────────┘
                                                                   Files for Version 1.0                                                                   
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ File Path                                                                                                                                               ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ /Users/bengal1/dev/IRIS-HEP/ServiceX_Client/cache-dir/de99473f-2300-4094-85f3-badf03c8d3a1/_d4e734cb5c29b16f5fc2261a0d3c87226e2e0175_000003.pool.root.1 │
│ /Users/bengal1/dev/IRIS-HEP/ServiceX_Client/cache-dir/de99473f-2300-4094-85f3-badf03c8d3a1/_dbbf75d3f660214b6c129eb2a91ed592c85cfe8e_000002.pool.root.1 │
│ /Users/bengal1/dev/IRIS-HEP/ServiceX_Client/cache-dir/de99473f-2300-4094-85f3-badf03c8d3a1/_853c79b751467bdf9e6b1bd02e743a5aa51e4516_000001.pool.root.1 │
└─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```