### PR TITLE
Added documentation autobuild workflow.

### DIFF
--- a/.github/workflows/trigger_website_build.yaml
+++ b/.github/workflows/trigger_website_build.yaml
@@ -1,0 +1,23 @@
+name: Trigger ServiceX Website Build
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["master"]
+    paths:
+      - "docs/**"
+  pull_request:
+    paths:
+      - "docs/**"
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch publishWebsite workflow
+        run: |
+          gh workflow run publishWebsite.yml \
+            --repo ssl-hep/ServiceX_Website \
+            --ref main
+        env:
+          GH_TOKEN: ${{ secrets.SERVICEX_WEBSITE_PAT }}


### PR DESCRIPTION
This workflow looks at pushes and PRs and if they update the docs it automatically runs the website build. The SSL_HEP PAT must be updated once a year!