### PR TITLE
Use server-generated file URLs if available

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,7 @@ repos:
     rev: 26.3.1
     hooks:
       -   id: black
+          args: ["-t", "py310"]
 
 ci:
     autofix_commit_msg: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ test = [
     "pytest-aioboto3>=0.6.0",
     "types-aiobotocore>=2.7.0,<=2.26.0",
     "coverage>=7.0.0",
+    "pytest-httpserver>=1.1.5",
 ]
 docs = [
     "sphinx>=7.0.1, <8.2.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ test = [
     "pytest-aioboto3>=0.6.0",
     "types-aiobotocore>=2.7.0,<=2.26.0",
     "coverage>=7.0.0",
-    "pytest-httpserver>=1.1.5",
+    "pytest-httpserver>=1.1.3",
 ]
 docs = [
     "sphinx>=7.0.1, <8.2.0",

--- a/servicex/app/transforms.py
+++ b/servicex/app/transforms.py
@@ -45,7 +45,7 @@ from servicex.app.cli_options import (
     config_file_option,
     cache_dir_option,
 )
-from servicex.minio_adapter import MinioAdapter
+from servicex.download_adapter import get_download_adapter
 from servicex.models import Status, ResultFile
 from servicex.servicex_client import ServiceXClient
 
@@ -124,12 +124,13 @@ def files(
     List the files that were produced by a transform.
     """
 
+    sx = ServiceXClient(backend=backend, config_path=config_path, cache_dir=cache_dir)
+
     async def list_files(sx: ServiceXClient, transform_id: str) -> List[ResultFile]:
         transform = await sx.get_transform_status_async(transform_id)
-        minio = MinioAdapter.for_transform(transform)
+        minio = await get_download_adapter(transform, sx.servicex)
         return await minio.list_bucket()
 
-    sx = ServiceXClient(backend=backend, config_path=config_path, cache_dir=cache_dir)
     result_files = asyncio.run(list_files(sx, transform_id))
     table = pipeable_table(title=f"Files from {transform_id}")
     table.add_column("filename")
@@ -167,7 +168,7 @@ def download(
             return p
 
         transform = await sx.get_transform_status_async(transform_id)
-        minio = MinioAdapter.for_transform(transform)
+        minio = await get_download_adapter(transform, sx.servicex)
         file_list = await minio.list_bucket()
         progress.update(download_progress, total=len(file_list))
         progress.start_task(download_progress)

--- a/servicex/download_adapter.py
+++ b/servicex/download_adapter.py
@@ -230,7 +230,14 @@ class HTTPDownloadAdapter(DownloadAdapter):
         stop=stop_after_attempt(3), wait=wait_random_exponential(max=60), reraise=True
     )
     async def list_bucket(self) -> List[ResultFile]:
-        return []
+        return [
+            ResultFile(
+                filename=_.filename,
+                size=_.total_bytes,
+                extension=_.filename.split(".")[-1],
+            )
+            for _ in await self.servicex.get_transformation_results(self.bucket)
+        ]
 
     @retry(
         stop=stop_after_attempt(3), wait=wait_random_exponential(max=60), reraise=True
@@ -253,14 +260,22 @@ class HTTPDownloadAdapter(DownloadAdapter):
         )
 
         async with _file_transfer_sem:
-            if path.exists() and expected_size is not None:
+            download_info = await self.get_signed_url(object_name)
+            if expected_size is not None:
+                remotesize = expected_size
+            else:
+                info = await self.session.head(
+                    download_info.url, headers=download_info.headers
+                )
+                remotesize = info.headers.get("Content-Length")
+                if remotesize is not None:
+                    remotesize = int(remotesize)
+            if path.exists() and remotesize is not None:
                 # if file size is the same, let's not download anything
                 # maybe move to a better verification mechanism with e-tags in the future
                 localsize = path.stat().st_size
-                if localsize == expected_size:
+                if localsize == remotesize:
                     return path.resolve()
-
-            download_info = await self.get_signed_url(object_name)
 
             async with self.session.stream(
                 "GET", download_info.url, headers=download_info.headers
@@ -268,9 +283,9 @@ class HTTPDownloadAdapter(DownloadAdapter):
                 with open(path, "wb") as outfile:
                     async for chunk in response.aiter_bytes():
                         outfile.write(chunk)
-            if expected_size is not None:
+            if remotesize is not None:
                 localsize = path.stat().st_size
-                if localsize != expected_size:
+                if localsize != remotesize:
                     raise RuntimeError(f"Download of {object_name} failed")
         return path.resolve()
 

--- a/servicex/download_adapter.py
+++ b/servicex/download_adapter.py
@@ -31,6 +31,7 @@ from pathlib import Path
 from typing import List, Optional
 from dataclasses import dataclass
 import sys
+from abc import ABC, abstractmethod
 
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
@@ -68,7 +69,11 @@ class URLAccessInfo:
     expiration: int
 
 
-class DownloadAdapter:
+class DownloadAdapter(ABC):
+    # This must be at least 40, the length of the `hash` we are using, or
+    # undefined things will happen.
+    MAX_PATH_LEN = 60
+
     @classmethod
     def hash_path(cls, file_name):
         """
@@ -90,12 +95,35 @@ class DownloadAdapter:
         else:
             return file_name
 
+    @classmethod
+    @abstractmethod
+    def for_transform(cls, transform: TransformStatus):
+        """Return an adapter instance for a given transform"""
+
+    @abstractmethod
+    async def list_bucket(self) -> List[ResultFile]:
+        """Directly query for the files associated with this transform"""
+
+    @abstractmethod
+    async def download_file(
+        self,
+        object_name: str,
+        local_dir: str,
+        shorten_filename: bool = False,
+        expected_size: Optional[int] = None,
+    ) -> Path:
+        """Download a file"""
+
+    @abstractmethod
+    async def get_signed_url(self, object_name: str) -> URLAccessInfo:
+        """Get URL from which a file can be downloaded"""
+
+    @abstractmethod
+    async def update_cache(self, object_names: list[str]) -> None:
+        """Signal to class that it should look up the URLs for object_names"""
+
 
 class MinioAdapter(DownloadAdapter):
-    # This must be at least 40, the length of the `hash` we are using, or
-    # undefined things will happen.
-    MAX_PATH_LEN = 60
-
     def __init__(
         self,
         endpoint_host: str,
@@ -198,15 +226,11 @@ class MinioAdapter(DownloadAdapter):
             return URLAccessInfo(url=url, headers={}, expiration=sys.maxsize)
 
     async def update_cache(self, object_names: list[str]) -> None:
-        # this does nothing
-        pass
+        """In this class this does nothing"""
 
 
 class HTTPDownloadAdapter(DownloadAdapter):
     # Ask the server what URL to download from
-    # This must be at least 40, the length of the `hash` we are using, or
-    # undefined things will happen.
-    MAX_PATH_LEN = 60
 
     def __init__(
         self,

--- a/servicex/download_adapter.py
+++ b/servicex/download_adapter.py
@@ -29,14 +29,18 @@ import os.path
 from hashlib import sha1
 from pathlib import Path
 from typing import List, Optional
+from dataclasses import dataclass
+import sys
 
 from tenacity import retry, stop_after_attempt, wait_random_exponential
 
 import aioboto3
 from boto3.s3.transfer import TransferConfig
 import asyncio
+import httpx
 
 from servicex.models import ResultFile, TransformStatus
+from servicex.servicex_adapter import ServiceXAdapter
 
 # Maximum five simultaneous streams per individual file download
 _transferconfig = TransferConfig(max_concurrency=5)
@@ -46,7 +50,7 @@ _file_transfer_sem = asyncio.Semaphore(10)
 _bucket_list_sem = asyncio.Semaphore(5)
 
 
-def init_s3_config(concurrency: int = 10):
+def init_download_concurrency(concurrency: int = 10):
     "Update the number of concurrent connections"
     global _file_transfer_sem
     _file_transfer_sem = asyncio.Semaphore(concurrency)
@@ -57,7 +61,37 @@ def _sanitize_filename(fname: str):
     return fname.replace("*", "_").replace(";", "_").replace(":", "_")
 
 
-class MinioAdapter:
+@dataclass
+class URLAccessInfo:
+    url: str
+    headers: dict[str, str]
+    expiration: int
+
+
+class DownloadAdapter:
+    @classmethod
+    def hash_path(cls, file_name):
+        """
+        Make the path safe for object store or POSIX, by keeping the length
+        less than MAX_PATH_LEN. Replace the leading (less interesting) characters with a
+        forty character hash.
+        :param file_name: Input filename
+        :return: Safe path string
+        """
+        if len(file_name) > cls.MAX_PATH_LEN:
+            hash = sha1(file_name.encode("utf-8")).hexdigest()
+            return "".join(
+                [
+                    "_",
+                    hash,
+                    file_name[-1 * (cls.MAX_PATH_LEN - len(hash) - 1) :],  # noqa: E203
+                ]
+            )
+        else:
+            return file_name
+
+
+class MinioAdapter(DownloadAdapter):
     # This must be at least 40, the length of the `hash` we are using, or
     # undefined things will happen.
     MAX_PATH_LEN = 60
@@ -154,31 +188,125 @@ class MinioAdapter:
     @retry(
         stop=stop_after_attempt(3), wait=wait_random_exponential(max=60), reraise=True
     )
-    async def get_signed_url(self, object_name: str) -> str:
+    async def get_signed_url(self, object_name: str) -> URLAccessInfo:
         async with self.minio.client("s3", endpoint_url=self.endpoint_host) as s3:
-            return await s3.generate_presigned_url(
+            url = await s3.generate_presigned_url(
                 "get_object",
                 Params={"Bucket": self.bucket, "Key": object_name},
                 ExpiresIn=365 * 24 * 60 * 60,
             )
+            return URLAccessInfo(url=url, headers={}, expiration=sys.maxsize)
+
+    async def update_cache(self, object_names: list[str]) -> None:
+        # this does nothing
+        pass
+
+
+class HTTPDownloadAdapter(DownloadAdapter):
+    # Ask the server what URL to download from
+    # This must be at least 40, the length of the `hash` we are using, or
+    # undefined things will happen.
+    MAX_PATH_LEN = 60
+
+    def __init__(
+        self,
+        servicex: ServiceXAdapter,
+        bucket: str,
+    ):
+        self.session = httpx.AsyncClient()
+
+        self.servicex = servicex
+        self.bucket = bucket
+        self.urlcache: dict[str, URLAccessInfo] = {}
 
     @classmethod
-    def hash_path(cls, file_name):
-        """
-        Make the path safe for object store or POSIX, by keeping the length
-        less than MAX_PATH_LEN. Replace the leading (less interesting) characters with a
-        forty character hash.
-        :param file_name: Input filename
-        :return: Safe path string
-        """
-        if len(file_name) > cls.MAX_PATH_LEN:
-            hash = sha1(file_name.encode("utf-8")).hexdigest()
-            return "".join(
-                [
-                    "_",
-                    hash,
-                    file_name[-1 * (cls.MAX_PATH_LEN - len(hash) - 1) :],  # noqa: E203
-                ]
+    def for_transform(cls, transform: TransformStatus, servicex: ServiceXAdapter):
+        return HTTPDownloadAdapter(
+            servicex=servicex,
+            bucket=transform.request_id,
+        )
+
+    @retry(
+        stop=stop_after_attempt(3), wait=wait_random_exponential(max=60), reraise=True
+    )
+    async def list_bucket(self) -> List[ResultFile]:
+        return []
+
+    @retry(
+        stop=stop_after_attempt(3), wait=wait_random_exponential(max=60), reraise=True
+    )
+    async def download_file(
+        self,
+        object_name: str,
+        local_dir: str,
+        shorten_filename: bool = False,
+        expected_size: Optional[int] = None,
+    ) -> Path:
+        os.makedirs(local_dir, exist_ok=True)
+        path = Path(
+            os.path.join(
+                local_dir,
+                _sanitize_filename(
+                    self.hash_path(object_name) if shorten_filename else object_name,
+                ),
             )
-        else:
-            return file_name
+        )
+
+        async with _file_transfer_sem:
+            if path.exists() and expected_size is not None:
+                # if file size is the same, let's not download anything
+                # maybe move to a better verification mechanism with e-tags in the future
+                localsize = path.stat().st_size
+                if localsize == expected_size:
+                    return path.resolve()
+
+            download_info = await self.get_signed_url(object_name)
+
+            async with self.session.stream(
+                "GET", download_info.url, headers=download_info.headers
+            ) as response:
+                with open(path, "wb") as outfile:
+                    async for chunk in response.aiter_bytes():
+                        outfile.write(chunk)
+            if expected_size is not None:
+                localsize = path.stat().st_size
+                if localsize != expected_size:
+                    raise RuntimeError(f"Download of {object_name} failed")
+        return path.resolve()
+
+    async def get_signed_url(self, object_name: str) -> URLAccessInfo:
+        urldata = self.urlcache.get(object_name)
+        if urldata is None:
+            await self.update_cache([object_name])
+            urldata = self.urlcache.get(object_name)
+            if urldata is None:
+                raise RuntimeError(f"Obtaining URL for {object_name} failed")
+        return urldata
+
+    @retry(
+        stop=stop_after_attempt(3), wait=wait_random_exponential(max=60), reraise=True
+    )
+    async def update_cache(self, object_names: list[str]) -> None:
+        to_lookup: list[str] = []
+        for key in object_names:
+            if key not in self.urlcache:
+                to_lookup.append(key)
+        if to_lookup:
+            download_info = await self.session.post(
+                f"{self.servicex.url}/servicex/transformation/file-urls",
+                json={"request_id": self.bucket, "file_list": to_lookup},
+                headers={"Authorization": f"Bearer {self.servicex.token}"},
+            )
+            self.urlcache |= {
+                key: URLAccessInfo(url=val[0], headers=val[1], expiration=val[2])
+                for key, val in download_info.json()["uris"].items()
+            }
+
+
+async def get_download_adapter(
+    current_status: TransformStatus, servicex: ServiceXAdapter
+):
+    if "generate_file_urls" in await servicex.get_servicex_capabilities():
+        return HTTPDownloadAdapter.for_transform(current_status, servicex)
+    else:
+        return MinioAdapter.for_transform(current_status)

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -224,6 +224,8 @@ class TransformedResults(DocStringBaseModel):
     """List of downloaded files on local disk"""
     signed_url_list: List[str]
     """List of URLs to retrieve output from remote ServiceX object store"""
+    headers: List[dict[str, str]]
+    """List of headers needed to retrieve outputs with URLs (e.g. needed authentication)"""
     files: int
     """Number of files in result"""
     result_format: ResultFormat

--- a/servicex/models.py
+++ b/servicex/models.py
@@ -226,6 +226,8 @@ class TransformedResults(DocStringBaseModel):
     """List of URLs to retrieve output from remote ServiceX object store"""
     headers: List[dict[str, str]]
     """List of headers needed to retrieve outputs with URLs (e.g. needed authentication)"""
+    expiries: List[int]
+    """List of expiry times for URLs (Unix epoch in seconds)"""
     files: int
     """Number of files in result"""
     result_format: ResultFormat

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -65,7 +65,8 @@ class QueryCache:
         completed_status: TransformStatus,
         data_dir: str,
         file_list: List[str],
-        signed_urls,
+        signed_urls: List[str],
+        headers: List[dict[str, str]],
     ) -> TransformedResults:
         return TransformedResults(
             hash=transform.compute_hash(),
@@ -76,6 +77,7 @@ class QueryCache:
             data_dir=data_dir,
             file_list=file_list,
             signed_url_list=signed_urls,
+            headers=headers,
             files=completed_status.files,
             result_format=transform.result_format,
             log_url=completed_status.log_url,
@@ -191,7 +193,7 @@ class QueryCache:
         if len(records) != 1:
             raise CacheException("Multiple records found in db for hash")
         else:
-            return TransformedResults(**records[0])
+            return TransformedResults(**self._patch_missing_fields(records[0]))
 
     def get_transform_by_request_id(
         self, request_id: str
@@ -210,7 +212,7 @@ class QueryCache:
         if len(records) != 1:
             raise CacheException("Multiple records found in db for request_id")
         else:
-            return TransformedResults(**records[0])
+            return TransformedResults(**self._patch_missing_fields(records[0]))
 
     def cache_path_for_transform(self, transform_status: TransformStatus) -> Path:
         assert self.config.cache_path is not None, "Cache path not set"
@@ -224,7 +226,7 @@ class QueryCache:
 
         with self.lock:
             result = [
-                TransformedResults(**doc)
+                TransformedResults(**self._patch_missing_fields(doc))
                 for doc in self.db.search(
                     transforms.request_id.exists() & ~(transforms.status == "SUBMITTED")
                 )
@@ -250,3 +252,9 @@ class QueryCache:
         transforms = Query()
         with self.lock:
             self.db.remove(transforms.hash == hash)
+
+    def _patch_missing_fields(self, rec: dict) -> dict:
+        rv = rec.copy()
+        if "headers" not in rv:
+            rv["headers"] = [{}] * len(rv["file_list"])
+        return rv

--- a/servicex/query_cache.py
+++ b/servicex/query_cache.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import json
 import os
+import sys
 from pathlib import Path
 from typing import List, Optional
 from datetime import datetime, timezone
@@ -67,6 +68,7 @@ class QueryCache:
         file_list: List[str],
         signed_urls: List[str],
         headers: List[dict[str, str]],
+        expiries: List[int],
     ) -> TransformedResults:
         return TransformedResults(
             hash=transform.compute_hash(),
@@ -78,6 +80,7 @@ class QueryCache:
             file_list=file_list,
             signed_url_list=signed_urls,
             headers=headers,
+            expiries=expiries,
             files=completed_status.files,
             result_format=transform.result_format,
             log_url=completed_status.log_url,
@@ -257,4 +260,6 @@ class QueryCache:
         rv = rec.copy()
         if "headers" not in rv:
             rv["headers"] = [{}] * len(rv["file_list"])
+        if "expiries" not in rv:
+            rv["expiries"] = [sys.maxsize] * len(rv["file_list"])
         return rv

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -33,7 +33,7 @@ import asyncio
 from abc import ABC
 from asyncio import Task, CancelledError
 import logging
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 from servicex.expandable_progress import ExpandableProgress
 from rich.logging import RichHandler
 
@@ -42,7 +42,11 @@ from servicex.types import DID
 from rich.progress import Progress, TaskID
 
 from servicex.configuration import Configuration
-from servicex.download_adapter import get_download_adapter, DownloadAdapter
+from servicex.download_adapter import (
+    get_download_adapter,
+    DownloadAdapter,
+    URLAccessInfo,
+)
 from servicex.models import (
     TransformRequest,
     ResultDestination,
@@ -358,19 +362,22 @@ class Query:
         try:
             signed_urls = []
             headers = []
+            expiries = []
             downloaded_files = []
 
             download_result = await download_files_task
             if signed_urls_only:
-                signed_urls = [_.url for _ in download_result]
-                headers = [_.headers for _ in download_result]
+                signed_urls = [_.url for _ in download_result[0]]
+                headers = [_.headers for _ in download_result[0]]
+                expiries = [_.expiration for _ in download_result[0]]
                 if cached_record:
                     cached_record.signed_url_list = signed_urls
                     cached_record.headers = headers
+                    cached_record.expiries = expiries
             else:
-                downloaded_files = download_result
+                downloaded_files = download_result[1]
                 if cached_record:
-                    cached_record.file_list = download_result
+                    cached_record.file_list = downloaded_files
 
             # Update the cache (if no failed files)
             if not cached_record:
@@ -381,6 +388,7 @@ class Query:
                     downloaded_files,
                     signed_urls,
                     headers,
+                    expiries,
                 )
                 if self.current_status.files_failed == 0:
                     self.cache.update_transform_status(sx_request_hash, "COMPLETE")
@@ -579,7 +587,7 @@ class Query:
         progress: ExpandableProgress,
         download_progress: TaskID,
         cached_record: Optional[TransformedResults],
-    ) -> List[str]:
+    ) -> Tuple[List[URLAccessInfo], List[str]]:
         """
         Task to monitor the list of files in the transform output's bucket. Any new files
         will be downloaded.
@@ -699,7 +707,10 @@ class Query:
 
         # Now just wait until all of our tasks complete
         await asyncio.gather(*download_tasks)
-        return result_uris
+        if signed_urls_only:
+            return (result_uris, [])
+        else:
+            return ([], result_uris)
 
     async def as_files_async(
         self,

--- a/servicex/query_core.py
+++ b/servicex/query_core.py
@@ -42,7 +42,7 @@ from servicex.types import DID
 from rich.progress import Progress, TaskID
 
 from servicex.configuration import Configuration
-from servicex.minio_adapter import MinioAdapter
+from servicex.download_adapter import get_download_adapter, DownloadAdapter
 from servicex.models import (
     TransformRequest,
     ResultDestination,
@@ -357,13 +357,16 @@ class Query:
 
         try:
             signed_urls = []
+            headers = []
             downloaded_files = []
 
             download_result = await download_files_task
             if signed_urls_only:
-                signed_urls = download_result
+                signed_urls = [_.url for _ in download_result]
+                headers = [_.headers for _ in download_result]
                 if cached_record:
-                    cached_record.signed_url_list = download_result
+                    cached_record.signed_url_list = signed_urls
+                    cached_record.headers = headers
             else:
                 downloaded_files = download_result
                 if cached_record:
@@ -377,6 +380,7 @@ class Query:
                     self.download_path.as_posix(),
                     downloaded_files,
                     signed_urls,
+                    headers,
                 )
                 if self.current_status.files_failed == 0:
                     self.cache.update_transform_status(sx_request_hash, "COMPLETE")
@@ -567,7 +571,7 @@ class Query:
         # status. This includes the minio host and credentials. We use the
         # transform id as the bucket.
         if not self.minio:
-            self.minio = MinioAdapter.for_transform(self.current_status)
+            self.minio = await get_download_adapter(self.current_status, self.servicex)
 
     async def download_files(
         self,
@@ -587,7 +591,7 @@ class Query:
         loop = asyncio.get_running_loop()
 
         async def download_file(
-            minio: MinioAdapter,
+            minio: DownloadAdapter,
             filename: str,
             progress: Progress,
             download_progress: TaskID,
@@ -604,7 +608,7 @@ class Query:
             progress.advance(task_id=download_progress, task_type="Download")
 
         async def get_signed_url(
-            minio: MinioAdapter,
+            minio: DownloadAdapter,
             filename: str,
             progress: Optional[Progress],
             download_progress: TaskID,
@@ -640,6 +644,8 @@ class Query:
                         )
                     else:
                         files = await self.minio.list_bucket()
+
+                    await self.minio.update_cache([_.filename for _ in files])
 
                     for file in files:
                         filename = file.filename

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -290,9 +290,9 @@ async def deliver_async(
     :return: A dictionary mapping the name of each :py:class:`Sample` to a :py:class:`.GuardList`
             with the file names or URLs for the outputs.
     """
-    from .minio_adapter import init_s3_config
+    from .download_adapter import init_download_concurrency
 
-    init_s3_config(concurrency)
+    init_download_concurrency(concurrency)
     config = _load_ServiceXSpec(spec)
 
     if ignore_local_cache or config.General.IgnoreLocalCache:

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -89,6 +90,7 @@ def test_cache_list(script_runner, tmp_path) -> None:
         file_list=[str(dummy_file)],
         signed_url_list=[],
         headers=[{"a": "b"}],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -133,6 +135,7 @@ def test_cache_list_size(script_runner, tmp_path) -> None:
         file_list=[str(dummy_file)],
         signed_url_list=[],
         headers=[{"a": "b"}],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -165,6 +168,7 @@ def test_cache_list_without_size(script_runner, tmp_path) -> None:
         file_list=[str(dummy_file)],
         signed_url_list=[],
         headers=[{"a": "b"}],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -196,6 +200,7 @@ def test_cache_list_size_gb(script_runner, tmp_path) -> None:
         file_list=[str(dummy_file)],
         signed_url_list=[],
         headers=[{"a": "b"}],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -233,6 +238,7 @@ def test_cache_list_size_tb(script_runner, tmp_path) -> None:
         file_list=[str(dummy_file)],
         signed_url_list=[],
         headers=[{"a": "b"}],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -296,6 +302,7 @@ def test_cache_delete(script_runner, tmp_path) -> None:
         file_list=[str(dummy_file)],
         signed_url_list=[],
         headers=[{"a": "b"}],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )

--- a/tests/app/test_app.py
+++ b/tests/app/test_app.py
@@ -88,6 +88,7 @@ def test_cache_list(script_runner, tmp_path) -> None:
         data_dir=str(tmp_path),
         file_list=[str(dummy_file)],
         signed_url_list=[],
+        headers=[{"a": "b"}],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -131,6 +132,7 @@ def test_cache_list_size(script_runner, tmp_path) -> None:
         data_dir=str(tmp_path),
         file_list=[str(dummy_file)],
         signed_url_list=[],
+        headers=[{"a": "b"}],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -162,6 +164,7 @@ def test_cache_list_without_size(script_runner, tmp_path) -> None:
         data_dir=str(tmp_path),
         file_list=[str(dummy_file)],
         signed_url_list=[],
+        headers=[{"a": "b"}],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -192,6 +195,7 @@ def test_cache_list_size_gb(script_runner, tmp_path) -> None:
         data_dir=str(tmp_path),
         file_list=[str(dummy_file)],
         signed_url_list=[],
+        headers=[{"a": "b"}],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -228,6 +232,7 @@ def test_cache_list_size_tb(script_runner, tmp_path) -> None:
         data_dir=str(tmp_path),
         file_list=[str(dummy_file)],
         signed_url_list=[],
+        headers=[{"a": "b"}],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -290,6 +295,7 @@ def test_cache_delete(script_runner, tmp_path) -> None:
         data_dir=str(tmp_path),
         file_list=[str(dummy_file)],
         signed_url_list=[],
+        headers=[{"a": "b"}],
         files=1,
         result_format=ResultFormat.parquet,
     )

--- a/tests/app/test_transforms.py
+++ b/tests/app/test_transforms.py
@@ -167,10 +167,13 @@ def test_transforms_list_filters(
 
 def test_list_files(script_runner, transform_status_record, result_files):
     with patch("servicex.app.transforms.ServiceXClient") as mock_servicex:
-        with patch("servicex.app.transforms.MinioAdapter") as mock_minio:
+        with patch("servicex.download_adapter.MinioAdapter") as mock_minio:
             mock_transform_status = AsyncMock(return_value=transform_status_record)
             mock_servicex.return_value.get_transform_status_async = (
                 mock_transform_status
+            )
+            mock_servicex.return_value.servicex.get_servicex_capabilities = AsyncMock(
+                return_value=[]
             )
 
             mock_minio_adapter = Mock()
@@ -201,10 +204,13 @@ def test_list_files(script_runner, transform_status_record, result_files):
 
 def test_download_files(script_runner, transform_status_record, result_files):
     with patch("servicex.app.transforms.ServiceXClient") as mock_servicex:
-        with patch("servicex.app.transforms.MinioAdapter") as mock_minio:
+        with patch("servicex.download_adapter.MinioAdapter") as mock_minio:
             mock_transform_status = AsyncMock(return_value=transform_status_record)
             mock_servicex.return_value.get_transform_status_async = (
                 mock_transform_status
+            )
+            mock_servicex.return_value.servicex.get_servicex_capabilities = AsyncMock(
+                return_value=[]
             )
 
             mock_minio_adapter = Mock()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -43,6 +43,7 @@ from servicex.download_adapter import MinioAdapter
 
 import pandas as pd
 import os
+import sys
 
 
 @fixture
@@ -93,7 +94,8 @@ def transformed_result_python_dataset(dummy_parquet_file) -> TransformedResults:
         data_dir="/foo/bar",
         file_list=[dummy_parquet_file],
         signed_url_list=[],
-        headers=[],
+        headers=[{}],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -177,6 +179,7 @@ def transformed_result(dummy_parquet_file) -> TransformedResults:
         file_list=[dummy_parquet_file],
         signed_url_list=[],
         headers=[],
+        expiries=[sys.maxsize],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -197,6 +200,7 @@ def transformed_result_signed_url() -> TransformedResults:
             "https://dummy.junk.io/2.parquet",
         ],
         headers=[{}, {}],
+        expiries=[sys.maxsize, sys.maxsize],
         files=2,
         result_format=ResultFormat.root_ttree,
     )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,7 @@ from servicex.models import (
 )
 
 from servicex.dataset_identifier import FileListDataset
-from servicex.minio_adapter import MinioAdapter
+from servicex.download_adapter import MinioAdapter
 
 import pandas as pd
 import os
@@ -93,6 +93,7 @@ def transformed_result_python_dataset(dummy_parquet_file) -> TransformedResults:
         data_dir="/foo/bar",
         file_list=[dummy_parquet_file],
         signed_url_list=[],
+        headers=[],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -175,6 +176,7 @@ def transformed_result(dummy_parquet_file) -> TransformedResults:
         data_dir="/foo/bar",
         file_list=[dummy_parquet_file],
         signed_url_list=[],
+        headers=[],
         files=1,
         result_format=ResultFormat.parquet,
     )
@@ -194,6 +196,7 @@ def transformed_result_signed_url() -> TransformedResults:
             "https://dummy.junk.io/1.parquet",
             "https://dummy.junk.io/2.parquet",
         ],
+        headers=[{}, {}],
         files=2,
         result_format=ResultFormat.root_ttree,
     )

--- a/tests/test_code_generator_fetch.py
+++ b/tests/test_code_generator_fetch.py
@@ -20,7 +20,7 @@ async def test_codegen_list_fetched_when_not_cached(mocker):
     sx_adapter.get_code_generators_async = AsyncMock(return_value={"uproot": "img"})
     sx_adapter.url = "http://example.com"
 
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=AsyncMock())
+    mocker.patch("servicex.download_adapter.MinioAdapter", return_value=AsyncMock())
 
     cache = MagicMock(spec=QueryCache)
     cache.get_transform_by_hash.return_value = None

--- a/tests/test_code_generator_fetch.py
+++ b/tests/test_code_generator_fetch.py
@@ -37,7 +37,7 @@ async def test_codegen_list_fetched_when_not_cached(mocker):
         query=GenericQueryStringGenerator("1", "uproot"),
     )
 
-    mocker.patch.object(Query, "download_files", AsyncMock(return_value=[]))
+    mocker.patch.object(Query, "download_files", AsyncMock(return_value=([], [])))
 
     await q.as_files_async(display_progress=False)
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -168,7 +168,7 @@ async def test_download_files(python_dataset):
     )
     minio_mock.download_file.assert_awaited()
     minio_mock.get_signed_url.assert_not_awaited()
-    assert result_uris == ["/path/to/downloaded_file", "/path/to/downloaded_file"]
+    assert result_uris == ([], ["/path/to/downloaded_file", "/path/to/downloaded_file"])
 
 
 @pytest.mark.asyncio
@@ -211,10 +211,13 @@ async def test_download_files_with_signed_urls(python_dataset):
     )
     minio_mock.download_file.assert_not_called()
     minio_mock.get_signed_url.assert_called()
-    assert result_uris == [
-        "http://example.com/signed_url",
-        "http://example.com/signed_url",
-    ]
+    assert result_uris == (
+        [
+            "http://example.com/signed_url",
+            "http://example.com/signed_url",
+        ],
+        [],
+    )
 
 
 @pytest.mark.asyncio
@@ -442,7 +445,7 @@ async def test_submit_and_download_cache_miss(python_dataset, completed_status):
         python_dataset.servicex.get_transform_status.return_value = completed_status
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
-        python_dataset.download_files.return_value = []
+        python_dataset.download_files.return_value = ([], [])
         python_dataset.cache.cache_submitted_transform = Mock()
 
         signed_urls_only = False
@@ -475,7 +478,7 @@ async def test_submit_and_download_cache_miss_overall_progress(
         python_dataset.servicex.get_transform_status.return_value = completed_status
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
-        python_dataset.download_files.return_value = []
+        python_dataset.download_files.return_value = ([], [])
         python_dataset.cache.cache_submitted_transform = Mock()
 
         signed_urls_only = False
@@ -512,7 +515,7 @@ async def test_submit_and_download_no_result_format(python_dataset, completed_st
             python_dataset.servicex.get_transform_status.return_value = completed_status
             python_dataset.servicex.submit_transform = AsyncMock()
             python_dataset.download_files = AsyncMock()
-            python_dataset.download_files.return_value = []
+            python_dataset.download_files.return_value = ([], [])
             signed_urls_only = False
             expandable_progress = ExpandableProgress()
             await python_dataset.submit_and_download(
@@ -544,7 +547,7 @@ async def test_submit_and_download_cache_miss_signed_urls_only(
         python_dataset.servicex.get_transform_status.return_value = completed_status
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
-        python_dataset.download_files.return_value = []
+        python_dataset.download_files.return_value = ([], [])
         python_dataset.cache.cache_submitted_transform = Mock()
 
         signed_urls_only = True
@@ -678,7 +681,7 @@ async def test_submit_and_download_get_request_id_from_previous_submitted_reques
         python_dataset.servicex.get_transform_status.return_value = completed_status
         python_dataset.servicex.submit_transform = AsyncMock()
         python_dataset.download_files = AsyncMock()
-        python_dataset.download_files.return_value = []
+        python_dataset.download_files.return_value = ([], [])
         python_dataset.cache.is_transform_request_submitted = Mock(return_value=True)
         python_dataset.cache.get_transform_request_id = Mock(
             return_value="b8c508d0-ccf2-4deb-a1f7-65c839eebabf"

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -33,7 +33,7 @@ import datetime
 from unittest.mock import AsyncMock, Mock, patch
 from servicex.dataset_identifier import FileListDataset
 from servicex.configuration import Configuration
-from servicex.minio_adapter import MinioAdapter
+from servicex.download_adapter import MinioAdapter
 from servicex.query_core import Query
 from servicex.query_cache import QueryCache
 from servicex.expandable_progress import ExpandableProgress

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import pytest
+from pathlib import Path
 
 from servicex.download_adapter import HTTPDownloadAdapter
 from servicex.models import ResultFile
@@ -105,6 +106,21 @@ async def test_download_file_with_expected_size(httpserver, content, tmp_path):
     assert result.exists()
     assert result.read_bytes() == (b"\x01" * 10)
     result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_download_file_with_bad_expected_size(httpserver, content, tmp_path):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    info = await http_adapter.list_bucket()
+    assert len(info) == 1
+    with pytest.raises(RuntimeError):
+        await http_adapter.download_file(
+            "test.txt", local_dir=tmp_path, expected_size=11
+        )
+    result = Path(tmp_path) / "text.txt"
+    assert not result.exists()
 
 
 @pytest.mark.parametrize("content", ["t::est.txt"])
@@ -188,6 +204,15 @@ async def test_get_signed_url(httpserver, content):
     http_adapter = adapter(httpserver)
     result = await http_adapter.get_signed_url("test.txt")
     assert result.url.startswith(httpserver.url_for("/"))
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_get_signed_url_bad_file(httpserver, content):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    with pytest.raises(RuntimeError):
+        await http_adapter.get_signed_url("test2.txt")
 
 
 # @pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -1,0 +1,204 @@
+# Copyright (c) 2022-2025, IRIS-HEP
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import pytest
+
+from servicex.download_adapter import HTTPDownloadAdapter
+from servicex.models import ResultFile
+from servicex.servicex_adapter import ServiceXAdapter
+
+DOWNLOAD_PATCH_COUNTER = 0
+
+
+def adapter(httpserver) -> HTTPDownloadAdapter:
+    mock_servicex = ServiceXAdapter(httpserver.url_for("/"))
+    httpserver.expect_request("/servicex").respond_with_json(
+        {
+            "app-version": "1.9.0",
+            "code-gen-image": {},
+            "capabilities": ["poll_local_transformation_results", "generate_file_urls"],
+        }
+    )
+    return HTTPDownloadAdapter(mock_servicex, "bucket")
+
+
+def populate_bucket(request, httpserver):
+    httpserver.expect_request(
+        "/servicex/transformation/bucket/results"
+    ).respond_with_json(
+        {
+            "results": [
+                {
+                    "s3-object-name": _,
+                    "total-bytes": 10,
+                    "transform_status": "success",
+                    "created_at": "2026-07-14 12:00+0000",
+                }
+                for _ in request
+            ]
+        }
+    )
+    httpserver.expect_request("/servicex/transformation/file-urls").respond_with_json(
+        {"uris": {_: (httpserver.url_for("/") + f"files/{_}", {}, 0) for _ in request}}
+    )
+    for _ in request:
+        httpserver.expect_request(f"/files/{_}").respond_with_data(b"\x01" * 10)
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_list_bucket(httpserver, content):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    files = [ResultFile(filename="test.txt", size=10, extension="txt")]
+    result = await http_adapter.list_bucket()
+    assert result == files
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_download_file(httpserver, content, tmp_path):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    result = await http_adapter.download_file("test.txt", local_dir=tmp_path)
+    assert str(result).endswith("test.txt")
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_download_file_with_expected_size(httpserver, content, tmp_path):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    info = await http_adapter.list_bucket()
+    assert len(info) == 1
+    result = await http_adapter.download_file(
+        "test.txt", local_dir=tmp_path, expected_size=info[0].size
+    )
+    assert str(result).endswith("test.txt")
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize("content", ["t::est.txt"])
+@pytest.mark.asyncio
+async def test_download_bad_filename(httpserver, content, tmp_path):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    result = await http_adapter.download_file("t::est.txt", local_dir=tmp_path)
+    assert str(result).endswith("t__est.txt")
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_download_short_filename_no_change(httpserver, content, tmp_path):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    result = await http_adapter.download_file(
+        "test.txt", local_dir=tmp_path, shorten_filename=True
+    )
+    assert str(result).endswith("test.txt")
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        "test12345678901234567890123456789012345678901234567898012345678901234567890.txt"  # noqa: E501
+    ],
+)
+@pytest.mark.asyncio
+async def test_download_short_filename_change(httpserver, content, tmp_path):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    result = await http_adapter.download_file(
+        "test12345678901234567890123456789012345678901234567898012345678901234567890.txt",
+        local_dir=tmp_path,
+        shorten_filename=True,
+    )
+
+    # Some of the filename should be left over still...
+    assert str(result).endswith("01234567890.txt")
+
+    # Make sure the length is right
+    assert len(result.name) == 60
+
+    assert result.exists()
+    assert result.read_bytes() == (b"\x01" * 10)
+    result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_download_repeat(httpserver, content, tmp_path):
+    import asyncio
+
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+
+    result = await http_adapter.download_file("test.txt", local_dir=tmp_path)
+    assert str(result).endswith("test.txt")
+    assert result.exists()
+    t0 = result.stat().st_mtime_ns
+    await asyncio.sleep(4)  # hopefully long enough for Windows/FAT32 ... ?
+
+    result2 = await http_adapter.download_file("test.txt", local_dir=tmp_path)
+    assert result2.exists()
+    assert result2 == result
+    assert t0 == result2.stat().st_mtime_ns
+    result.unlink()  # it should exist, from above ...
+
+
+@pytest.mark.parametrize("content", ["test.txt"])
+@pytest.mark.asyncio
+async def test_get_signed_url(httpserver, content):
+    populate_bucket([content], httpserver)
+    http_adapter = adapter(httpserver)
+    result = await http_adapter.get_signed_url("test.txt")
+    assert result.url.startswith(httpserver.url_for("/"))
+
+
+# @pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)
+# @pytest.mark.asyncio
+# async def test_download_file_retry(minio_adapter, populate_bucket, mocker, tmp_path):
+#     download_patch = mocker.patch(
+#         "aioboto3.s3.inject.download_file",
+#         side_effect=make_mock_downloader(tmp_path / "test.txt"),
+#     )
+#     result = await minio_adapter.download_file("test.txt", local_dir=tmp_path)
+#     assert str(result).endswith("test.txt")
+#     assert result.exists()
+#     assert download_patch.call_count == 3
+#     result.unlink()

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import pytest
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 from servicex.download_adapter import HTTPDownloadAdapter
 from servicex.models import ResultFile
@@ -213,6 +214,15 @@ async def test_get_signed_url_bad_file(httpserver, content):
     http_adapter = adapter(httpserver)
     with pytest.raises(RuntimeError):
         await http_adapter.get_signed_url("test2.txt")
+
+
+def _sx_mock() -> AsyncMock:
+    """Create a ServiceX adapter mock with code generators configured."""
+    mock = AsyncMock()
+    mock.get_code_generators_async = AsyncMock(
+        return_value={"uproot": "img", "uproot-raw": "img"}
+    )
+    return mock
 
 
 # @pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -57,7 +57,7 @@ def populate_bucket(request, httpserver):
                     "s3-object-name": _,
                     "total-bytes": 10,
                     "transform_status": "success",
-                    "created_at": "2026-07-14 12:00+0000",
+                    "created_at": "2026-07-14T12:00:00+0000",
                 }
                 for _ in request
             ]

--- a/tests/test_http_adapter.py
+++ b/tests/test_http_adapter.py
@@ -57,7 +57,7 @@ def populate_bucket(request, httpserver):
                     "s3-object-name": _,
                     "total-bytes": 10,
                     "transform_status": "success",
-                    "created_at": "2026-07-14T12:00:00+0000",
+                    "created_at": "2026-07-14T12:00:00+00:00",
                 }
                 for _ in request
             ]

--- a/tests/test_minio_adapter.py
+++ b/tests/test_minio_adapter.py
@@ -30,7 +30,7 @@ import urllib.parse
 import pytest
 from pytest_asyncio import fixture
 
-from servicex.minio_adapter import MinioAdapter
+from servicex.download_adapter import MinioAdapter
 from servicex.models import ResultFile
 from pathlib import Path
 
@@ -193,7 +193,7 @@ async def test_download_repeat(minio_adapter, populate_bucket, tmp_path):
 @pytest.mark.asyncio
 async def test_get_signed_url(minio_adapter, moto_services, populate_bucket):
     result = await minio_adapter.get_signed_url("test.txt")
-    assert result.startswith(moto_services["s3"])
+    assert result.url.startswith(moto_services["s3"])
 
 
 @pytest.mark.parametrize("populate_bucket", ["test.txt"], indirect=True)

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -86,6 +86,7 @@ def test_cache_transform(transform_request, completed_status):
                 data_dir="/foo/bar",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             )
         )
 
@@ -112,6 +113,7 @@ def test_cache_transform(transform_request, completed_status):
                 data_dir="/foo/baz",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             )
         )
 
@@ -125,6 +127,7 @@ def test_cache_transform(transform_request, completed_status):
                 data_dir="/foo/baz",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             ).model_dump_json()
         )
         record["hash"] = transform_request.compute_hash()
@@ -164,6 +167,7 @@ def test_record_delete(transform_request, completed_status):
                 data_dir="/foo/bar",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             )
         )
         transform_request.did = "rucio://foo.baz"
@@ -176,6 +180,7 @@ def test_record_delete(transform_request, completed_status):
                 data_dir="/foo/baz",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             )
         )
         assert len(cache.cached_queries()) == 2
@@ -196,6 +201,7 @@ def test_delete_transform_by_hash(transform_request, completed_status):
                 data_dir="/foo/bar",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             )
         )
 
@@ -222,6 +228,7 @@ def test_contains_hash(transform_request, completed_status):
                 data_dir="/foo/bar",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             )
         )
 
@@ -270,6 +277,7 @@ def test_get_transform_request_status(transform_request, completed_status):
                 data_dir="/foo/bar",
                 file_list=file_uris,
                 signed_urls=[],
+                headers=[{}] * len(file_uris),
             )
         )
 

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -29,6 +29,7 @@ import os
 import tempfile
 import json
 import pytest
+from pathlib import Path
 
 from servicex.configuration import Configuration
 from servicex.models import ResultFormat
@@ -310,3 +311,22 @@ def test_cache_queries_in_state(transform_request):
         )
 
         cache.close()
+
+
+def test_patch_old_db():
+    with tempfile.TemporaryDirectory() as temp_dir:
+        config = Configuration(cache_path=temp_dir, api_endpoints=[])  # type: ignore
+        cache = QueryCache(config)
+        cache.close()
+        with open(Path(temp_dir) / ".servicex" / "db.json", "w") as f:
+            f.write(
+                """{"_default": {"207": {"hash": "hash", "title": "123456", "codegen": "uproot","""
+                """ "result_format": "root-file", "request_id": "123456", "status": "COMPLETE","""
+                """ "submit_time": "2026-02-04T17:53:56.642131Z", "data_dir": "123456","""
+                """ "file_list": ["a"], "signed_url_list": [], "files": 1,"""
+                """ "log_url": "https://testing/"}}} """
+            )
+        cache = QueryCache(config)
+        transform = cache.get_transform_by_hash("hash")
+        assert transform is not None
+        assert transform.headers == [{}]

--- a/tests/test_query_cache.py
+++ b/tests/test_query_cache.py
@@ -26,6 +26,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 import os
+import sys
 import tempfile
 import json
 import pytest
@@ -88,6 +89,7 @@ def test_cache_transform(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             )
         )
 
@@ -115,6 +117,7 @@ def test_cache_transform(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             )
         )
 
@@ -129,6 +132,7 @@ def test_cache_transform(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             ).model_dump_json()
         )
         record["hash"] = transform_request.compute_hash()
@@ -169,6 +173,7 @@ def test_record_delete(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             )
         )
         transform_request.did = "rucio://foo.baz"
@@ -182,6 +187,7 @@ def test_record_delete(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             )
         )
         assert len(cache.cached_queries()) == 2
@@ -203,6 +209,7 @@ def test_delete_transform_by_hash(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             )
         )
 
@@ -230,6 +237,7 @@ def test_contains_hash(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             )
         )
 
@@ -279,6 +287,7 @@ def test_get_transform_request_status(transform_request, completed_status):
                 file_list=file_uris,
                 signed_urls=[],
                 headers=[{}] * len(file_uris),
+                expiries=[sys.maxsize] * len(file_uris),
             )
         )
 
@@ -330,3 +339,4 @@ def test_patch_old_db():
         transform = cache.get_transform_by_hash("hash")
         assert transform is not None
         assert transform.headers == [{}]
+        assert transform.expiries == [sys.maxsize]

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from datetime import datetime
 from pathlib import Path
+import sys
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -114,6 +115,7 @@ def transformed_results() -> TransformedResults:
             "https://example.com/signed-url-2",
         ],
         "headers": [{}, {}],
+        "expiries": [sys.maxsize, sys.maxsize],
         "files": 2,
         "result_format": ResultFormat.parquet,
         "log_url": "https://logs.servicex.com/request-789",

--- a/tests/test_servicex_client.py
+++ b/tests/test_servicex_client.py
@@ -113,6 +113,7 @@ def transformed_results() -> TransformedResults:
             "https://example.com/signed-url-1",
             "https://example.com/signed-url-2",
         ],
+        "headers": [{}, {}],
         "files": 2,
         "result_format": ResultFormat.parquet,
         "log_url": "https://logs.servicex.com/request-789",
@@ -169,7 +170,7 @@ async def test_deliver_async_invalid_delivery_config():
     # Mock the config loading to return invalid delivery type
     with patch("servicex.servicex_client._load_ServiceXSpec") as mock_load_spec:
         with patch("servicex.servicex_client._build_datasets") as mock_build_datasets:
-            with patch("servicex.minio_adapter.init_s3_config"):
+            with patch("servicex.download_adapter.init_download_concurrency"):
                 mock_config = MagicMock()
                 mock_config.General.Delivery = (
                     "INVALID_DELIVERY"  # Invalid delivery type

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -196,6 +196,7 @@ def transformed_results(
     file_list: List[str],
     signed_urls,
     headers,
+    expiries,
 ) -> TransformedResults:
     return TransformedResults(
         hash=transform.compute_hash(),
@@ -207,6 +208,7 @@ def transformed_results(
         file_list=file_list,
         signed_url_list=signed_urls,
         headers=headers,
+        expiries=expiries,
         files=completed_status.files,
         result_format=transform.result_format,
         log_url=completed_status.log_url,
@@ -920,3 +922,114 @@ async def test_use_of_ignore_cache(mocker, servicex):
         mock_minio.download_file.assert_not_awaited()
         assert len(res.signed_url_list) == 2
         cache.close()
+
+
+def adapter(httpserver) -> None:
+    httpserver.expect_request("/servicex").respond_with_json(
+        {
+            "app-version": "1.9.0",
+            "code-gen-image": {},
+            "capabilities": ["poll_local_transformation_results", "generate_file_urls"],
+        }
+    )
+
+
+def populate_bucket(request, httpserver):
+    httpserver.expect_request(
+        "/servicex/transformation/bucket/results"
+    ).respond_with_json(
+        {
+            "results": [
+                {
+                    "s3-object-name": _,
+                    "total-bytes": 10,
+                    "transform_status": "success",
+                    "created_at": "2026-07-14T12:00:00+00:00",
+                }
+                for _ in request
+            ]
+        }
+    )
+    httpserver.expect_request("/servicex/transformation/file-urls").respond_with_json(
+        {"uris": {_: (httpserver.url_for("/") + f"files/{_}", {}, 0) for _ in request}}
+    )
+    for _ in request:
+        httpserver.expect_request(f"/files/{_}").respond_with_data(b"\x01" * 10)
+
+
+@pytest.mark.asyncio
+async def test_submit_chain(mocker, httpserver):
+    adapter(httpserver)
+    populate_bucket(["file1", "file2"], httpserver)
+    servicex = _sx_mock()
+    servicex.submit_transform = AsyncMock()
+    servicex.submit_transform.return_value = {"request_id": "123-456-789"}
+
+    # Configure capabilities based on polling type
+    capabilities = ["poll_local_transformation_results", "generate_file_urls"]
+    servicex.get_servicex_capabilities = AsyncMock(return_value=capabilities)
+    servicex.url = httpserver.url_for("/")
+
+    servicex.get_transformation_results = AsyncMock(
+        side_effect=[
+            [
+                ServiceXFile(
+                    filename="file1",
+                    total_bytes=100,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                )
+            ],
+            [
+                ServiceXFile(
+                    filename="file1",
+                    total_bytes=100,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                ),
+                ServiceXFile(
+                    filename="file2",
+                    total_bytes=100,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                ),
+            ],
+        ]
+    )
+
+    servicex.get_transform_status = AsyncMock()
+    servicex.get_transform_status.side_effect = [
+        transform_status1,
+        transform_status2,
+        transform_status3,
+    ]
+
+    mocker.patch(
+        "servicex.download_adapter.HTTPDownloadAdapter.download_file",
+        side_effect=lambda a, _, shorten_filename, expected_size: PurePath(a),
+    )
+
+    mock_cache = mocker.MagicMock(QueryCache)
+    mock_cache.get_transform_by_hash = mocker.MagicMock(return_value=None)
+    mock_cache.transformed_results = mocker.MagicMock(side_effect=transformed_results)
+    mock_cache.cache_transform = mocker.MagicMock(side_effect=cache_transform)
+    mock_cache.cache_path_for_transform = mocker.MagicMock(return_value=PurePath("."))
+
+    did = FileListDataset("/foo/bar/baz.root")
+    datasource = Query(
+        dataset_identifier=did,
+        title="ServiceX Client",
+        codegen="uproot",
+        sx_adapter=servicex,
+        query_cache=mock_cache,
+        config=Configuration(
+            api_endpoints=[{"name": "default", "endpoint": httpserver.url_for("/")}]
+        ),
+    )
+    datasource.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
+
+    with ExpandableProgress(display_progress=False) as progress:
+        datasource.result_format = ResultFormat.parquet
+        result = await datasource.submit_and_download(
+            signed_urls_only=False, expandable_progress=progress
+        )
+
+    assert result.file_list == ["file1", "file2"]
+    mock_cache.cache_transform.assert_called_once()

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -299,6 +299,84 @@ async def test_submit(mocker, use_s3_polling):
     mock_cache.cache_transform.assert_called_once()
 
 
+@pytest.mark.asyncio
+async def test_submit_remote_urls(mocker):
+    servicex = _sx_mock()
+    servicex.submit_transform = AsyncMock()
+    servicex.submit_transform.return_value = {"request_id": "123-456-789"}
+
+    # Configure capabilities based on polling type
+    capabilities = ["poll_local_transformation_results", "generate_file_urls"]
+    servicex.get_servicex_capabilities = AsyncMock(return_value=capabilities)
+
+    servicex.get_transformation_results = AsyncMock(
+        side_effect=[
+            [
+                ServiceXFile(
+                    filename="file1",
+                    total_bytes=100,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                )
+            ],
+            [
+                ServiceXFile(
+                    filename="file1",
+                    total_bytes=100,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                ),
+                ServiceXFile(
+                    filename="file2",
+                    total_bytes=100,
+                    created_at=datetime.datetime.now(datetime.timezone.utc),
+                ),
+            ],
+        ]
+    )
+
+    servicex.get_transform_status = AsyncMock()
+    servicex.get_transform_status.side_effect = [
+        transform_status1,
+        transform_status2,
+        transform_status3,
+    ]
+
+    mock_http = AsyncMock()
+    mock_http.download_file = AsyncMock(
+        side_effect=lambda a, _, shorten_filename, expected_size: PurePath(a)
+    )
+
+    mock_cache = mocker.MagicMock(QueryCache)
+    mock_cache.get_transform_by_hash = mocker.MagicMock(return_value=None)
+    mock_cache.transformed_results = mocker.MagicMock(side_effect=transformed_results)
+    mock_cache.cache_transform = mocker.MagicMock(side_effect=cache_transform)
+    mock_cache.cache_path_for_transform = mocker.MagicMock(return_value=PurePath("."))
+
+    mocker.patch(
+        "servicex.download_adapter.HTTPDownloadAdapter.for_transform",
+        return_value=mock_http,
+    )
+
+    did = FileListDataset("/foo/bar/baz.root")
+    datasource = Query(
+        dataset_identifier=did,
+        title="ServiceX Client",
+        codegen="uproot",
+        sx_adapter=servicex,
+        query_cache=mock_cache,
+        config=Configuration(api_endpoints=[]),
+    )
+    datasource.query_string_generator = FuncADLQuery_Uproot().FromTree("nominal")
+
+    with ExpandableProgress(display_progress=False) as progress:
+        datasource.result_format = ResultFormat.parquet
+        result = await datasource.submit_and_download(
+            signed_urls_only=False, expandable_progress=progress
+        )
+
+    assert result.file_list == ["file1", "file2"]
+    mock_cache.cache_transform.assert_called_once()
+
+
 @pytest.mark.parametrize("use_s3_polling", [False, True])
 @pytest.mark.asyncio
 async def test_submit_partial_success(mocker, use_s3_polling):

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -50,6 +50,7 @@ from servicex.query_core import ServiceXException, Query
 from servicex.servicex_adapter import ServiceXFile
 from servicex.servicex_client import ServiceXClient
 from servicex.uproot_raw.uproot_raw import UprootRawQuery
+from servicex.download_adapter import URLAccessInfo
 
 
 def _sx_mock() -> AsyncMock:
@@ -194,6 +195,7 @@ def transformed_results(
     data_dir: str,
     file_list: List[str],
     signed_urls,
+    headers,
 ) -> TransformedResults:
     return TransformedResults(
         hash=transform.compute_hash(),
@@ -204,6 +206,7 @@ def transformed_results(
         data_dir=data_dir,
         file_list=file_list,
         signed_url_list=signed_urls,
+        headers=headers,
         files=completed_status.files,
         result_format=transform.result_format,
         log_url=completed_status.log_url,
@@ -271,7 +274,9 @@ async def test_submit(mocker, use_s3_polling):
     mock_cache.cache_transform = mocker.MagicMock(side_effect=cache_transform)
     mock_cache.cache_path_for_transform = mocker.MagicMock(return_value=PurePath("."))
 
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch(
+        "servicex.download_adapter.MinioAdapter.for_transform", return_value=mock_minio
+    )
 
     did = FileListDataset("/foo/bar/baz.root")
     datasource = Query(
@@ -335,6 +340,7 @@ async def test_submit_partial_success(mocker, use_s3_polling):
     mock_minio.download_file = AsyncMock(
         side_effect=lambda a, _, shorten_filename, expected_size: PurePath(a)
     )
+    mock_minio.update_cache = AsyncMock()
 
     if use_s3_polling:
         mock_minio.list_bucket = AsyncMock(side_effect=[[file1], [file1]])
@@ -345,7 +351,9 @@ async def test_submit_partial_success(mocker, use_s3_polling):
     mock_cache.cache_transform = mocker.MagicMock(side_effect=cache_transform)
     mock_cache.cache_path_for_transform = mocker.MagicMock(return_value=PurePath("."))
 
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch(
+        "servicex.download_adapter.MinioAdapter.for_transform", return_value=mock_minio
+    )
 
     did = FileListDataset("/foo/bar/baz.root")
     datasource = Query(
@@ -404,12 +412,19 @@ async def test_use_of_cache(mocker, use_s3_polling):
     mock_minio.download_file = AsyncMock(
         side_effect=lambda a, _, shorten_filename, expected_size: PurePath(a)
     )
-    mock_minio.get_signed_url = AsyncMock(side_effect=["http://file1", "http://file2"])
+    mock_minio.get_signed_url = AsyncMock(
+        side_effect=[
+            URLAccessInfo("http://file1", {}, 0),
+            URLAccessInfo("http://file2", {}, 0),
+        ]
+    )
 
     if use_s3_polling:
         mock_minio.list_bucket = AsyncMock(return_value=[file1, file2])
 
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch(
+        "servicex.download_adapter.MinioAdapter.for_transform", return_value=mock_minio
+    )
 
     did = FileListDataset("/foo/bar/baz.root")
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -522,7 +537,7 @@ async def test_submit_cancel(mocker):
     mock_cache.get_transform_by_hash = mocker.MagicMock(return_value=None)
     mock_cache.cache_transform = mocker.MagicMock(side_effect=cache_transform)
     mock_cache.cache_path_for_transform = mocker.MagicMock(return_value=PurePath("."))
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch("servicex.download_adapter.MinioAdapter", return_value=mock_minio)
     did = FileListDataset("/foo/bar/baz.root")
     datasource = Query(
         dataset_identifier=did,
@@ -562,7 +577,9 @@ async def test_submit_fatal(mocker):
     mock_cache.get_transform_by_hash = mocker.MagicMock(return_value=None)
     mock_cache.cache_transform = mocker.MagicMock(side_effect=cache_transform)
     mock_cache.cache_path_for_transform = mocker.MagicMock(return_value=PurePath("."))
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch(
+        "servicex.download_adapter.MinioAdapter.for_transform", return_value=mock_minio
+    )
     did = FileListDataset("/foo/bar/baz.root")
     datasource = Query(
         dataset_identifier=did,
@@ -601,7 +618,7 @@ async def test_submit_generic(mocker, codegen_list):
     mock_minio.download_file = AsyncMock()
 
     mock_cache = mocker.MagicMock(QueryCache)
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch("servicex.download_adapter.MinioAdapter", return_value=mock_minio)
     did = FileListDataset("/foo/bar/baz.root")
     with patch(
         "servicex.servicex_adapter.ServiceXAdapter.get_code_generators",
@@ -649,7 +666,7 @@ async def test_submit_cancelled(mocker, codegen_list):
     mock_minio.download_file = AsyncMock()
 
     mock_cache = mocker.MagicMock(QueryCache)
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch("servicex.download_adapter.MinioAdapter", return_value=mock_minio)
     did = FileListDataset("/foo/bar/baz.root")
     with patch(
         "servicex.servicex_adapter.ServiceXAdapter.get_code_generators",
@@ -733,8 +750,16 @@ async def test_use_of_ignore_cache(mocker, servicex):
     ]
     # Prepare Minio
     mock_minio = AsyncMock()
-    mock_minio.get_signed_url = AsyncMock(side_effect=["http://file1", "http://file2"])
-    mocker.patch("servicex.minio_adapter.MinioAdapter", return_value=mock_minio)
+    mock_minio.get_signed_url = AsyncMock(
+        side_effect=[
+            URLAccessInfo("http://file1", {}, 0),
+            URLAccessInfo("http://file2", {}, 0),
+        ]
+    )
+    mock_minio.update_cache = AsyncMock()
+    mocker.patch(
+        "servicex.download_adapter.MinioAdapter.for_transform", return_value=mock_minio
+    )
     did = FileListDataset("/foo/bar/baz.root")
 
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -784,7 +809,10 @@ async def test_use_of_ignore_cache(mocker, servicex):
 
         # 2nd time sending the same request with ignore_cache (So it will run again)
         mock_minio.get_signed_url = AsyncMock(
-            side_effect=["http://file1", "http://file2"]
+            side_effect=[
+                URLAccessInfo("http://file1", {}, 0),
+                URLAccessInfo("http://file2", {}, 0),
+            ]
         )
         upd = mocker.patch.object(
             cache, "update_record", side_effect=cache.update_record

--- a/tests/test_servicex_dataset.py
+++ b/tests/test_servicex_dataset.py
@@ -537,7 +537,9 @@ async def test_submit_cancel(mocker):
     mock_cache.get_transform_by_hash = mocker.MagicMock(return_value=None)
     mock_cache.cache_transform = mocker.MagicMock(side_effect=cache_transform)
     mock_cache.cache_path_for_transform = mocker.MagicMock(return_value=PurePath("."))
-    mocker.patch("servicex.download_adapter.MinioAdapter", return_value=mock_minio)
+    mocker.patch(
+        "servicex.download_adapter.MinioAdapter.for_transform", return_value=mock_minio
+    )
     did = FileListDataset("/foo/bar/baz.root")
     datasource = Query(
         dataset_identifier=did,


### PR DESCRIPTION
Support for using server-generated URLs for result files.

Sorry that this is kind of a big PR but a lot of the changes are in the tests. The main things that happen here are that when the server reports the appropriate capability flag, we will request the URLs (and associated required headers and an expiry date) from the server, and use those to download files. The cache is updated to store the additional information. We don't do anything with the expiry yet, but in a future PR the expectation would be that we re-request the URLs if we pass the expiry date.