### PR TITLE
add client version to custom HTTP header in servicex_adapter

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -35,6 +35,7 @@ from dataclasses import dataclass
 from httpx import AsyncClient, Response, Timeout
 from json import JSONDecodeError
 from httpx_retries import RetryTransport, Retry
+from servicex._version import __version__
 from google.auth import jwt
 from tenacity import (
     AsyncRetrying,
@@ -85,12 +86,19 @@ class ServiceXAdapter:
         self._servicex_info: Optional[ServiceXInfo] = None
         self._sample_title_limit: Optional[int] = None
 
+    def _make_client(self, **kwargs) -> AsyncClient:
+        headers = {"X-ServiceX-Client-Version": __version__}
+        headers.update(kwargs.pop("headers", {}))
+        return AsyncClient(headers=headers, **kwargs)
+
     async def _get_token(self):
         url = f"{self.url}/token/refresh"
         headers = {"Authorization": f"Bearer {self.refresh_token}"}
         retry_options = Retry(total=3, backoff_factor=10, allowed_methods=["POST"])
 
-        async with AsyncClient(transport=RetryTransport(retry=retry_options)) as client:
+        async with self._make_client(
+            transport=RetryTransport(retry=retry_options)
+        ) as client:
             r = await client.post(url, headers=headers, json=None)
             if r.status_code == 200:
                 o = r.json()
@@ -150,7 +158,9 @@ class ServiceXAdapter:
 
         headers = await self._get_authorization()
         retry_options = Retry(total=3, backoff_factor=10)
-        async with AsyncClient(transport=RetryTransport(retry=retry_options)) as client:
+        async with self._make_client(
+            transport=RetryTransport(retry=retry_options)
+        ) as client:
             r = await client.get(url=f"{self.url}/servicex", headers=headers)
             if r.status_code in (401, 403):
                 raise AuthorizationError(
@@ -188,7 +198,9 @@ class ServiceXAdapter:
     async def get_transforms(self) -> List[TransformStatus]:
         headers = await self._get_authorization()
         retry_options = Retry(total=3, backoff_factor=10)
-        async with AsyncClient(transport=RetryTransport(retry=retry_options)) as client:
+        async with self._make_client(
+            transport=RetryTransport(retry=retry_options)
+        ) as client:
             r = await client.get(
                 url=f"{self.url}/servicex/transformation", headers=headers
             )
@@ -219,7 +231,7 @@ class ServiceXAdapter:
         if show_deleted:
             params["show-deleted"] = True
 
-        async with AsyncClient() as session:
+        async with self._make_client() as session:
             r = await session.get(
                 headers=headers, url=f"{self.url}/servicex/datasets", params=params
             )
@@ -240,7 +252,7 @@ class ServiceXAdapter:
         headers = await self._get_authorization()
         path_template = "/servicex/datasets/{dataset_id}"
         url = self.url + path_template.format(dataset_id=dataset_id)
-        async with AsyncClient() as session:
+        async with self._make_client() as session:
             r = await session.get(headers=headers, url=url)
             if r.status_code == 403:
                 raise AuthorizationError(
@@ -261,7 +273,7 @@ class ServiceXAdapter:
         path_template = "/servicex/datasets/{dataset_id}"
         url = self.url + path_template.format(dataset_id=dataset_id)
 
-        async with AsyncClient() as session:
+        async with self._make_client() as session:
             r = await session.delete(headers=headers, url=url)
             if r.status_code == 403:
                 raise AuthorizationError(
@@ -280,7 +292,7 @@ class ServiceXAdapter:
         path_template = f"/servicex/transformation/{transform_id}"
         url = self.url + path_template.format(transform_id=transform_id)
 
-        async with AsyncClient() as session:
+        async with self._make_client() as session:
             r = await session.delete(headers=headers, url=url)
             if r.status_code == 403:
                 raise AuthorizationError(
@@ -308,7 +320,7 @@ class ServiceXAdapter:
             params["later_than"] = later_than.isoformat()
 
         retry_options = Retry(total=3, backoff_factor=10)
-        async with AsyncClient(
+        async with self._make_client(
             transport=RetryTransport(retry=retry_options), timeout=_timeout
         ) as session:
             r = await session.get(headers=headers, url=url, params=params)
@@ -343,7 +355,7 @@ class ServiceXAdapter:
         path_template = f"/servicex/transformation/{transform_id}/cancel"
         url = self.url + path_template.format(transform_id=transform_id)
 
-        async with AsyncClient() as session:
+        async with self._make_client() as session:
             r = await session.get(headers=headers, url=url)
             if r.status_code == 403:
                 raise AuthorizationError(
@@ -358,7 +370,7 @@ class ServiceXAdapter:
     async def submit_transform(self, transform_request: TransformRequest) -> str:
         headers = await self._get_authorization()
         retry_options = Retry(total=3, backoff_factor=30)
-        async with AsyncClient(
+        async with self._make_client(
             transport=RetryTransport(retry=retry_options), timeout=_timeout
         ) as client:
             r = await client.post(
@@ -392,7 +404,9 @@ class ServiceXAdapter:
     async def get_transform_status(self, request_id: str) -> TransformStatus:
         headers = await self._get_authorization()
         retry_options = Retry(total=5, backoff_factor=3)
-        async with AsyncClient(transport=RetryTransport(retry=retry_options)) as client:
+        async with self._make_client(
+            transport=RetryTransport(retry=retry_options)
+        ) as client:
             try:
                 async for attempt in AsyncRetrying(
                     retry=retry_if_not_exception_type(ValueError),


### PR DESCRIPTION
Add client version to HTTP header so the server can consume this information.

For issue: https://github.com/ssl-hep/ServiceX/issues/832

Backend work: https://github.com/ssl-hep/ServiceX/pull/1412