### PR TITLE
Error raised when wrong key in deliver spec

### DIFF
--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -126,9 +126,7 @@ def _async_execute_and_wait(coro: Coroutine) -> Any:
     return asyncio.run(coro)
 
 
-def _check_wrong_keys(
-    config_dict: Mapping[str, Any]
-) -> None:
+def _check_wrong_keys(config_dict: Mapping[str, Any]) -> None:
 
     general_keys = set(General.model_fields.keys())
     usr_general_keys = set(config_dict.get("General", {}).keys())

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -125,10 +125,11 @@ def _async_execute_and_wait(coro: Coroutine) -> Any:
 
     return asyncio.run(coro)
 
+
 def _check_wrong_keys(
     config_dict: Mapping[str, Any]
-)-> None:
-    
+) -> None:
+
     general_keys = set(General.model_fields.keys())
     usr_general_keys = set(config_dict.get("General", {}).keys())
     wrong_general_keys = usr_general_keys - general_keys
@@ -138,10 +139,10 @@ def _check_wrong_keys(
             f"Wrong key(s): {list(wrong_general_keys)}. "
             f"Allowed keys in the 'General' field: {list(general_keys)}"
         )
-        
+
     sample_keys = set(Sample.model_fields.keys())
     user_sample_keys = set()
-    #Sample is a list  
+    # Sample is a list
     for sample in config_dict.get("Sample", []):
         if isinstance(sample, Mapping):
             user_sample_keys.update(sample.keys())
@@ -153,7 +154,8 @@ def _check_wrong_keys(
             f"Wrong key(s): {list(wrong_sample_keys)}. "
             f"Allowed keys in the 'Sample' field: {list(sample_keys)}"
         )
-    
+
+
 def _load_ServiceXSpec(
     config: Union[ServiceXSpec, Mapping[str, Any], str, Path],
 ) -> ServiceXSpec:

--- a/servicex/servicex_client.py
+++ b/servicex/servicex_client.py
@@ -125,12 +125,41 @@ def _async_execute_and_wait(coro: Coroutine) -> Any:
 
     return asyncio.run(coro)
 
+def _check_wrong_keys(
+    config_dict: Mapping[str, Any]
+)-> None:
+    
+    general_keys = set(General.model_fields.keys())
+    usr_general_keys = set(config_dict.get("General", {}).keys())
+    wrong_general_keys = usr_general_keys - general_keys
 
+    if wrong_general_keys:
+        raise TypeError(
+            f"Wrong key(s): {list(wrong_general_keys)}. "
+            f"Allowed keys in the 'General' field: {list(general_keys)}"
+        )
+        
+    sample_keys = set(Sample.model_fields.keys())
+    user_sample_keys = set()
+    #Sample is a list  
+    for sample in config_dict.get("Sample", []):
+        if isinstance(sample, Mapping):
+            user_sample_keys.update(sample.keys())
+
+    wrong_sample_keys = user_sample_keys - sample_keys
+
+    if wrong_sample_keys:
+        raise TypeError(
+            f"Wrong key(s): {list(wrong_sample_keys)}. "
+            f"Allowed keys in the 'Sample' field: {list(sample_keys)}"
+        )
+    
 def _load_ServiceXSpec(
     config: Union[ServiceXSpec, Mapping[str, Any], str, Path],
 ) -> ServiceXSpec:
     if isinstance(config, Mapping):
         logger.debug("Config from dictionary")
+        _check_wrong_keys(config)
         config = ServiceXSpec(**config)
     elif isinstance(config, ServiceXSpec):
         logger.debug("Config from ServiceXSpec")


### PR DESCRIPTION
The `ServiceXSpec` pydantic model does not complain when an non-existing parameter is fed via the spec config. 
Which leads to issues like in #746, a typo in a dictionary field is ignored if the field is optional. The user wont be notified. 

This PR raises a `TypeError` if a key in `"General"` and `"Sample"` fields does not match with the respective `DocStringBaseModel`