### PR TITLE
implement post_cancel_transform capability

### DIFF
--- a/servicex/app/transforms.py
+++ b/servicex/app/transforms.py
@@ -216,7 +216,7 @@ def cancel(
     """
     sx = ServiceXClient(backend=backend, config_path=config_path, cache_dir=cache_dir)
     for transform_id in transform_id_list:
-        asyncio.run(sx.cancel_transform(transform_id))
+        sx.cancel_transform(transform_id)
         print(f"Transform {transform_id} cancelled")
 
 

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -367,10 +367,16 @@ class ServiceXAdapter:
     async def cancel_transform(self, transform_id=None):
         headers = await self._get_authorization()
         path_template = f"/servicex/transformation/{transform_id}/cancel"
+
         url = self.url + path_template.format(transform_id=transform_id)
 
         async with AsyncClient() as session:
-            r = await session.get(headers=headers, url=url)
+            capabilities = await self.get_servicex_capabilities()
+            if "post_cancel_transform" in capabilities:
+                r = await session.post(headers=headers, url=url)
+            else:
+                r = await session.get(headers=headers, url=url)
+
             if r.status_code == 403:
                 raise AuthorizationError(
                     f"Not authorized to access serviceX at {self.url}"

--- a/servicex/servicex_adapter.py
+++ b/servicex/servicex_adapter.py
@@ -372,7 +372,7 @@ class ServiceXAdapter:
 
         async with AsyncClient() as session:
             capabilities = await self.get_servicex_capabilities()
-            if "post_cancel_transform" in capabilities:
+            if "cancel_transform_post_method" in capabilities:
                 r = await session.post(headers=headers, url=url)
             else:
                 r = await session.get(headers=headers, url=url)

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -368,6 +368,7 @@ async def test_delete_transform_errors(delete, servicex):
 @pytest.mark.asyncio
 @patch("servicex.servicex_adapter.AsyncClient.get")
 async def test_cancel_transform(get, servicex):
+    servicex.get_servicex_capabilities = AsyncMock(return_value=[])
     get.return_value.json.return_value = {
         "message": "Canceled transformation request 123"
     }
@@ -375,6 +376,23 @@ async def test_cancel_transform(get, servicex):
 
     await servicex.cancel_transform(123)
     get.assert_called_with(
+        url="https://servicex.org/servicex/transformation/123/cancel", headers={}
+    )
+
+
+@pytest.mark.asyncio
+@patch("servicex.servicex_adapter.AsyncClient.post")
+async def test_cancel_transform_post(post, servicex):
+    servicex.get_servicex_capabilities = AsyncMock(
+        return_value=["post_cancel_transform"]
+    )
+    post.return_value.json.return_value = {
+        "message": "Canceled transformation request 123"
+    }
+    post.return_value.status_code = 200
+
+    await servicex.cancel_transform(123)
+    post.assert_called_with(
         url="https://servicex.org/servicex/transformation/123/cancel", headers={}
     )
 

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -384,7 +384,7 @@ async def test_cancel_transform_get(get, servicex):
 @patch("servicex.servicex_adapter.AsyncClient.post")
 async def test_cancel_transform(post, servicex):
     servicex.get_servicex_capabilities = AsyncMock(
-        return_value=["post_cancel_transform"]
+        return_value=["cancel_transform_post_method"]
     )
     post.return_value.json.return_value = {
         "message": "Canceled transformation request 123"
@@ -424,7 +424,7 @@ async def test_cancel_transform_errors_get(get, servicex):
 @patch("servicex.servicex_adapter.AsyncClient.post")
 async def test_cancel_transform_errors(post, servicex):
     servicex.get_servicex_capabilities = AsyncMock(
-        return_value=["post_cancel_transform"]
+        return_value=["cancel_transform_post_method"]
     )
     post.return_value = MagicMock()
     post.return_value.status_code = 403

--- a/tests/test_servicex_adapter.py
+++ b/tests/test_servicex_adapter.py
@@ -367,7 +367,7 @@ async def test_delete_transform_errors(delete, servicex):
 
 @pytest.mark.asyncio
 @patch("servicex.servicex_adapter.AsyncClient.get")
-async def test_cancel_transform(get, servicex):
+async def test_cancel_transform_get(get, servicex):
     servicex.get_servicex_capabilities = AsyncMock(return_value=[])
     get.return_value.json.return_value = {
         "message": "Canceled transformation request 123"
@@ -382,7 +382,7 @@ async def test_cancel_transform(get, servicex):
 
 @pytest.mark.asyncio
 @patch("servicex.servicex_adapter.AsyncClient.post")
-async def test_cancel_transform_post(post, servicex):
+async def test_cancel_transform(post, servicex):
     servicex.get_servicex_capabilities = AsyncMock(
         return_value=["post_cancel_transform"]
     )
@@ -399,7 +399,8 @@ async def test_cancel_transform_post(post, servicex):
 
 @pytest.mark.asyncio
 @patch("servicex.servicex_adapter.AsyncClient.get")
-async def test_cancel_transform_errors(get, servicex):
+async def test_cancel_transform_errors_get(get, servicex):
+    servicex.get_servicex_capabilities = AsyncMock(return_value=[])
     get.return_value = MagicMock()
     get.return_value.status_code = 403
     with pytest.raises(AuthorizationError) as err:
@@ -414,6 +415,31 @@ async def test_cancel_transform_errors(get, servicex):
     get.return_value.json.side_effect = JSONDecodeError("", "", 0)
     get.return_value.text = "error_message"
     get.return_value.status_code = 500
+    with pytest.raises(RuntimeError) as err:
+        await servicex.cancel_transform(123)
+    assert "Failed to cancel transform 123 - error_message" in str(err.value)
+
+
+@pytest.mark.asyncio
+@patch("servicex.servicex_adapter.AsyncClient.post")
+async def test_cancel_transform_errors(post, servicex):
+    servicex.get_servicex_capabilities = AsyncMock(
+        return_value=["post_cancel_transform"]
+    )
+    post.return_value = MagicMock()
+    post.return_value.status_code = 403
+    with pytest.raises(AuthorizationError) as err:
+        await servicex.cancel_transform(123)
+    assert "Not authorized to access serviceX at" in str(err.value)
+
+    post.return_value.status_code = 404
+    with pytest.raises(ValueError) as err:
+        await servicex.cancel_transform(123)
+    assert "Transform 123 not found" in str(err.value)
+
+    post.return_value.json.side_effect = JSONDecodeError("", "", 0)
+    post.return_value.text = "error_message"
+    post.return_value.status_code = 500
     with pytest.raises(RuntimeError) as err:
         await servicex.cancel_transform(123)
     assert "Failed to cancel transform 123 - error_message" in str(err.value)


### PR DESCRIPTION
Conditionally use GET or POST based on `post_cancel_transform` capability on the `/cancel` route.