### PR TITLE
Update the kibana link code to use the new, cleaner Kibana URL

### DIFF
--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -183,11 +183,7 @@ class Query:
         :return: Transform results object which contains the list of files downloaded
                  or the list of pre-signed urls
         """
-        from servicex.app.transforms import (
-            create_kibana_link_parameters,
-            TimeFrame,
-            LogLevel,
-        )
+        from servicex.app.transforms import create_kibana_link_parameters
 
         download_files_task = None
         loop = asyncio.get_running_loop()
@@ -240,10 +236,7 @@ class Query:
                     )
                     if self.current_status.log_url is not None:
                         kibana_link = create_kibana_link_parameters(
-                            self.current_status.log_url,
-                            self.current_status.request_id,
-                            LogLevel.error,
-                            TimeFrame.month,
+                            self.current_status.log_url, self.current_status.request_id
                         )
                         logger.error(
                             f"More information of '{self.title}' [bold red on white][link={kibana_link}]HERE[/link][/bold red on white]"  # NOQA: E501
@@ -412,11 +405,7 @@ class Query:
         of status. Once we know the number of files in the dataset, update the progress
         bars.
         """
-        from servicex.app.transforms import (
-            LogLevel,
-            create_kibana_link_parameters,
-            TimeFrame,
-        )
+        from servicex.app.transforms import create_kibana_link_parameters
 
         # Actual number of files in the dataset. We only know this once the DID
         # finder has completed its work. In the meantime transformers will already
@@ -476,8 +465,6 @@ class Query:
                             kibana_link = create_kibana_link_parameters(
                                 self.current_status.log_url,
                                 self.current_status.request_id,
-                                LogLevel.error,
-                                TimeFrame.month,
                             )
                             logger.warning(
                                 f"More logfiles of '{self.title}' [bold red on white]"
@@ -504,10 +491,7 @@ class Query:
                     err_str = f"Request {titlestr}was canceled"
                     if self.current_status.log_url is not None:
                         kibana_link = create_kibana_link_parameters(
-                            self.current_status.log_url,
-                            self.current_status.request_id,
-                            LogLevel.error,
-                            TimeFrame.month,
+                            self.current_status.log_url, self.current_status.request_id
                         )
                         logger.error(
                             f"{err_str}\nMore logfiles of '{self.title}' [bold red on white][link={kibana_link}]HERE[/link][/bold red on white]"  # NOQA: E501
@@ -549,10 +533,7 @@ class Query:
                         )
                     if self.current_status.log_url is not None:
                         kibana_link = create_kibana_link_parameters(
-                            self.current_status.log_url,
-                            self.current_status.request_id,
-                            LogLevel.error,
-                            TimeFrame.month,
+                            self.current_status.log_url, self.current_status.request_id
                         )
                         logger.error(
                             f"More logfiles of '{self.title}' [bold red on white][link={kibana_link}]HERE[/link][/bold red on white]"  # NOQA: E501
@@ -562,10 +543,7 @@ class Query:
                     err_str = f"Fatal issue in ServiceX server for request {titlestr}"
                     if self.current_status.log_url is not None:
                         kibana_link = create_kibana_link_parameters(
-                            self.current_status.log_url,
-                            self.current_status.request_id,
-                            LogLevel.error,
-                            TimeFrame.month,
+                            self.current_status.log_url, self.current_status.request_id
                         )
                         logger.error(
                             f"{err_str}\nMore logfiles of '{self.title}' [bold red on white][link={kibana_link}]HERE[/link][/bold red on white]"  # NOQA: E501

--- a/tests/test_servicex_app_transforms.py
+++ b/tests/test_servicex_app_transforms.py
@@ -1,96 +1,73 @@
-from servicex.app.transforms import LogLevel, TimeFrame
-from servicex.app.transforms import (
-    add_query,
-    select_time,
-    create_kibana_link_parameters,
-)
+from servicex.app.transforms import LogLevel, create_kibana_link_parameters
 
 
-def test_add_query():
-    key = "abc"
-    value = "123-345-567"
-    query = "(query:(match_phrase:(abc:'123-345-567')))"
-    assert add_query(key, value) == query
+class TestAddRequestIdFilter:
+    """Tests for add_request_id_filter using a real Kibana dashboard URL."""
 
-    key = "requestId"
-    value = "d2ede739-9779-4075-95b1-0c7fae1de408"
-    query = "(query:(match_phrase:(requestId:'d2ede739-9779-4075-95b1-0c7fae1de408')))"
-    assert add_query(key, value) == query
-
-
-def test_select_time():
-    time_frame = TimeFrame.week
-    time_filter = "time:(from:now%2Fw,to:now%2Fw)"
-    assert time_filter == select_time(time_frame)
-
-    time_frame = "month"
-    time_filter = "time:(from:now-30d%2Fd,to:now)"
-    assert time_filter == select_time(time_frame)
-
-    time_frame = "daY"
-    time_filter = "time:(from:now%2Fd,to:now%2Fd)"
-    assert time_filter == select_time(time_frame)
-
-
-def test_create_kibana_link_parameters():
-    initial_log_url = (
-        "https://atlas-kibana.mwt2.org:5601/s/servicex/app"
-        "/dashboards?auth_provider_hint=anonymous1#/view/"
-        "2d2b3b40-f34e-11ed-a6d8-9f6a16cd6d78?embed=true&_g=()"
-        "&show-time-filter=true&hide-filter-bar=true"
+    EXAMPLE_URL = (
+        "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards"
+        "?auth_provider_hint=anonymous1#/view/bb682100-5558-11ed-afcf-d91dad577662#"
+        "?embed=true"
+        "&_g=(filters:!(),refreshInterval:(pause:!t,value:1000),"
+        "time:(from:now-24h/h,to:now))"
+        "&_a=(filters:!((query:(match_phrase:(instance:servicex-unit-test))))"
+        ",index:'923eaa00-45b9-11ed-afcf-d91dad577662')"
     )
-    transform_id = "d2ede739-9779-4075-95b1-0c7fae1de408"
-    log_level = LogLevel.error
-    time_frame = TimeFrame.day
-    final_url = (
-        "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?"
-        "auth_provider_hint=anonymous1#/view/2d2b3b40-f34e-11ed-a6d8-9f6a16cd6d78?"
-        "embed=true&_g=(time:(from:now%2Fd,to:now%2Fd))"
-        "&_a=(filters:!((query:(match_phrase:"
-        "(requestId:'d2ede739-9779-4075-95b1-0c7fae1de408'))),"
-        "(query:(match_phrase:(level:'error')))))&show-time-filter=true"
-        "&hide-filter-bar=true"
-    )
-    assert (
-        create_kibana_link_parameters(
-            initial_log_url, transform_id, log_level, time_frame
+
+    def test_preserves_base_url(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
         )
-        == final_url
-    )
-
-    transform_id = "93713b34-2f0b-4d53-8412-8afa98626516"
-    log_level = LogLevel.info
-    time_frame = TimeFrame.month
-    final_url = (
-        "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?"
-        "auth_provider_hint=anonymous1#/view/2d2b3b40-f34e-11ed-a6d8-9f6a16cd6d78?"
-        "embed=true&_g=(time:(from:now-30d%2Fd,to:now))"
-        "&_a=(filters:!((query:(match_phrase:"
-        "(requestId:'93713b34-2f0b-4d53-8412-8afa98626516'))),"
-        "(query:(match_phrase:(level:'info')))))&show-time-filter=true"
-        "&hide-filter-bar=true"
-    )
-    assert (
-        create_kibana_link_parameters(
-            initial_log_url, transform_id, log_level, time_frame
+        assert result.startswith(
+            "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards"
         )
-        == final_url
-    )
 
-    transform_id = "93713b34-2f0b-4d53-8412-8afa98626516"
-    log_level = None
-    time_frame = TimeFrame.month
-    final_url = (
-        "https://atlas-kibana.mwt2.org:5601/s/servicex/app/dashboards?"
-        "auth_provider_hint=anonymous1#/view/2d2b3b40-f34e-11ed-a6d8-9f6a16cd6d78?"
-        "embed=true&_g=(time:(from:now-30d%2Fd,to:now))"
-        "&_a=(filters:!((query:(match_phrase:"
-        "(requestId:'93713b34-2f0b-4d53-8412-8afa98626516')))))"
-        "&show-time-filter=true&hide-filter-bar=true"
-    )
-    assert (
-        create_kibana_link_parameters(
-            initial_log_url, transform_id, log_level, time_frame
+    def test_preserves_auth_query(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
         )
-        == final_url
-    )
+        assert "?auth_provider_hint=anonymous1" in result
+
+    def test_preserves_view_path(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
+        )
+        assert "#/view/bb682100-5558-11ed-afcf-d91dad577662" in result
+
+    def test_includes_embed_true(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
+        )
+        assert "embed=true" in result
+
+    def test_preserves_instance_in_query(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
+        )
+        assert "servicex-unit-test" in result
+
+    def test_includes_request_id_in_query(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
+        )
+        assert "abc-123" in result
+
+    def test_includes_log_level_in_query(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.error
+        )
+        assert "level%3AERROR" in result
+
+    def test_includes_app_state_filter(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
+        )
+        assert "_a=" in result
+        assert "requestId" in result
+
+    def test_preserves_time_range(self):
+        result = create_kibana_link_parameters(
+            self.EXAMPLE_URL, "abc-123", log_level=LogLevel.info
+        )
+        assert "now-24h/h" in result
+        assert "to:now" in result


### PR DESCRIPTION
Companion to [ServiceX PR 1295](https://github.com/ssl-hep/ServiceX/pull/1295) and part of fix for [Issue 1111](https://github.com/ssl-hep/ServiceX/issues/1111)

# Problem
The default Kibana URL we've been using in ServiceX deployments is more complicated than it needs to be and makes manipulating the filters a heroic task.

# Approach
We devised a cleaner URL which will now be vended by ServiceX and included in the status messages. This code matches the code in the backend for producing a link that shows just messages associated with a particular transaction on a particular ServiceX deployment.