### PR TITLE
add client-version to transformation submission

### DIFF
--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -43,7 +43,7 @@ from tenacity import (
     retry_if_not_exception_type,
 )
 from make_it_sync import make_sync
-
+from servicex._version import __version__
 from servicex.models import (
     TransformRequest,
     TransformStatus,
@@ -384,13 +384,17 @@ class ServiceXAdapter:
     async def submit_transform(self, transform_request: TransformRequest) -> str:
         headers = await self._get_authorization()
         retry_options = Retry(total=3, backoff_factor=30)
+
+        submit_json = transform_request.model_dump(by_alias=True, exclude_none=True)
+        submit_json["client-version"] = __version__
+
         async with AsyncClient(
             transport=RetryTransport(retry=retry_options), timeout=_timeout
         ) as client:
             r = await client.post(
                 url=f"{self.url}/servicex/transformation",
                 headers=headers,
-                json=transform_request.model_dump(by_alias=True, exclude_none=True),
+                json=submit_json,
             )
 
             if r.status_code >= 400:

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -421,6 +421,27 @@ async def test_submit(post, servicex):
 
 @pytest.mark.asyncio
 @patch("servicex.servicex_adapter.AsyncClient.post")
+async def test_submit_includes_client_version(post, servicex):
+    from servicex._version import __version__
+
+    post.return_value = MagicMock()
+    post.return_value.json.return_value = {"request_id": "123-456-789"}
+    post.return_value.status_code = 200
+    request = TransformRequest(
+        title="Test submission",
+        did="rucio://foo.bar",
+        selection="(call EventDataset)",
+        codegen="uproot",
+        result_destination=ResultDestination.object_store,
+        result_format=ResultFormat.parquet,
+    )
+    await servicex.submit_transform(request)
+    _, kwargs = post.call_args
+    assert kwargs["json"]["client-version"] == __version__
+
+
+@pytest.mark.asyncio
+@patch("servicex.servicex_adapter.AsyncClient.post")
 async def test_submit_errors(post, servicex):
     post.return_value = MagicMock()
     post.return_value.status_code = 401


### PR DESCRIPTION
Add `client-version` variable every transformation submission.

For issue: https://github.com/ssl-hep/ServiceX/issues/832

Backend work: https://github.com/ssl-hep/ServiceX/pull/1412